### PR TITLE
Several improvements to ListItem, BottomSheet and CollectionView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [13.3.0]
+- [ListItem] Added font attributes for title and subtitle.
+- [BottomSheet] Made sure Android and iOS bottom sheets are always closed from RemoveViewsLocatedOnTopOfPage().
+- [BottomSheet] Made sure Android bottom sheet service returns a task that waits until the fragment is dismissed for consumers to rely on the task from closing methods.
+
 ## [13.2.0]
 - Added ActivityIndicator and RefreshView to reuse same colors and size for indicator.
 - [ComponentsApp] Made sure that only positive sizes are displayed in the samples, as negatives or 0 makes sense.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [ListItem] Added font attributes for title and subtitle.
 - [BottomSheet] Made sure Android and iOS bottom sheets are always closed from RemoveViewsLocatedOnTopOfPage().
 - [BottomSheet] Made sure Android bottom sheet service returns a task that waits until the fragment is dismissed for consumers to rely on the task from closing methods.
+- [CollectionView] Made sure we add additional space at the end of the list (footer) so the last item is always visible. 1/3 of the visible list will be added as a invisible footer so people can easily see and tap the last item.
 
 ## [13.2.0]
 - Added ActivityIndicator and RefreshView to reuse same colors and size for indicator.

--- a/src/app/Components/MainPage.cs
+++ b/src/app/Components/MainPage.cs
@@ -12,7 +12,6 @@ public class MainPage : DIPS.Mobile.UI.Components.Pages.ContentPage
         Title = $"{AppInfo.Current.Name} ({AppInfo.Current.VersionString})";
         Content = new DIPS.Mobile.UI.Components.Lists.CollectionView()
         {
-            ItemSpacing = 0,
             ItemsSource = sampleTypes, ItemTemplate = new DataTemplate(() => new NavigateToSamplesItem(samples)),
         };
     }

--- a/src/app/Components/MauiProgram.cs
+++ b/src/app/Components/MauiProgram.cs
@@ -1,5 +1,7 @@
 ﻿using DIPS.Mobile.UI.API.Builder;
+using DIPS.Mobile.UI.API.Library;
 using Microsoft.Extensions.Logging;
+using Microsoft.Maui.LifecycleEvents;
 
 namespace Components;
 
@@ -11,6 +13,20 @@ public static class MauiProgram
         builder
             .UseMauiApp<App>()
             .UseDIPSUI();
+        
+        //Close things when the app is going to background and back again
+#if __ANDROID__
+        builder.ConfigureLifecycleEvents(events =>
+        {
+            events.AddAndroid(android => android.OnResume(_ => DUI.RemoveViewsLocatedOnTopOfPage()));
+        });
+
+#elif __IOS__
+ builder.ConfigureLifecycleEvents(events =>
+        {
+            events.AddiOS(ios => ios.OnResignActivation(_ => DUI.RemoveViewsLocatedOnTopOfPage()));
+        });
+#endif
 #if DEBUG
         builder.Logging.AddDebug();
 #endif

--- a/src/app/Playground/MauiProgram.cs
+++ b/src/app/Playground/MauiProgram.cs
@@ -1,6 +1,8 @@
 ﻿using DIPS.Mobile.UI;
 using DIPS.Mobile.UI.API.Builder;
+using DIPS.Mobile.UI.API.Library;
 using Microsoft.Extensions.Logging;
+using Microsoft.Maui.LifecycleEvents;
 
 namespace Playground;
 
@@ -17,7 +19,6 @@ public static class MauiProgram
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                 fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
             });
-
 #if DEBUG
         builder.Logging.AddDebug();
 #endif

--- a/src/library/DIPS.Mobile.UI/API/Builder/Android/AppHostBuilderExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Builder/Android/AppHostBuilderExtensions.cs
@@ -16,7 +16,6 @@ public static partial class AppHostBuilderExtensions
     {
         events.AddAndroid(android => android
             .OnCreate((activity, _) => DUI.Init(activity)));
-        events.AddAndroid(android => android.OnPause(_ => DUI.RemoveViewsLocatedOnTopOfPage()));
     }
 }
 

--- a/src/library/DIPS.Mobile.UI/API/Builder/iOS/AppHostBuilderExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Builder/iOS/AppHostBuilderExtensions.cs
@@ -15,7 +15,6 @@ public static partial class AppHostBuilderExtensions
 
     static partial void ConfigurePlatformLifecycleEvents(ILifecycleBuilder events)
     {
-        events.AddiOS(ios => ios.OnResignActivation(_ => DUI.RemoveViewsLocatedOnTopOfPage()));
     }
 
 }

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetService.cs
@@ -1,4 +1,6 @@
+using Android.App;
 using DIPS.Mobile.UI.Components.BottomSheets.Android;
+using Google.Android.Material.BottomSheet;
 using Microsoft.Maui.Platform;
 
 // ReSharper disable once CheckNamespace
@@ -8,28 +10,30 @@ public static partial class BottomSheetService
 {
     internal const string BottomSheetFragmentTag = nameof(BottomSheetFragment);
 
-    public static partial Task OpenBottomSheet(BottomSheet bottomSheet) => new BottomSheetFragment(bottomSheet).Show();
-
-    public static partial Task CloseCurrentBottomSheet(bool animated)
+    internal static BottomSheetFragment? Current { get; set; }
+    
+    public static async partial Task OpenBottomSheet(BottomSheet bottomSheet)
     {
-        var currentBottomSheetFragment = CurrentBottomSheetFragment();
-        currentBottomSheetFragment?.Close(animated);
-        return Task.CompletedTask;
+        if (IsBottomSheetOpen())
+        {
+            await CloseCurrentBottomSheet();
+        }
+
+        var fragment = new BottomSheetFragment(bottomSheet);
+        await fragment.Show();
+        Current = fragment;
+    }
+
+    public static async partial Task CloseCurrentBottomSheet(bool animated)
+    {
+        if (Current != null)
+        {
+            await Current.Close(animated);
+        }
     }
 
     public static partial bool IsBottomSheetOpen()
     {
-        return CurrentBottomSheetFragment() != null;
-    }
-
-    private static BottomSheetFragment? CurrentBottomSheetFragment()
-    {
-        var fragment = Platform.CurrentActivity?.GetFragmentManager()?.FindFragmentByTag(BottomSheetFragmentTag);
-        if (fragment is BottomSheetFragment bottomSheetFragment)
-        {
-            return bottomSheetFragment;
-        }
-
-        return null;
+        return Current != null;
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetService.cs
@@ -8,8 +8,6 @@ namespace DIPS.Mobile.UI.Components.BottomSheets;
 
 public static partial class BottomSheetService
 {
-    internal const string BottomSheetFragmentTag = nameof(BottomSheetFragment);
-
     internal static BottomSheetFragment? Current { get; set; }
     
     public static async partial Task OpenBottomSheet(BottomSheet bottomSheet)

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/iOS/BottomSheetService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/iOS/BottomSheetService.cs
@@ -7,33 +7,28 @@ namespace DIPS.Mobile.UI.Components.BottomSheets;
 public static partial class BottomSheetService
 {
     internal const string BottomSheetRestorationIdentifier = nameof(BottomSheetContentPage);
-    internal static BottomSheet? m_currentOpenedBottomSheet;
+    internal static BottomSheetContentPage? Current { get; set; }
     public static partial Task OpenBottomSheet(BottomSheet bottomSheet)
     {
-        m_currentOpenedBottomSheet = bottomSheet;
-        return new BottomSheetContentPage(bottomSheet).Open();
+        if (IsBottomSheetOpen())
+        {
+            CloseCurrentBottomSheet();
+        }
+        
+        Current = new BottomSheetContentPage(bottomSheet);
+        return Current.Open();
     }
 
     public static async partial Task CloseCurrentBottomSheet(bool animated)
     {
-        var potentialBottomSheetUiViewController = GetCurrentBottomSheetUiViewController();
-        if (potentialBottomSheetUiViewController != null)
+        if (Current != null)
         {
-            await potentialBottomSheetUiViewController.DismissViewControllerAsync(animated);
-            await Task.Delay(100); //Small delay before its actually removed.
-            m_currentOpenedBottomSheet?.SendClose();
-            m_currentOpenedBottomSheet = null;
+            await Current.Close(animated);
         }
     }
 
     public static partial bool IsBottomSheetOpen()
     {
-        return GetCurrentBottomSheetUiViewController() != null;
-    }
-
-    private static UIViewController? GetCurrentBottomSheetUiViewController()
-    {
-        var currentPresentedUiViewController = Platform.GetCurrentUIViewController();
-        return currentPresentedUiViewController?.RestorationIdentifier == BottomSheetRestorationIdentifier ? currentPresentedUiViewController : null;
+        return Current != null;
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
@@ -18,6 +18,15 @@ public partial class ListItem
         get => (string)GetValue(TitleProperty);
         set => SetValue(TitleProperty, value);
     }
+    
+    /// <summary>
+    /// Sets the font attributes of the <see cref="Title"/>
+    /// </summary>
+    public FontAttributes TitleFontAttributes
+    {
+        get => (FontAttributes)GetValue(TitleFontAttributesProperty);
+        set => SetValue(TitleFontAttributesProperty, value);
+    }
 
     /// <summary>
     /// Sets the subtitle text that people will see below <see cref="Title"/>
@@ -26,6 +35,15 @@ public partial class ListItem
     {
         get => (string)GetValue(SubtitleProperty);
         set => SetValue(SubtitleProperty, value);
+    }
+    
+    /// <summary>
+    /// Sets the font attributes of the <see cref="Subtitle"/>
+    /// </summary>
+    public FontAttributes SubtitleFontAttributes
+    {
+        get => (FontAttributes)GetValue(SubtitleFontAttributesProperty);
+        set => SetValue(SubtitleFontAttributesProperty, value);
     }
 
     /// <summary>
@@ -98,5 +116,15 @@ public partial class ListItem
     public static readonly BindableProperty HasBottomDividerProperty = BindableProperty.Create(
         nameof(HasBottomDivider),
         typeof(bool),
+        typeof(ListItem));
+
+    public static readonly BindableProperty TitleFontAttributesProperty = BindableProperty.Create(
+        nameof(TitleFontAttributes),
+        typeof(FontAttributes),
+        typeof(ListItem));
+    
+    public static readonly BindableProperty SubtitleFontAttributesProperty = BindableProperty.Create(
+        nameof(SubtitleFontAttributes),
+        typeof(FontAttributes),
         typeof(ListItem));
 }

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
@@ -78,25 +78,29 @@ public partial class ListItem : ContentView
             VerticalTextAlignment = TextAlignment.Center,
             HorizontalTextAlignment = TextAlignment.Start
         };
-
+        
         if (string.IsNullOrEmpty(Subtitle))
         {
             label.SetBinding(Label.TextProperty, new Binding(nameof(Title), source: this));
+            label.SetBinding(Label.FontAttributesProperty, new Binding(nameof(TitleFontAttributes), source: this));
         }
         else
         {
             var title = new Span();
             title.SetBinding(Span.TextProperty, new Binding(nameof(Title), source: this));
+            title.SetBinding(Span.FontAttributesProperty, new Binding(nameof(TitleFontAttributes), source: this));
 
             var newLine = new Span { Text = Environment.NewLine };
 
             var subTitle = new Span { FontSize = Sizes.GetSize(SizeName.size_3), TextColor = Colors.GetColor(ColorName.color_neutral_60)};
             subTitle.SetBinding(Span.TextProperty, new Binding(nameof(Subtitle), source: this));
+            subTitle.SetBinding(Span.FontAttributesProperty, new Binding(nameof(SubtitleFontAttributes), source: this));
+
                 
-            label.FormattedText = new FormattedString { Spans = { title, newLine, subTitle } };
+            label.FormattedText = new FormattedString { Spans = { title, newLine, subTitle }};
         }
 
-        label.Margin = new Thickness(0, 0, 10, 0);
+        label.Margin = new Thickness(0, 0, Sizes.GetSize(SizeName.size_3), 0);
         
         MainContent.Add(label);
     }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView.Properties.cs
@@ -2,11 +2,6 @@ namespace DIPS.Mobile.UI.Components.Lists;
 
 public partial class CollectionView
 {
-    public static readonly BindableProperty ItemSpacingProperty = BindableProperty.Create(
-        nameof(ItemSpacing),
-        typeof(double),
-        typeof(CollectionView), propertyChanged: OnItemSpacingPropertyChanged, defaultValue:(double)Sizes.GetSize(SizeName.size_1));
-    
     /// <summary>
     /// Adds spacing between the items in the collection view.
     /// </summary>
@@ -16,4 +11,24 @@ public partial class CollectionView
         get => (double)GetValue(ItemSpacingProperty);
         set => SetValue(ItemSpacingProperty, value);
     }
+    
+    /// <summary>
+    /// Adds additional space at the end of the list so people can more easily see and tap the last items.
+    /// </summary>
+    /// <remarks>This is achieved by using the <see cref="CollectionView.Footer"/>. If you overwrite the <see cref="CollectionView.Footer"/> it will be removed</remarks>
+    public bool HasAdditionalSpaceAtTheEnd
+    {
+        get => (bool)GetValue(HasAdditionalSizeAtTheEndProperty);
+        set => SetValue(HasAdditionalSizeAtTheEndProperty, value);
+    }
+
+    public static readonly BindableProperty HasAdditionalSizeAtTheEndProperty = BindableProperty.Create(
+        nameof(HasAdditionalSpaceAtTheEnd),
+        typeof(bool),
+        typeof(CollectionView), defaultValue:true);
+    
+    public static readonly BindableProperty ItemSpacingProperty = BindableProperty.Create(
+        nameof(ItemSpacing),
+        typeof(double),
+        typeof(CollectionView), propertyChanged: OnItemSpacingPropertyChanged, defaultValue:(double)Sizes.GetSize(SizeName.size_1));
 }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView.cs
@@ -5,14 +5,20 @@ namespace DIPS.Mobile.UI.Components.Lists;
 
 public partial class CollectionView : Microsoft.Maui.Controls.CollectionView
 {
-    private Border? m_extraSpaceBorder;
+    private readonly Border m_extraSpaceBorder;
 
     public CollectionView()
     {
         BackgroundColor = Microsoft.Maui.Graphics.Colors.Transparent;
+        //Adds a extra space in the bottom to make sure the last item is not placed at the very bottom of the page, this makes the last item more accessible for people.
+        m_extraSpaceBorder ??= new Border()
+        {
+            BackgroundColor = Microsoft.Maui.Graphics.Colors.Transparent
+        };
+        Footer = m_extraSpaceBorder;
         SelectionMode = SelectionMode.None;
     }
-    
+
     private static void OnItemSpacingPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
     {
         if (bindable is not CollectionView collectionView || newvalue is not double itemsSpacing) return;
@@ -32,18 +38,23 @@ public partial class CollectionView : Microsoft.Maui.Controls.CollectionView
     protected override void OnSizeAllocated(double width, double height)
     {
         base.OnSizeAllocated(width, height);
-        if (HasAdditionalSpaceAtTheEnd && (Footer is null || Footer == m_extraSpaceBorder)) //If the consumer wants it and the footer is not set or the footer is the same border (happens if the size changes)
+        if (HasAdditionalSpaceAtTheEnd && Footer == m_extraSpaceBorder)
         {
-            m_extraSpaceBorder ??= new Border() {BackgroundColor = Microsoft.Maui.Graphics.Colors.Transparent};
-            
-#if __IOS__ //Collectionviews height is always the same, no matter how much is visible, which is the same as the entire screen size
-            var visibleSize = height - Bounds.Y;
-            var nonVisibleSize = height - visibleSize;
-            m_extraSpaceBorder.HeightRequest = nonVisibleSize+((visibleSize)/3); //The border has to be as big as the non visible size + one third of the visible size
+            AddExtraSpaceAtTheEnd(height);
+        }
+    }
+
+    private void AddExtraSpaceAtTheEnd(double height)
+    {
+#if __IOS__ //Collectionviews height is bigger than the visual height of the collection view
+        var visibleSize = height - Bounds.Y;
+        var nonVisibleSize = height - visibleSize;
+        m_extraSpaceBorder.HeightRequest =
+            nonVisibleSize +
+            ((visibleSize) /
+             3); //The border has to be as big as the non visible size + one third of the visible size
 #elif __ANDROID__
         m_extraSpaceBorder.HeightRequest = height/3; //The border has to be the one third of the visible size
-#endif      
-            Footer = m_extraSpaceBorder;
-        }
+#endif
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView.cs
@@ -5,11 +5,11 @@ namespace DIPS.Mobile.UI.Components.Lists;
 
 public partial class CollectionView : Microsoft.Maui.Controls.CollectionView
 {
+    private Border? m_extraSpaceBorder;
+
     public CollectionView()
     {
         BackgroundColor = Microsoft.Maui.Graphics.Colors.Transparent;
-        //Adds a extra space in the bottom to make sure the last item is not placed at the very bottom of the page, this makes the last item more accessible for people.
-        Footer = new BoxView() { HeightRequest = Sizes.GetSize(SizeName.size_24), BackgroundColor = Microsoft.Maui.Graphics.Colors.Transparent};
         SelectionMode = SelectionMode.None;
     }
     
@@ -26,6 +26,24 @@ public partial class CollectionView : Microsoft.Maui.Controls.CollectionView
                 gridItemsLayout.HorizontalItemSpacing = itemsSpacing;
                 gridItemsLayout.VerticalItemSpacing = itemsSpacing;
                 break;
+        }
+    }
+
+    protected override void OnSizeAllocated(double width, double height)
+    {
+        base.OnSizeAllocated(width, height);
+        if (HasAdditionalSpaceAtTheEnd && (Footer is null || Footer == m_extraSpaceBorder)) //If the consumer wants it and the footer is not set or the footer is the same border (happens if the size changes)
+        {
+            m_extraSpaceBorder ??= new Border() {BackgroundColor = Microsoft.Maui.Graphics.Colors.Transparent};
+            
+#if __IOS__ //Collectionviews height is always the same, no matter how much is visible, which is the same as the entire screen size
+            var visibleSize = height - Bounds.Y;
+            var nonVisibleSize = height - visibleSize;
+            m_extraSpaceBorder.HeightRequest = nonVisibleSize+((visibleSize)/3); //The border has to be as big as the non visible size + one third of the visible size
+#elif __ANDROID__
+        m_extraSpaceBorder.HeightRequest = height/3; //The border has to be the one third of the visible size
+#endif      
+            Footer = m_extraSpaceBorder;
         }
     }
 }


### PR DESCRIPTION
### Description of Change

- [ListItem] Added font attributes for title and subtitle.
- [BottomSheet] Made sure Android and iOS bottom sheets are always closed from RemoveViewsLocatedOnTopOfPage().
- [BottomSheet] Made sure Android bottom sheet service returns a task that waits until the fragment is dismissed for consumers to rely on the task from closing methods.
- [CollectionView] Made sure we add additional space at the end of the list (footer) so the last item is always visible. 1/3 of the visible list will be added as a invisible footer so people can easily see and tap the last item.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->