### PR TITLE
FloatingNavigationButton changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [13.7.0]
 - Extended FloatingNavigationButton so that consumers can programatically close it and also remove it from layout.
-- [Android] Changed API calls to get FragmentManager so Android < 31 can also execute the code. 
+- [Android] Changed API calls to get FragmentManager so Android < 31 can also execute the code.
+- Changed animation of FloatingNavigationButton.
 
 ## [13.6.1]
 - [Android] dui:ImageButton now fixes padding issue: https://github.com/dotnet/maui/pull/14905

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [13.7.0]
+- Extended FloatingNavigationButton so that consumers can programatically close it and also remove it from layout.
+- [Android] Changed API calls to get FragmentManager so Android < 31 can also execute the code. 
+
 ## [13.6.1]
 - [Android] dui:ImageButton now fixes padding issue: https://github.com/dotnet/maui/pull/14905
 

--- a/src/app/Components/Components.csproj
+++ b/src/app/Components/Components.csproj
@@ -40,9 +40,11 @@
     <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
         <!--DEBUG ON DEVICE-->
 
+<!--
         <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
+-->
         <!--DEBUG ON SIMULATOR-->
-<!--        <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>-->
+        <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     </PropertyGroup>
     
     <ItemGroup>

--- a/src/app/Components/ComponentsSamples/Navigation/FloatingNavigationButtonSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Navigation/FloatingNavigationButtonSamples.xaml
@@ -26,5 +26,6 @@
         </dui:ListItem>
         <dui:Button Text="Toggle enable button 1" Command="{Binding ToggleCommand}" />
         <dui:Button Text="{x:Static localizedStrings:LocalizedStrings.AddButton}" Command="{Binding AddNavigationMenuButtonCommand}" />
+        <dui:Button Text="{x:Static localizedStrings:LocalizedStrings.Remove}" Command="{Binding RemoveCommand}" />
     </dui:VerticalStackLayout>
 </dui:ContentPage>

--- a/src/app/Components/ComponentsSamples/Navigation/FloatingNavigationButtonSamples.xaml.cs
+++ b/src/app/Components/ComponentsSamples/Navigation/FloatingNavigationButtonSamples.xaml.cs
@@ -34,7 +34,7 @@ public partial class FloatingNavigationButtonSamples
             config.AddNavigationButton(string.Empty, "Button 3",  IconName.ascending_fill, new Command(() => { }));
             config.AddNavigationButton(string.Empty, "Button 4", IconName.descending_fill, new Command(() => { }));
             config.AddNavigationButton(string.Empty, "Button 5", IconName.descending_fill, new Command(() => { }));
-            config.AddNavigationButton(string.Empty, "Button 6", IconName.descending_fill, new Command(() => { }));
+            config.AddNavigationButton(string.Empty, "Close", IconName.descending_fill, new Command(FloatingNavigationButtonService.Close));
 
         });
     }

--- a/src/app/Components/ComponentsSamples/Navigation/FloatingNavigationButtonSamplesViewModel.cs
+++ b/src/app/Components/ComponentsSamples/Navigation/FloatingNavigationButtonSamplesViewModel.cs
@@ -17,6 +17,7 @@ public class FloatingNavigationButtonSamplesViewModel : ViewModel
         RemoveNavigationMenuButtonCommand = new Command(RemoveNavigationMenuButton);
         AddNavigationMenuButtonCommand = new Command(AddNavigationMenuButton);
         ToggleCommand = new Command(Toggle);
+        RemoveCommand = new Command(FloatingNavigationButtonService.Remove);
 
         ColorList = new(DIPS.Mobile.UI.Extensions.Enum.ToList<ColorName>().Select(c => c.ToString()));
     }
@@ -72,4 +73,5 @@ public class FloatingNavigationButtonSamplesViewModel : ViewModel
 
     public List<string> ColorList { get; }
     public ICommand ToggleCommand { get; }
+    public ICommand RemoveCommand { get; }
 }

--- a/src/app/Components/Resources/LocalizedStrings/LocalizedStrings.Designer.cs
+++ b/src/app/Components/Resources/LocalizedStrings/LocalizedStrings.Designer.cs
@@ -506,5 +506,11 @@ namespace Components.Resources.LocalizedStrings {
                 return ResourceManager.GetString("ActivityIndicator", resourceCulture);
             }
         }
+        
+        internal static string Remove {
+            get {
+                return ResourceManager.GetString("Remove", resourceCulture);
+            }
+        }
     }
 }

--- a/src/app/Components/Resources/LocalizedStrings/LocalizedStrings.nb.resx
+++ b/src/app/Components/Resources/LocalizedStrings/LocalizedStrings.nb.resx
@@ -242,4 +242,7 @@
     <data name="ActivityIndicator" xml:space="preserve">
         <value>Aktivitetsindikator</value>
     </data>
+    <data name="Remove" xml:space="preserve">
+        <value>Fjern</value>
+    </data>
 </root>

--- a/src/app/Components/Resources/LocalizedStrings/LocalizedStrings.resx
+++ b/src/app/Components/Resources/LocalizedStrings/LocalizedStrings.resx
@@ -249,4 +249,7 @@
     <data name="ActivityIndicator" xml:space="preserve">
         <value>Activity indicator</value>
     </data>
+    <data name="Remove" xml:space="preserve">
+        <value>Remove</value>
+    </data>
 </root>

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/SystemMessage/Android/SystemMessageFragment.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/SystemMessage/Android/SystemMessageFragment.cs
@@ -2,12 +2,11 @@ using Android.OS;
 using Android.Views;
 using DIPS.Mobile.UI.API.Library;
 using Microsoft.Maui.Platform;
-using Fragment = Android.App.Fragment;
 using View = Android.Views.View;
 
 namespace DIPS.Mobile.UI.Components.Alerting.SystemMessage.Android;
 
-internal class SystemMessageFragment : Fragment
+internal class SystemMessageFragment : AndroidX.Fragment.App.Fragment
 {
     private readonly SystemMessage m_systemMessage;
 

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/SystemMessage/Android/SystemMessageService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/SystemMessage/Android/SystemMessageService.cs
@@ -1,4 +1,7 @@
+using AndroidX.Fragment.App;
 using DIPS.Mobile.UI.Components.Alerting.SystemMessage.Android;
+using DIPS.Mobile.UI.Extensions.Android;
+using Microsoft.Maui.Platform;
 
 namespace DIPS.Mobile.UI.Components.Alerting.SystemMessage;
 public static partial class SystemMessageService
@@ -9,17 +12,16 @@ public static partial class SystemMessageService
 
         // Small delay so that FragmentManager is initialized
         await Task.Delay(10);
-        var fragmentManager = Platform.CurrentActivity.FragmentManager;
+        var fragmentManager = Platform.CurrentActivity!.GetFragmentManager();
+        
 
-        fragmentManager.BeginTransaction()
+        fragmentManager!.BeginTransaction()
             .Add(global::Android.Resource.Id.Content, fragment, SystemMessageTagId.ToString())
             .Commit();
     }
 
     private static partial void PlatformRemove()
     {
-        var fragment = Platform.CurrentActivity.FragmentManager.FindFragmentByTag(Alerting.SystemMessage.SystemMessageService.SystemMessageTagId.ToString());
-        if(fragment is not null)
-            Platform.CurrentActivity.FragmentManager.BeginTransaction().Remove(fragment).Commit();
+        Platform.CurrentActivity!.GetFragmentManager()!.RemoveFragmentWithTag(SystemMessageTagId.ToString());
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/SystemMessage/iOS/SystemMessageService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/SystemMessage/iOS/SystemMessageService.cs
@@ -1,4 +1,6 @@
 using DIPS.Mobile.UI.API.Library;
+using DIPS.Mobile.UI.Extensions.iOS;
+using DIPS.Mobile.UI.Platforms.iOS;
 using Microsoft.Maui.Platform;
 
 namespace DIPS.Mobile.UI.Components.Alerting.SystemMessage;
@@ -23,14 +25,7 @@ public static partial class SystemMessageService
 
     private static partial void PlatformRemove()
     {
-        MainThread.BeginInvokeOnMainThread(delegate
-        {
-            foreach (var uiView in DUI.RootController!.Subviews)
-            {
-                if(uiView.Tag == SystemMessageTagId)
-                    uiView.RemoveFromSuperview();
-            }
-        });
+        DUI.RootController!.RemoveUIViewChildWithTag(SystemMessageTagId);
     }
   
 }

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/Android/FloatingNavigationButtonMenuFragment.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/Android/FloatingNavigationButtonMenuFragment.cs
@@ -7,11 +7,11 @@ using View = Android.Views.View;
 
 namespace DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton.Android;
 
-internal class FloatingNavigationButtonMenuFragment : Fragment
+internal class FloatingNavigationButtonMenuFragment : AndroidX.Fragment.App.Fragment
 {
-    private readonly Navigation.FloatingNavigationButton.FloatingNavigationButton m_fab;
+    private readonly FloatingNavigationButton m_fab;
 
-    public FloatingNavigationButtonMenuFragment(Navigation.FloatingNavigationButton.FloatingNavigationButton fab)
+    public FloatingNavigationButtonMenuFragment(FloatingNavigationButton fab)
     {
         m_fab = fab;
     }

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/Android/FloatingNavigationButtonService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/Android/FloatingNavigationButtonService.cs
@@ -1,4 +1,6 @@
 using DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton.Android;
+using DIPS.Mobile.UI.Extensions.Android;
+using Microsoft.Maui.Platform;
 
 // ReSharper disable once CheckNamespace
 namespace DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton;
@@ -11,11 +13,16 @@ public partial class FloatingNavigationButtonService
 
         // Small delay so that FragmentManager is initialized
         await Task.Delay(10);
-        var fragmentManager = Platform.CurrentActivity.FragmentManager;
+        var fragmentManager = Platform.CurrentActivity!.GetFragmentManager();
 
-        fragmentManager.BeginTransaction()
-            .Add(global::Android.Resource.Id.Content, fragment)
+        fragmentManager!.BeginTransaction()
+            .Add(global::Android.Resource.Id.Content, fragment, FloatingNavigationButtonIdentifier.ToString())
             .Commit();
 
+    }
+
+    private static partial void PlatformRemove()
+    {
+        Platform.CurrentActivity!.GetFragmentManager()!.RemoveFragmentWithTag(FloatingNavigationButtonIdentifier.ToString());
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
@@ -133,8 +133,11 @@ internal class FloatingNavigationButton : Grid
         }
     }
 
-    private async Task Close()
+    public async Task Close()
     {
+        if(!m_isExpanded)
+            return;
+        
         InputTransparent = true;
         
         m_isExpanded = false;
@@ -169,9 +172,11 @@ internal class FloatingNavigationButton : Grid
     private void AnimateExpand(int index)
     {
         var navMenuButton = m_floatingNavigationButtonConfigurator.NavigationMenuButtons[index - 1];
-
-        navMenuButton.FadeTo(1, easing: Easing.SpringOut);
-        navMenuButton.TranslateTo(0, -MenuButtonsSpacing * index, easing: Easing.SpringOut);
+        
+        navMenuButton.Scale = 0.5;
+        navMenuButton.FadeTo(1, easing: Easing.CubicOut);
+        navMenuButton.TranslateTo(0, -MenuButtonsSpacing * index, easing: Easing.CubicOut);
+        navMenuButton.ScaleTo(1, easing: Easing.CubicOut);
     }
     
     private void AnimateClose(int index)
@@ -179,7 +184,7 @@ internal class FloatingNavigationButton : Grid
         var navMenuButton = m_floatingNavigationButtonConfigurator.NavigationMenuButtons[index - 1];
         
         navMenuButton.FadeTo(0, easing: Easing.CubicIn);
-        navMenuButton.TranslateTo(0, 0, easing: Easing.SpringIn);
+        navMenuButton.TranslateTo(0, 0, easing: Easing.CubicIn);
     }
 
     public void TryHideOrShowFloatingNavigationButton(ContentPage page)

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButtonService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButtonService.cs
@@ -5,11 +5,13 @@ namespace DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton;
 public static partial class FloatingNavigationButtonService
 {
     private static FloatingNavigationButton? FloatingNavigationButton { get; set; }
+
+    internal const int FloatingNavigationButtonIdentifier = 2910961;
     
     /// <summary>
     /// Adds a <see cref="FloatingNavigationButton"/> to the root window, placed in the bottom right of the screen
     /// </summary>
-    /// <param name="config">To configurate the <see cref="FloatingNavigationButton"/></param>
+    /// <param name="config">To configure the <see cref="FloatingNavigationButton"/></param>
     public static void AddFloatingNavigationButton(Action<IFloatingNavigationButtonConfigurator> config)
     {
         var configurator = new FloatingNavigationButtonConfigurator();
@@ -129,4 +131,22 @@ public static partial class FloatingNavigationButtonService
     {
         return FloatingNavigationButton?.CheckButtonAvailability(identifier);
     }
+
+    /// <summary>
+    /// Closes the <see cref="FloatingNavigationButton"/> if it is expanded
+    /// </summary>
+    public static void Close()
+    {
+        FloatingNavigationButton?.Close();
+    }
+
+    /// <summary>
+    /// Removes the <see cref="FloatingNavigationButton"/> from the layout
+    /// </summary>
+    public static void Remove()
+    {
+        PlatformRemove();
+    }
+
+    private static partial void PlatformRemove();
 }

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/dotnet/FloatingNavigationButtonService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/dotnet/FloatingNavigationButtonService.cs
@@ -6,4 +6,8 @@ public partial class FloatingNavigationButtonService
     private static partial void AttachToRootWindow(FloatingNavigationButton fab)
     {
     }
+
+    private static partial void PlatformRemove()
+    {
+    }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/iOS/FloatingNavigationButtonService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/iOS/FloatingNavigationButtonService.cs
@@ -1,5 +1,7 @@
 using CoreGraphics;
 using DIPS.Mobile.UI.API.Library;
+using DIPS.Mobile.UI.Extensions.iOS;
+using DIPS.Mobile.UI.Platforms.iOS;
 using Microsoft.Maui.Platform;
 using UIKit;
 
@@ -18,10 +20,18 @@ public static partial class FloatingNavigationButtonService
                 await Task.Delay(10);
                 rootView = DUI.RootController;
             }
-            fab.HeightRequest = rootView.Frame.Height;
+            fab.HeightRequest = rootView!.Frame.Height;
             fab.WidthRequest = rootView.Frame.Width;
-            rootView.AddSubview(fab.ToPlatform(DUI.GetCurrentMauiContext!));
+            var uiView = fab.ToPlatform(DUI.GetCurrentMauiContext!);
+            uiView.Tag = FloatingNavigationButtonIdentifier;
+            
+            rootView.AddSubview(uiView);
             
         }
+    }
+
+    private static partial void PlatformRemove()
+    {
+        DUI.RootController!.RemoveUIViewChildWithTag(FloatingNavigationButtonIdentifier);
     }
 }

--- a/src/library/DIPS.Mobile.UI/Extensions/Android/FragmentManagerExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/Extensions/Android/FragmentManagerExtensions.cs
@@ -1,0 +1,14 @@
+using Android.App;
+using FragmentManager = AndroidX.Fragment.App.FragmentManager;
+
+namespace DIPS.Mobile.UI.Extensions.Android;
+
+public static class FragmentManagerExtensions
+{
+    public static void RemoveFragmentWithTag(this FragmentManager fragmentManager, string tag)
+    {
+        var fragment = fragmentManager.FindFragmentByTag(tag);
+        if (fragment is not null)
+            fragmentManager.BeginTransaction().Remove(fragment).Commit();
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Extensions/iOS/UIViewExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/Extensions/iOS/UIViewExtensions.cs
@@ -87,5 +87,17 @@ namespace DIPS.Mobile.UI.Extensions.iOS
 
             return null;
         }
+        
+        public static void RemoveUIViewChildWithTag(this UIView uiView, int tag)
+        {
+            MainThread.BeginInvokeOnMainThread(delegate
+            {
+                foreach (var uiView in uiView.Subviews)
+                {
+                    if(uiView.Tag == tag)
+                        uiView.RemoveFromSuperview();
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
### Description of Change

- Extended FloatingNavigationButton so that consumers can programatically close it and also remove it from layout.
- [Android] Changed API calls to get FragmentManager so Android < 31 can also execute the code.
- Changed animation of FloatingNavigationButton.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->