### PR TITLE
Made sure ListItem options inherit the BindingContext of ListItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [16.8.2]
 - [ContentControl][iOS] If content is CollectionView we wrap it in a grid with row=auto.
+- [ListItem] Options now inherit the BindingContext of the ListItem.
 
 ## [16.8.1]
 - [Chip] Made sure background color of chip is set correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [16.8.2]
+- [ContentControl][iOS] If content is CollectionView we wrap it in a grid with row=auto.
+
 ## [16.8.1]
 - [Chip] Made sure background color of chip is set correctly.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [16.8.2]
+## [16.8.2]
 - [ContentControl][iOS] If content is CollectionView we wrap it in a grid with row=auto.
 
 ## [16.8.1]

--- a/src/app/Components/ResourcesSamples/Icons/IconsSamples.xaml
+++ b/src/app/Components/ResourcesSamples/Icons/IconsSamples.xaml
@@ -33,7 +33,7 @@
                                 <RoundRectangle CornerRadius="{dui:CornerRadius size_3}" />
                             </Border.StrokeShape>
 
-                            <Image HeightRequest="{dui:Sizes SizeName=size_10}"
+                            <dui:Image HeightRequest="{dui:Sizes SizeName=size_10}"
                                    WidthRequest="{dui:Sizes SizeName=size_10}"
                                    Source="{Binding Value}" />
                         </Border>

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -26,20 +26,22 @@
                     </dui:BooleanDataTemplateSelector.TrueTemplate>
                     <dui:BooleanDataTemplateSelector.FalseTemplate>
                         <DataTemplate>
+                            <ScrollView>
                                 <dui:CollectionView ItemsSource="{Binding Items}">
                                     <dui:CollectionView.ItemTemplate>
-                                        <DataTemplate>
-                                            <dui:ListItem Icon="{dui:Icons heartrate_line}"
-                                                          Title="Pulse">
+                                        <DataTemplate x:DataType="{x:Type x:String}">
+                                            <dui:NavigationListItem Icon="{dui:Icons heartrate_line}"
+                                                                    Title="Pulse">
                                                 <dui:ListItem.IconOptions>
                                                     <dui:IconOptions
-                                                        Color="{Binding Source={x:Reference Switch}, Path=IsToggled, Converter={dui:BoolToObjectConverter TrueObject={dui:Colors color_attention_dark}, FalseObject={dui:Colors color_information_dark}}}">
+                                                        Color="{Binding ., Converter={dui:IsEmptyToObjectConverter TrueObject={dui:Colors color_attention_dark}, FalseObject={dui:Colors color_information_dark}}}">
                                                     </dui:IconOptions>
                                                 </dui:ListItem.IconOptions>
-                                            </dui:ListItem>
+                                            </dui:NavigationListItem>
                                         </DataTemplate>
                                     </dui:CollectionView.ItemTemplate>
                                 </dui:CollectionView>
+                            </ScrollView>
                         </DataTemplate>
                     </dui:BooleanDataTemplateSelector.FalseTemplate>
                 </dui:BooleanDataTemplateSelector>

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -13,12 +13,37 @@
     </dui:ContentPage.BindingContext>
     <VerticalStackLayout>
 
-        <dui:Chip Color="{dui:Colors ColorName=color_error_dark}"/>
-        <!-- <Switch x:Name="Switch" -->
-        <!--         HorizontalOptions="Start" /> -->
-        <!-- <dui:Checkmark HorizontalOptions="Start" -->
-        <!--                IsSelected="{Binding Source={x:Reference Switch}, Path=IsToggled}" /> -->
-        <!-- <dui:RadioButton HorizontalOptions="Start" -->
-        <!--                  IsSelected="{Binding Source={x:Reference Switch}, Path=IsToggled}" /> -->
+        <Switch x:Name="Switch" />
+
+        <dui:ContentControl SelectorItem="{Binding Source={x:Reference Switch}, Path=IsToggled}">
+            <dui:ContentControl.TemplateSelector>
+                <dui:BooleanDataTemplateSelector>
+                    <dui:BooleanDataTemplateSelector.TrueTemplate>
+                        <DataTemplate>
+                            <dui:ActivityIndicator IsRunning="True"
+                                                   IsVisible="True" />
+                        </DataTemplate>
+                    </dui:BooleanDataTemplateSelector.TrueTemplate>
+                    <dui:BooleanDataTemplateSelector.FalseTemplate>
+                        <DataTemplate>
+                                <dui:CollectionView ItemsSource="{Binding Items}">
+                                    <dui:CollectionView.ItemTemplate>
+                                        <DataTemplate>
+                                            <dui:ListItem Icon="{dui:Icons heartrate_line}"
+                                                          Title="Pulse">
+                                                <dui:ListItem.IconOptions>
+                                                    <dui:IconOptions
+                                                        Color="{Binding Source={x:Reference Switch}, Path=IsToggled, Converter={dui:BoolToObjectConverter TrueObject={dui:Colors color_attention_dark}, FalseObject={dui:Colors color_information_dark}}}">
+                                                    </dui:IconOptions>
+                                                </dui:ListItem.IconOptions>
+                                            </dui:ListItem>
+                                        </DataTemplate>
+                                    </dui:CollectionView.ItemTemplate>
+                                </dui:CollectionView>
+                        </DataTemplate>
+                    </dui:BooleanDataTemplateSelector.FalseTemplate>
+                </dui:BooleanDataTemplateSelector>
+            </dui:ContentControl.TemplateSelector>
+        </dui:ContentControl>
     </VerticalStackLayout>
 </dui:ContentPage>

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -29,12 +29,13 @@
                             <ScrollView>
                                 <dui:CollectionView ItemsSource="{Binding Items}">
                                     <dui:CollectionView.ItemTemplate>
-                                        <DataTemplate x:DataType="{x:Type x:String}">
+                                        <DataTemplate x:DataType="{x:Type håvardSamples:Something}">
                                             <dui:NavigationListItem Icon="{dui:Icons heartrate_line}"
                                                                     Title="Pulse">
                                                 <dui:ListItem.IconOptions>
+                                                    
                                                     <dui:IconOptions
-                                                        Color="{Binding ., Converter={dui:IsEmptyToObjectConverter TrueObject={dui:Colors color_attention_dark}, FalseObject={dui:Colors color_information_dark}}}">
+                                                        Color="{Binding TheTing.IsIt, Converter={dui:BoolToObjectConverter TrueObject={dui:Colors color_attention_dark}, FalseObject={dui:Colors color_information_dark}}, FallbackValue={dui:Colors color_error_dark}}">
                                                     </dui:IconOptions>
                                                 </dui:ListItem.IconOptions>
                                             </dui:NavigationListItem>

--- a/src/app/Playground/HåvardSamples/HåvardPageViewModel.cs
+++ b/src/app/Playground/HåvardSamples/HåvardPageViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+
 using System.Windows.Input;
 using DIPS.Mobile.UI.MVVM;
 
@@ -15,21 +15,26 @@ public class HåvardPageViewModel : ViewModel
 
     public HåvardPageViewModel()
     {
-        Items = new List<string>()
+        Items = new List<Something>()
         {
-            "948 19 788",
-            "936 15 719",
-            "418 01 260",
-            "959 94 238",
-            "464 51 717",
-            "916 18 816",
-            "998 15 227",
-            "468 14 026",
-            "413 10 076",
-            "986 77 073",
-            "979 82 486",
-            "453 26 392",
-            "439 14 037"
+            new Something(new SomeOtherThing(true)),
+            new Something(new SomeOtherThing(true)),
+            new Something(new SomeOtherThing(false)),
+            new Something(new SomeOtherThing(false)),
+            new Something(new SomeOtherThing(true)),
+            new Something(new SomeOtherThing(false)),
+            new Something(new SomeOtherThing(false)),
+            new Something(new SomeOtherThing(true)),
+            new Something(new SomeOtherThing(false)),
+            new Something(new SomeOtherThing(false)),
+            new Something(new SomeOtherThing(false)),
+            new Something(new SomeOtherThing(true)),
+            new Something(new SomeOtherThing(false)),
+            new Something(new SomeOtherThing(false)),
+            new Something(new SomeOtherThing(false)),
+            new Something(new SomeOtherThing(false)),
+            new Something(new SomeOtherThing(true)),
+            new Something(new SomeOtherThing(false)),
         };
 
         var items = Items.Take(new Range(0, 4));
@@ -43,7 +48,7 @@ public class HåvardPageViewModel : ViewModel
     
     
 
-    public List<string> Items { get; set; }
+    public List<Something> Items { get; set; }
 
     public IEnumerable<object> SelectedItems
     {
@@ -57,5 +62,46 @@ public class HåvardPageViewModel : ViewModel
     {
         get => m_selectedItem;
         set => RaiseWhenSet(ref m_selectedItem, value);
+    }
+
+    
+    }
+
+public class Something : ViewModel
+{
+    private SomeOtherThing m_theTing;
+
+    public SomeOtherThing TheTing
+    {
+        get => m_theTing;
+        set => RaiseWhenSet(ref m_theTing, value);
+    }
+
+    public Something(SomeOtherThing theTing)
+    {
+        TheTing = theTing;
+    }
+
+    public async void Initialize()
+    {
+        await Task.Delay(1500);
+        var randomNumber = new Random(10).Next(0, 10);
+        TheTing.IsIt = randomNumber > 5;
+    }
+}
+
+public class SomeOtherThing : ViewModel
+{
+    private bool m_isIt;
+
+    public bool IsIt
+    {
+        get => m_isIt;
+        set => RaiseWhenSet(ref m_isIt, value);
+    }
+
+    public SomeOtherThing(bool isIt)
+    {
+        IsIt = isIt;
     }
 }

--- a/src/app/Playground/HåvardSamples/HåvardPageViewModel.cs
+++ b/src/app/Playground/HåvardSamples/HåvardPageViewModel.cs
@@ -40,6 +40,8 @@ public class HåvardPageViewModel : ViewModel
         {
         });
     }
+    
+    
 
     public List<string> Items { get; set; }
 

--- a/src/library/DIPS.Mobile.UI/Components/Content/ContentControl.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Content/ContentControl.cs
@@ -12,7 +12,19 @@
                 return;
             }
             
-            Content = TemplateSelector.SelectTemplate(SelectorItem ?? BindingContext, this).CreateContent() as View;
+            var theContent = TemplateSelector.SelectTemplate(SelectorItem ?? BindingContext, this).CreateContent() as View;
+#if __IOS__
+            if (theContent is CollectionView)
+            {
+                //TODO: Fix Dotnet 8. : UICollectionViews inside a ContentView messes up the height, the fix is to wrap it in a grid with row=auto
+                var grid = new Grid() {RowDefinitions = new RowDefinitionCollection() {new(GridLength.Auto)}};
+                grid.Add(theContent);
+                theContent = grid;
+            } 
+#endif
+           
+
+            Content = theContent;
         }
 
         protected override void OnBindingContextChanged()

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
@@ -220,7 +220,7 @@ public partial class ListItem
         defaultValueCreator: CreateOptionsAndBind<Options.InLineContent.InLineContentOptions>,
         propertyChanged: (bindable, _, newValue) => ((Options.InLineContent.InLineContentOptions)newValue).Bind(((ListItem)bindable)));
     
-    private static T CreateOptionsAndBind<T>(BindableObject bindable) where T : IListItemOptions, new()
+    private static T CreateOptionsAndBind<T>(BindableObject bindable) where T : ListItemOptions, new()
     {
         if (bindable is not ListItem listItem)
             return default!;

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
@@ -245,5 +245,5 @@ public partial class ListItem : ContentView
 
     private void SetTouchIsEnabled() => Touch.SetIsEnabled(Border, IsEnabled && Command is not null);
 
-    private void BindToOptions(IListItemOptions? options) => options?.Bind(this);
+    private void BindToOptions(ListItemOptions? options) => options?.Bind(this);
 }

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
@@ -50,9 +50,9 @@ public partial class ListItem : ContentView
     };
     
     public Border Border { get; } = new();
-    internal Image ImageIcon { get; private set; }
-    internal Label TitleLabel { get; private set; }
-    internal Label SubtitleLabel { get; private set; }
+    internal Image? ImageIcon { get; private set; }
+    internal Label? TitleLabel { get; private set; }
+    internal Label? SubtitleLabel { get; private set; }
     
     private IView m_oldInLineContent;
     private IView m_oldUnderlyingContent;

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/IListItemOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/IListItemOptions.cs
@@ -1,6 +1,0 @@
-namespace DIPS.Mobile.UI.Components.ListItems.Options;
-
-public interface IListItemOptions
-{
-    void Bind(ListItem listItem);
-}

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Icon/IconOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Icon/IconOptions.cs
@@ -7,8 +7,6 @@ public partial class IconOptions : ListItemOptions
     
     public override void DoBind(ListItem listItem)
     {
-        base.Bind(listItem);
-        
         if(listItem.ImageIcon is null)
             return;
 

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Icon/IconOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Icon/IconOptions.cs
@@ -4,8 +4,11 @@ namespace DIPS.Mobile.UI.Components.ListItems.Options.Icon;
 
 public partial class IconOptions : BindableObject, IListItemOptions
 {
+    
     public void Bind(ListItem listItem)
     {
+        BindingContext = listItem.BindingContext;
+        
         if(listItem.ImageIcon is null)
             return;
 

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Icon/IconOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Icon/IconOptions.cs
@@ -7,7 +7,7 @@ public partial class IconOptions : BindableObject, IListItemOptions
     
     public void Bind(ListItem listItem)
     {
-        BindingContext = listItem.BindingContext;
+        SetBinding(BindingContextProperty, new Binding(source: listItem, path:nameof(BindingContext)));
         
         if(listItem.ImageIcon is null)
             return;

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Icon/IconOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Icon/IconOptions.cs
@@ -2,12 +2,12 @@ using Image = DIPS.Mobile.UI.Components.Images.Image.Image;
 
 namespace DIPS.Mobile.UI.Components.ListItems.Options.Icon;
 
-public partial class IconOptions : BindableObject, IListItemOptions
+public partial class IconOptions : ListItemOptions
 {
     
-    public void Bind(ListItem listItem)
+    public override void DoBind(ListItem listItem)
     {
-        SetBinding(BindingContextProperty, new Binding(source: listItem, path:nameof(BindingContext)));
+        base.Bind(listItem);
         
         if(listItem.ImageIcon is null)
             return;

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/InLineContent/InLineContentOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/InLineContent/InLineContentOptions.cs
@@ -6,6 +6,8 @@ public partial class InLineContentOptions : BindableObject, IListItemOptions
 {
     public void Bind(ListItem listItem)
     {
+        BindingContext = listItem.BindingContext;
+        
         if(listItem.InLineContent is not View inLineContent)
             return;
 

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/InLineContent/InLineContentOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/InLineContent/InLineContentOptions.cs
@@ -6,7 +6,7 @@ public partial class InLineContentOptions : BindableObject, IListItemOptions
 {
     public void Bind(ListItem listItem)
     {
-        BindingContext = listItem.BindingContext;
+        SetBinding(BindingContextProperty, new Binding(source: listItem, path:nameof(BindingContext)));
         
         if(listItem.InLineContent is not View inLineContent)
             return;

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/InLineContent/InLineContentOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/InLineContent/InLineContentOptions.cs
@@ -2,11 +2,11 @@ using Label = DIPS.Mobile.UI.Components.Labels.Label;
 
 namespace DIPS.Mobile.UI.Components.ListItems.Options.InLineContent;
 
-public partial class InLineContentOptions : BindableObject, IListItemOptions
+public partial class InLineContentOptions : ListItemOptions
 {
-    public void Bind(ListItem listItem)
-    {
-        SetBinding(BindingContextProperty, new Binding(source: listItem, path:nameof(BindingContext)));
+    public override void DoBind(ListItem listItem)
+    { 
+        base.Bind(listItem);
         
         if(listItem.InLineContent is not View inLineContent)
             return;

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/InLineContent/InLineContentOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/InLineContent/InLineContentOptions.cs
@@ -6,8 +6,6 @@ public partial class InLineContentOptions : ListItemOptions
 {
     public override void DoBind(ListItem listItem)
     { 
-        base.Bind(listItem);
-        
         if(listItem.InLineContent is not View inLineContent)
             return;
 

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/ListItemOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/ListItemOptions.cs
@@ -7,6 +7,6 @@ public abstract class ListItemOptions : BindableObject
         SetBinding(BindingContextProperty, new Binding(source: listItem, path:nameof(BindingContext)));
         DoBind(listItem);
     }
-    TEST FØR DENNE COMMITEN OG ETTER REFAKTORERING PÅ IKONFARGEN (LISTITEM OPTIONS)
+    
     public abstract void DoBind(ListItem listItem);
 }

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/ListItemOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/ListItemOptions.cs
@@ -1,0 +1,12 @@
+namespace DIPS.Mobile.UI.Components.ListItems.Options;
+
+public abstract class ListItemOptions : BindableObject
+{
+    public void Bind(ListItem listItem)
+    {
+        SetBinding(BindingContextProperty, new Binding(source: listItem, path:nameof(BindingContext)));
+        DoBind(listItem);
+    }
+    TEST FØR DENNE COMMITEN OG ETTER REFAKTORERING PÅ IKONFARGEN (LISTITEM OPTIONS)
+    public abstract void DoBind(ListItem listItem);
+}

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Subtitle/SubtitleOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Subtitle/SubtitleOptions.cs
@@ -6,7 +6,7 @@ public partial class SubtitleOptions : BindableObject, IListItemOptions
 {
     public void Bind(ListItem listItem)
     {
-        BindingContext = listItem.BindingContext;
+        SetBinding(BindingContextProperty, new Binding(source: listItem, path:nameof(BindingContext)));
         
         if(listItem.SubtitleLabel is null)
             return;            

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Subtitle/SubtitleOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Subtitle/SubtitleOptions.cs
@@ -6,8 +6,6 @@ public partial class SubtitleOptions : ListItemOptions
 {
     public override void DoBind(ListItem listItem)
     {
-        base.Bind(listItem);
-        
         if(listItem.SubtitleLabel is null)
             return;            
         

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Subtitle/SubtitleOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Subtitle/SubtitleOptions.cs
@@ -6,6 +6,8 @@ public partial class SubtitleOptions : BindableObject, IListItemOptions
 {
     public void Bind(ListItem listItem)
     {
+        BindingContext = listItem.BindingContext;
+        
         if(listItem.SubtitleLabel is null)
             return;            
         

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Subtitle/SubtitleOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Subtitle/SubtitleOptions.cs
@@ -2,11 +2,11 @@ using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 
 namespace DIPS.Mobile.UI.Components.ListItems.Options.Subtitle;
 
-public partial class SubtitleOptions : BindableObject, IListItemOptions
+public partial class SubtitleOptions : ListItemOptions
 {
-    public void Bind(ListItem listItem)
+    public override void DoBind(ListItem listItem)
     {
-        SetBinding(BindingContextProperty, new Binding(source: listItem, path:nameof(BindingContext)));
+        base.Bind(listItem);
         
         if(listItem.SubtitleLabel is null)
             return;            

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
@@ -6,8 +6,6 @@ public partial class TitleOptions : ListItemOptions
 {
     public override void DoBind(ListItem listItem)
     {
-        base.Bind(listItem);
-        
         if(listItem.TitleLabel is null)
             return;
 

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
@@ -2,11 +2,11 @@ using Label = DIPS.Mobile.UI.Components.Labels.Label;
 
 namespace DIPS.Mobile.UI.Components.ListItems.Options.Title;
 
-public partial class TitleOptions : BindableObject, IListItemOptions
+public partial class TitleOptions : ListItemOptions
 {
-    public void Bind(ListItem listItem)
+    public override void DoBind(ListItem listItem)
     {
-        SetBinding(BindingContextProperty, new Binding(source: listItem, path:nameof(BindingContext)));
+        base.Bind(listItem);
         
         if(listItem.TitleLabel is null)
             return;

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
@@ -6,7 +6,7 @@ public partial class TitleOptions : BindableObject, IListItemOptions
 {
     public void Bind(ListItem listItem)
     {
-        BindingContext = listItem.BindingContext;
+        SetBinding(BindingContextProperty, new Binding(source: listItem, path:nameof(BindingContext)));
         
         if(listItem.TitleLabel is null)
             return;

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
@@ -6,6 +6,8 @@ public partial class TitleOptions : BindableObject, IListItemOptions
 {
     public void Bind(ListItem listItem)
     {
+        BindingContext = listItem.BindingContext;
+        
         if(listItem.TitleLabel is null)
             return;
 


### PR DESCRIPTION
### Description of Change

Fixed an issue when using bindings to control the options did not work due to to the options not having its binding context set.

- [ContentControl][iOS] If content is CollectionView we wrap it in a grid with row=auto.
- [ListItem] Options now inherit the BindingContext of the ListItem.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->