### PR TITLE
Made sure SearchPage clears the search text when people tap the X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [16.14.0] 
 - [SearchBar] Added ClearCommand as a command to execute when people tap the clear button (x mark).
 - [SearchPage] Make sure clear the text and state of the view when people tap the clear button.
+- [ItemPicker] Made sure Placeholder gets set the first time it draws.
 
 ## [16.13.1]
 - Selected Item can now be set to null. When its set to null the placeholder will be used. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [16.14.0] 
+- [SearchBar] Added ClearCommand as a command to execute when people tap the clear button (x mark).
+- [SearchPage] Make sure clear the text and state of the view when people tap the clear button.
+
 ## [16.13.1]
 - Selected Item can now be set to null. When its set to null the placeholder will be used. 
 

--- a/src/app/Components/ComponentsSamples/Searching/SearchBarSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Searching/SearchBarSamples.xaml
@@ -23,7 +23,9 @@
                        CancelCommand="{Binding CancelCommand}"
                        Text="{Binding FilterQuery}"
                        TextChanged="InputView_OnTextChanged"
-                       Margin="{dui:Thickness Bottom=size_1}" />
+                       Margin="{dui:Thickness Bottom=size_1}"
+                       TextColor="Red"/>
+        
         <dui:CollectionView Grid.Row="1"
                             BackgroundColor="Transparent"
                             ItemsSource="{Binding People}">

--- a/src/app/Components/ComponentsSamples/Searching/SearchPageSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Searching/SearchPageSamples.xaml
@@ -10,6 +10,7 @@
                 xmlns:localizedStrings="clr-namespace:Components.Resources.LocalizedStrings"
                 x:Class="Components.ComponentsSamples.Searching.SearchPageSamples"
                 SearchCommand="{Binding SearchCommand}"
+                SearchMode="WhenTappedComplete"
                 SearchPlaceholder="{x:Static localizedStrings:LocalizedStrings.SearchPage_PlaceholderText}"
                 Shell.PresentationMode="ModalAnimated"
                 Padding="{dui:Thickness Bottom=size_1}">

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Mode.ContextMenu.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Mode.ContextMenu.cs
@@ -5,15 +5,15 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
 {
     public partial class ItemPicker
     {
-        private static void UpdateContextMenuItems(ItemPicker itemPicker)
+        private void UpdateContextMenuItems()
         {
-            if (itemPicker.m_contextMenu == null ||
-                itemPicker.m_contextMenu.ItemsSource!.FirstOrDefault() is not ContextMenuGroup contextMenuGroup)
+            if (m_contextMenu == null ||
+                m_contextMenu.ItemsSource!.FirstOrDefault() is not ContextMenuGroup contextMenuGroup)
             {
                 return;
             }
 
-            if (itemPicker.SelectedItem == null) //Reset checked items
+            if (SelectedItem == null) //Reset checked items
             {
                 if (contextMenuGroup.ItemsSource == null)
                 {
@@ -25,12 +25,12 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                     item.IsChecked = false;
                 }
 
-                itemPicker.m_contextMenu.SendItemsSourceUpdated();
+                m_contextMenu.SendItemsSourceUpdated();
                 return;
             }
 
             var contextMenuItem = contextMenuGroup.ItemsSource?.FirstOrDefault(i =>
-                i.Title != null && i.Title.Equals(itemPicker.SelectedItem.GetPropertyValue(itemPicker.ItemDisplayProperty),
+                i.Title != null && i.Title.Equals(SelectedItem.GetPropertyValue(ItemDisplayProperty),
                     StringComparison.InvariantCultureIgnoreCase));
             if (contextMenuItem != null)
             {

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Properties.cs
@@ -89,7 +89,7 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
         public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(
             nameof(SelectedItem),
             typeof(object),
-            typeof(ItemPicker), propertyChanged: SelectedItemChanged, defaultBindingMode: BindingMode.TwoWay);
+            typeof(ItemPicker), propertyChanged: (bindable, value, newValue) => ((ItemPicker)bindable).SelectedItemChanged(), defaultBindingMode: BindingMode.TwoWay);
 
        
     }

--- a/src/library/DIPS.Mobile.UI/Components/Searching/Android/SearchBarHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Searching/Android/SearchBarHandler.cs
@@ -17,6 +17,16 @@ namespace DIPS.Mobile.UI.Components.Searching
 {
     internal partial class SearchBarHandler : ViewHandler<SearchBar, AView>
     {
+        private ImageView? RemoveTextImageView =>
+            AutoCompleteTextView is {Parent: ViewGroup viewGroup}
+                ? viewGroup.FindChildView<ImageView>() ?? null
+                : null;
+
+        private AutoCompleteTextView? AutoCompleteTextView =>
+            InternalSearchBar.Handler?.PlatformView is not ViewGroup androidView
+                ? null
+                : androidView.FindChildView<AutoCompleteTextView>() ?? null;
+
         private Microsoft.Maui.Controls.SearchBar InternalSearchBar { get; set; }
         private IndeterminateProgressBar ProgressBar { get; set; }
         private Button CancelButton { get; set; }
@@ -93,12 +103,28 @@ namespace DIPS.Mobile.UI.Components.Searching
                     mauiSearchView.MaxWidth = int.MaxValue;
                 }
             }
+
+            if (RemoveTextImageView != null)
+            {
+                RemoveTextImageView.Click += OnClearTextClicked;    
+            }
+            
         }
 
         protected override void DisconnectHandler(AView platformView)
         {
             base.DisconnectHandler(platformView);
             InternalSearchBar.TextChanged -= SearchBarTextChanged;
+            if (RemoveTextImageView != null)
+            {
+                RemoveTextImageView.Click -= OnClearTextClicked;    
+            }
+        }
+        
+        
+        private void OnClearTextClicked(object? sender, EventArgs e)
+        {
+            VirtualView.ClearTextCommand?.Execute(null);   
         }
 
         private void SearchBarTextChanged(object? sender, TextChangedEventArgs e)
@@ -151,14 +177,10 @@ namespace DIPS.Mobile.UI.Components.Searching
 
         private static void SetHorizontalLineColor(SearchBarHandler handler, Color color)
         {
-            if (handler.InternalSearchBar.Handler?.PlatformView is not ViewGroup androidView)
+            if (handler.AutoCompleteTextView != null)
             {
-                return;
+                handler.AutoCompleteTextView.BackgroundTintList = ColorStateList.ValueOf(color.ToPlatform());    
             }
-
-            var autoCompleteTextView = androidView.FindChildView<AutoCompleteTextView>();
-            
-            autoCompleteTextView.BackgroundTintList = ColorStateList.ValueOf(color.ToPlatform());
         }
 
         private static void MapBarColor(SearchBarHandler handler, SearchBar searchBar)

--- a/src/library/DIPS.Mobile.UI/Components/Searching/SearchBar.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Searching/SearchBar.Properties.cs
@@ -127,6 +127,22 @@ namespace DIPS.Mobile.UI.Components.Searching
             set => SetValue(SearchCommandProperty, value);
         }
 
+        public static readonly BindableProperty ClearTextCommandProperty = BindableProperty.Create(
+            nameof(ClearTextCommand),
+            typeof(ICommand),
+            typeof(SearchBar));
+
+        
+        /// <summary>
+        /// Executed when people has tapped the image that clears the text.
+        /// </summary>
+        /// <remarks><see cref="TextChanged"/> and <see cref="Text"/> will be raised when this happens as well.</remarks>
+        public ICommand? ClearTextCommand
+        {
+            get => (ICommand)GetValue(ClearTextCommandProperty);
+            set => SetValue(ClearTextCommandProperty, value);
+        }
+
         /// <summary>
         /// The background color of the textfield.
         /// </summary>

--- a/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.cs
@@ -47,6 +47,7 @@ namespace DIPS.Mobile.UI.Components.Searching
             SearchBar.TextChanged += SearchBarOnTextChanged;
 
             SearchBar.SearchCommand = new Command(() => OnSearchQueryChanged(SearchBar.Text));
+            SearchBar.ClearTextCommand = new Command(() => TextWasClearedFromClick());
             SearchBar.CancelCommand = new Command(OnCancel);
 
 
@@ -79,6 +80,15 @@ namespace DIPS.Mobile.UI.Components.Searching
             m_grid.Add(SearchBar, 0, 1);
 
             base.Content = m_grid;
+        }
+
+        private void TextWasClearedFromClick()
+        {
+            if (SearchMode is SearchMode.WhenTappedComplete)
+            {
+                SearchBar.Text = string.Empty;
+                OnSearchQueryChanged(string.Empty);
+            }
         }
 
         protected override void OnHandlerChanged()

--- a/src/library/DIPS.Mobile.UI/Components/Searching/iOS/SearchBarHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Searching/iOS/SearchBarHandler.cs
@@ -165,7 +165,21 @@ internal partial class SearchBarHandler : ViewHandler<SearchBar, DuiSearchBar>
         PlatformView.CancelButtonClicked += OnCancelButtonClicked;
         PlatformView.SearchButtonClicked += OnSearchButtonClicked;
         PlatformView.TextChanged += OnSearchTextChanged;
+        if (ClearButton != null)
+        {
+            ClearButton.TouchUpInside += OnClearButtonClicked;    
+        }
     }
+
+    private void OnClearButtonClicked(object? sender, EventArgs e)
+    {
+        VirtualView.ClearTextCommand?.Execute(null);
+    }
+
+    private UIButton? ClearButton =>
+        PlatformView.SearchTextField.ValueForKey(new NSString("_clearButton")) is UIButton clearButton
+            ? clearButton
+            : null;
 
     private void OnSearchTextChanged(object? sender, UISearchBarTextChangedEventArgs e)
     {
@@ -182,6 +196,10 @@ internal partial class SearchBarHandler : ViewHandler<SearchBar, DuiSearchBar>
         PlatformView.CancelButtonClicked -= OnCancelButtonClicked;
         PlatformView.CancelButtonClicked -= OnSearchButtonClicked;
         PlatformView.TextChanged -= OnSearchTextChanged;
+        if (ClearButton != null)
+        {
+            ClearButton.TouchUpInside += OnClearButtonClicked;    
+        }
     }
 
     private void OnCancelButtonClicked(object? sender, EventArgs e)


### PR DESCRIPTION
### Description of Change

- [SearchBar] Added ClearCommand as a command to execute when people tap the clear button (x mark).
- [SearchPage] Make sure clear the text and state of the view when people tap the clear button.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->