### PR TITLE
Fixes to bottom sheet closing, horizontal in line date picker and added version number to components app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [11.0.0]
+- [BreakingChange] Changed the animated flag for closing bottom sheets from bottom sheet service from default:false to true.
+- Fixed an issue where HorizontalInlineDatePicker did not set a colors for the date that it started with.
+- Fixed an issue where item picker bottom sheet mode did not close the bottom sheet.
+- Fixed an issue where setting animated flag when closing bottom sheet did not do anything for Android.
+- [ComponentsApp] Added version number to the first pages title.
+
 ## [10.0.0]
 - [BreakingChange] Changed API of BottomSheet regarding events when closing/opening
 - Added the ability to set title and toolbar items to BottomSheet

--- a/src/app/Components/MainPage.cs
+++ b/src/app/Components/MainPage.cs
@@ -10,7 +10,7 @@ public class MainPage : DIPS.Mobile.UI.Components.Pages.ContentPage
     public MainPage(IEnumerable<SampleType> sampleTypes, List<Sample> samples)
     {
         Padding = Sizes.GetSize(SizeName.size_4);
-        Title = LocalizedStrings.Components;
+        Title = $"{AppInfo.Current.Name} ({AppInfo.Current.VersionString})";
         Content = new DIPS.Mobile.UI.Components.Lists.CollectionView()
         {
             ItemsSource = sampleTypes, ItemTemplate = new DataTemplate(() => new NavigateToSamplesItem(samples)),

--- a/src/library/DIPS.Mobile.UI/API/Library/DUI.cs
+++ b/src/library/DIPS.Mobile.UI/API/Library/DUI.cs
@@ -11,7 +11,7 @@ namespace DIPS.Mobile.UI.API.Library
         {
             if (BottomSheetService.IsBottomSheetOpen())
             {
-                _ = BottomSheetService.CloseCurrentBottomSheet();    
+                _ = BottomSheetService.CloseCurrentBottomSheet(false);    
             }
             
             RemovePlatformSpecificViewsLocatedOnTopOfPage();

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetFragment.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetFragment.cs
@@ -1,4 +1,5 @@
 using Android.App;
+using Android.Content;
 using Android.OS;
 using Android.Text;
 using Android.Text.Style;
@@ -210,6 +211,19 @@ namespace DIPS.Mobile.UI.Components.BottomSheets.Android
             {
                 m_callback.Invoke();
                 return true;
+            }
+        }
+
+        public void Close(bool animated)
+        {
+            if (!animated)
+            {
+                OnStop(); //Kills the fragment without animation
+                OnDestroy(); //Has to call OnDestroy to send the closed event
+            }
+            else
+            {
+                Dismiss();
             }
         }
     }

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetService.cs
@@ -13,7 +13,7 @@ public static partial class BottomSheetService
     public static partial Task CloseCurrentBottomSheet(bool animated)
     {
         var currentBottomSheetFragment = CurrentBottomSheetFragment();
-       currentBottomSheetFragment?.Dismiss();
+        currentBottomSheetFragment?.Close(animated);
         return Task.CompletedTask;
     }
 

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/BottomSheetService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/BottomSheetService.cs
@@ -16,7 +16,7 @@ namespace DIPS.Mobile.UI.Components.BottomSheets
         /// Closes the current presented bottom sheet.
         /// </summary>
         /// <returns></returns>
-        public static partial Task CloseCurrentBottomSheet(bool animated=false);
+        public static partial Task CloseCurrentBottomSheet(bool animated=true);
 
         public static partial bool IsBottomSheetOpen();
     }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/HorizontalInLine/HorizontalInlineDatePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/HorizontalInLine/HorizontalInlineDatePicker.cs
@@ -106,7 +106,7 @@ public partial class HorizontalInlineDatePicker : ContentView
         
         var dateTime = m_startDate.Value.AddDays(i);
         
-        var isSelected = dateTime.Date == m_startDate; //Only true the first time we load the layout, every other event is happening in OnDateScrolledTo
+        var isSelected = dateTime.Date == m_startDate.Value.Date; //Only true the first time we load the layout
         var selectableDateViewModel = new SelectableDateViewModel(dateTime, isSelected);
         return selectableDateViewModel;
     }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.cs
@@ -1,7 +1,6 @@
 using DIPS.Mobile.UI.Components.BottomSheets;
 using DIPS.Mobile.UI.Components.Chips;
 using DIPS.Mobile.UI.Components.ContextMenus;
-using DIPS.Mobile.UI.Extensions;
 
 namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
 {
@@ -49,9 +48,20 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             picker.SelectedItemCommand?.Execute(picker.SelectedItem);
             picker.DidSelectItem?.Invoke(picker, picker.SelectedItem);
 
-            if (picker.Mode == PickerMode.ContextMenu)
+            switch (picker.Mode)
             {
-                UpdateContextMenuItems(picker); //<-- Needed if the selected item was set programatically, and not by the user    
+                case PickerMode.ContextMenu:
+                    UpdateContextMenuItems(picker); //<-- Needed if the selected item was set programatically, and not by the user
+                    break;
+                case PickerMode.BottomSheet:
+                    if (BottomSheetService.IsBottomSheetOpen())
+                    {
+                        BottomSheetService.CloseCurrentBottomSheet();    
+                    }
+                    
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
         }
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -70,7 +70,6 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                 }
 
                 m_itemPicker.SelectedItem = theSelectedItem;
-                SendClose();
             }
         }
 


### PR DESCRIPTION
### Description of Change

- [BreakingChange] Changed the animated flag for closing bottom sheets from bottom sheet service from default:false to true.
- Fixed an issue where HorizontalInlineDatePicker did not set a colors for the date that it started with.
- Fixed an issue where item picker bottom sheet mode did not close the bottom sheet.
- Fixed an issue where setting animated flag when closing bottom sheet did not do anything for Android.
- [ComponentsApp] Added version number to the first pages title.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->