### PR TITLE
Made sure modal effect on Android to add navbar does not use a vertical stack layout because it will break collection view scrolling on Android.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 
 ## [12.9.3]
-- Made sure modal effect on Android to add toolbar does not use a vertical stack layout because it will break collection view scrolling on Android.
+- Made sure modal effect on Android to add navbar does not use a vertical stack layout because it will break collection view scrolling on Android.
 
 ## [12.9.2]
 - Icons on a context menu item is now of type icon image source.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+
+## [12.9.3]
+- Made sure modal effect on Android to add toolbar does not use a vertical stack layout because it will break collection view scrolling on Android.
+
 ## [12.9.2]
 - Icons on a context menu item is now of type icon image source.
 

--- a/src/library/DIPS.Mobile.UI/API/Builder/AppHostBuilderExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Builder/AppHostBuilderExtensions.cs
@@ -53,7 +53,7 @@ public static partial class AppHostBuilderExtensions
             effects.Add(typeof(ContextMenuEffect), typeof(ContextMenuPlatformEffect));
             effects.Add(typeof(Touch), typeof(TouchPlatformEffect));
 #if __ANDROID__
-            effects.Add<Modal, >();
+            effects.Add<Modal, ModalPlatformEffect>();
 #endif
         });
 

--- a/src/library/DIPS.Mobile.UI/API/Builder/AppHostBuilderExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Builder/AppHostBuilderExtensions.cs
@@ -53,7 +53,7 @@ public static partial class AppHostBuilderExtensions
             effects.Add(typeof(ContextMenuEffect), typeof(ContextMenuPlatformEffect));
             effects.Add(typeof(Touch), typeof(TouchPlatformEffect));
 #if __ANDROID__
-            effects.Add<Modal, ModalPlatformEffect>();
+            effects.Add<Modal, >();
 #endif
         });
 

--- a/src/library/DIPS.Mobile.UI/Effects/Modal/Android/ModalPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Modal/Android/ModalPlatformEffect.cs
@@ -8,22 +8,22 @@ namespace DIPS.Mobile.UI.Effects.Modal.Android;
 
 public class ModalPlatformEffect : PlatformEffect
 {
-    protected override void OnAttached()
+    protected override void OnAttached()ModalPlatformEffect
     {
         if (Element is not ContentPage contentPage)
             return;
 
-        var verticalStackLayout = new VerticalStackLayout();
+        var grid = new Grid(){RowDefinitions = new RowDefinitionCollection(){new(GridLength.Auto), new(GridLength.Star)}};
 
         var toolbar = new DUIToolbar 
         { 
             PageConnectedTo = contentPage, 
             BackgroundColor = Colors.GetColor(ColorName.color_primary_90),
         };
-        verticalStackLayout.Add(toolbar);
-        verticalStackLayout.Add(new ContentView { Content = contentPage.Content, Padding = contentPage.Padding });
+        grid.Add(toolbar, 0, 0);
+        grid.Add(new ContentView { Content = contentPage.Content, Padding = contentPage.Padding }, 0, 1);
         contentPage.Padding = 0;
-        contentPage.Content = verticalStackLayout;
+        contentPage.Content = grid;
     }
 
     protected override void OnDetached()

--- a/src/library/DIPS.Mobile.UI/Effects/Modal/Android/ModalPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Modal/Android/ModalPlatformEffect.cs
@@ -8,7 +8,7 @@ namespace DIPS.Mobile.UI.Effects.Modal.Android;
 
 public class ModalPlatformEffect : PlatformEffect
 {
-    protected override void OnAttached()ModalPlatformEffect
+    protected override void OnAttached()
     {
         if (Element is not ContentPage contentPage)
             return;


### PR DESCRIPTION
### Description of Change

-Made sure modal effect on Android to add navbar does not use a vertical stack layout because it will break collection view scrolling on Android.

### Todos
- [X] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->