### PR TITLE
Made sure we safely commit the fragmentmanager when the state was lost to prevent app crashes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [16.10.1] 
+- [Android] Made sure we safely commit the fragmentmanager when the state was lost to prevent app crashes.
+
 ## [16.10.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/SystemMessage/Android/SystemMessageService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/SystemMessage/Android/SystemMessageService.cs
@@ -1,6 +1,7 @@
 using AndroidX.Fragment.App;
 using DIPS.Mobile.UI.Components.Alerting.SystemMessage.Android;
 using DIPS.Mobile.UI.Extensions.Android;
+using Java.Lang;
 using Microsoft.Maui.Platform;
 
 namespace DIPS.Mobile.UI.Components.Alerting.SystemMessage;
@@ -13,11 +14,20 @@ public static partial class SystemMessageService
         // Small delay so that FragmentManager is initialized
         await Task.Delay(10);
         var fragmentManager = Platform.CurrentActivity!.GetFragmentManager();
-        
 
-        fragmentManager!.BeginTransaction()
-            .Add(global::Android.Resource.Id.Content, fragment, SystemMessageTagId.ToString())
-            .Commit();
+
+        try
+        {
+            fragmentManager!.BeginTransaction()
+                .Add(global::Android.Resource.Id.Content, fragment, SystemMessageTagId.ToString())
+                .Commit();
+        }
+        catch (IllegalStateException ignored) //https://stackoverflow.com/a/27854077, to reproduce this : Debug (start) the app but keep the phone locked (blackscreen).
+        {
+            fragmentManager!.BeginTransaction()
+                .Add(global::Android.Resource.Id.Content, fragment, SystemMessageTagId.ToString())
+                .CommitAllowingStateLoss();
+        }
     }
 
     private static partial void PlatformRemove()

--- a/src/library/DIPS.Mobile.UI/Extensions/Android/FragmentManagerExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/Extensions/Android/FragmentManagerExtensions.cs
@@ -1,4 +1,5 @@
 using Android.App;
+using Java.Lang;
 using FragmentManager = AndroidX.Fragment.App.FragmentManager;
 
 namespace DIPS.Mobile.UI.Extensions.Android;
@@ -8,7 +9,19 @@ public static class FragmentManagerExtensions
     public static void RemoveFragmentWithTag(this FragmentManager fragmentManager, string tag)
     {
         var fragment = fragmentManager.FindFragmentByTag(tag);
-        if (fragment is not null)
+        if (fragment is null)
+        {
+            return;
+        }
+
+        try
+        {
             fragmentManager.BeginTransaction().Remove(fragment).Commit();
+        }
+        catch (IllegalStateException ignored) //https://stackoverflow.com/a/27854077, to reproduce this : Debug (start) the app but keep the phone locked (blackscreen).
+        {
+            fragmentManager.BeginTransaction().Remove(fragment).CommitAllowingStateLoss();
+        }
+
     }
 }


### PR DESCRIPTION
### Description of Change

- [Android] Made sure we safely commit the fragmentmanager when the state was lost to prevent app crashes.

### Todos
- [X] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->