### PR TITLE
Added delay and search mode to search page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [13.6.0]
+- Added ShouldDelay property to SearchPage for enabling a small delay before search is invoked
+- Added Delay property for defining delay in milliseconds (default = 500)
+- Added SearchMode property for disabling automatic search triggering on search text changed
+
+
 ## [13.5.0]
 - Add IsEnabled property for Touch.
 

--- a/src/library/DIPS.Mobile.UI/Components/Searching/SearchBar.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Searching/SearchBar.Properties.cs
@@ -153,7 +153,7 @@ namespace DIPS.Mobile.UI.Components.Searching
             set => SetValue(PlaceholderColorProperty, value);
         }
         
-           public static readonly BindableProperty IconsColorProperty = BindableProperty.Create(
+        public static readonly BindableProperty IconsColorProperty = BindableProperty.Create(
             nameof(IconsColor),
             typeof(Color),
             typeof(SearchBar));
@@ -232,6 +232,5 @@ namespace DIPS.Mobile.UI.Components.Searching
             nameof(BarColor),
             typeof(Color),
             typeof(SearchBar));
-
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.Properties.cs
@@ -79,6 +79,53 @@ namespace DIPS.Mobile.UI.Components.Searching
             set => SetValue(SearchPlaceholderProperty, value);
         }
 
+        public static readonly BindableProperty ShouldDelayProperty = BindableProperty.Create(
+            nameof(ShouldDelay),
+            typeof(bool),
+            typeof(SearchPage));
+
+        /// <summary>
+        /// Whether the search invocation should be delayed according to <see cref="Delay"/>.
+        /// </summary>
+        public bool ShouldDelay
+        {
+            get => (bool)GetValue(ShouldDelayProperty);
+            set => SetValue(ShouldDelayProperty, value);
+        }
+
+        public static readonly BindableProperty DelayProperty = BindableProperty.Create(
+            nameof(Delay),
+            typeof(int),
+            typeof(SearchPage),
+            500);
+
+        /// <summary>
+        /// The amount of delay before search invocation in milliseconds. Is only in effect if <see cref="ShouldDelay"/>
+        /// is true.
+        /// </summary>
+        public int Delay
+        {
+            get => (int)GetValue(DelayProperty);
+            set => SetValue(DelayProperty, value);
+        }
+
+        public static readonly BindableProperty SearchModeProperty = BindableProperty.Create(
+            nameof(SearchMode),
+            typeof(SearchMode),
+            typeof(SearchPage),
+            SearchMode.Auto);
+
+        /// <summary>
+        /// Defines when a search should be triggered.
+        /// <see cref="SearchMode.Auto"/> = search is triggered when a character is typed or removed from the search text
+        /// <see cref="SearchMode.Explicit"/> = search is triggered only when user presses complete on the device's keyboard
+        /// </summary>
+        public SearchMode SearchMode
+        {
+            get => (SearchMode)GetValue(SearchModeProperty);
+            set => SetValue(SearchModeProperty, value);
+        }
+
         /// <summary>
         /// The method to return the result that people will see when they use the search bar in the search page.
         /// </summary>

--- a/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.Properties.cs
@@ -114,12 +114,12 @@ namespace DIPS.Mobile.UI.Components.Searching
             nameof(SearchMode),
             typeof(SearchMode),
             typeof(SearchPage),
-            SearchMode.Auto);
+            SearchMode.WhenTextChanged);
 
         /// <summary>
         /// Defines when a search should be triggered.
-        /// <see cref="SearchMode.Auto"/> = search is triggered when a character is typed or removed from the search text
-        /// <see cref="SearchMode.Explicit"/> = search is triggered only when user presses complete on the device's keyboard
+        /// <see cref="Searching.SearchMode.WhenTextChanged"/> = search is triggered when a character is typed or removed from the search text
+        /// <see cref="Searching.SearchMode.WhenTappedComplete"/> = search is triggered only when user presses complete on the device's keyboard
         /// </summary>
         public SearchMode SearchMode
         {

--- a/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.Properties.cs
@@ -82,10 +82,11 @@ namespace DIPS.Mobile.UI.Components.Searching
         public static readonly BindableProperty ShouldDelayProperty = BindableProperty.Create(
             nameof(ShouldDelay),
             typeof(bool),
-            typeof(SearchPage));
+            typeof(SearchPage),
+            false);
 
         /// <summary>
-        /// Whether the search invocation should be delayed according to <see cref="Delay"/>.
+        /// Whether the invocation of <see cref="ProvideSearchResult"/> should be delayed according to <see cref="Delay"/>.
         /// </summary>
         public bool ShouldDelay
         {
@@ -100,7 +101,7 @@ namespace DIPS.Mobile.UI.Components.Searching
             500);
 
         /// <summary>
-        /// The amount of delay before search invocation in milliseconds. Is only in effect if <see cref="ShouldDelay"/>
+        /// The amount of delay before invocation of <see cref="ProvideSearchResult"/> in milliseconds. Is only in effect if <see cref="ShouldDelay"/>
         /// is true.
         /// </summary>
         public int Delay

--- a/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.cs
@@ -43,7 +43,7 @@ namespace DIPS.Mobile.UI.Components.Searching
             m_searchBar.SetBinding(SearchBar.PlaceholderProperty,
                 new Binding(nameof(SearchPlaceholder), source: this));
             m_searchBar.TextChanged += SearchBarOnTextChanged;
-            //TODO:If Mode: WhenKeyboardPressed
+
             m_searchBar.SearchCommand = new Command(() => OnSearchQueryChanged(m_searchBar.Text));
             m_searchBar.CancelCommand = new Command(OnCancel);
 
@@ -113,9 +113,10 @@ namespace DIPS.Mobile.UI.Components.Searching
 
         private void SearchBarOnTextChanged(object? sender, TextChangedEventArgs e)
         {
-            //TODO:If Mode:WhenPeopleType
-            //TODO:If, TypeDelay
-            OnSearchQueryChanged(e.NewTextValue);
+            if (SearchMode is SearchMode.Auto)
+            {
+                OnSearchQueryChanged(e.NewTextValue);
+            }
         }
 
         private async void OnSearchQueryChanged(string searchQuery)
@@ -131,10 +132,14 @@ namespace DIPS.Mobile.UI.Components.Searching
                 return;
             }
 
-            //TODO: Implement delay if its needed from the consumer
             try
             {
                 SetSearchState(SearchStates.Searching);
+
+                if (ShouldDelay && Delay > 0)
+                {
+                    await Task.Delay(Delay, m_searchCancellationToken.Token);
+                }
 
                 var result = await ProvideSearchResult(searchQuery, m_searchCancellationToken.Token);
                 if (result == null)
@@ -196,6 +201,12 @@ namespace DIPS.Mobile.UI.Components.Searching
         {
             m_searchBar.IsBusy = visible;
         }
+    }
+
+    public enum SearchMode
+    {
+        Auto,
+        Explicit
     }
 
     public enum SearchStates

--- a/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.cs
@@ -113,7 +113,7 @@ namespace DIPS.Mobile.UI.Components.Searching
 
         private void SearchBarOnTextChanged(object? sender, TextChangedEventArgs e)
         {
-            if (SearchMode is SearchMode.Auto)
+            if (SearchMode is SearchMode.WhenTextChanged)
             {
                 OnSearchQueryChanged(e.NewTextValue);
             }
@@ -208,11 +208,11 @@ namespace DIPS.Mobile.UI.Components.Searching
         /// <summary>
         /// Search is triggered whenever the search text changes
         /// </summary>
-        Auto,
+        WhenTextChanged,
         /// <summary>
         /// Search is only triggered when the user presses "Complete" on the device's keyboard
         /// </summary>
-        Explicit
+        WhenTappedComplete
     }
 
     public enum SearchStates

--- a/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.cs
@@ -205,7 +205,13 @@ namespace DIPS.Mobile.UI.Components.Searching
 
     public enum SearchMode
     {
+        /// <summary>
+        /// Search is triggered whenever the search text changes
+        /// </summary>
         Auto,
+        /// <summary>
+        /// Search is only triggered when the user presses "Complete" on the device's keyboard
+        /// </summary>
         Explicit
     }
 


### PR DESCRIPTION
### Description of Change
- Added ShouldDelay property to SearchPage for enabling a small delay before search is invoked
- Added Delay property for defining delay in milliseconds (default = 500)
- Added SearchMode property for disabling automatic search triggering on search text changed

### Todos
- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility
