### PR TITLE
Added option to add a navigation button as the last button. This will be respected if a new button is added after the button was added.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [16.15.0] 
+- [FloatingNavigationButton] Added option to add a navigation button as the last button. This will be respected if a new button is added after the button was added.
+
 ## [16.14.0] 
 - [SearchBar] Added ClearCommand as a command to execute when people tap the clear button (x mark).
 - [SearchPage] Make sure clear the text and state of the view when people tap the clear button.

--- a/src/app/Components/ComponentsSamples/Navigation/FloatingNavigationButtonSamples.xaml.cs
+++ b/src/app/Components/ComponentsSamples/Navigation/FloatingNavigationButtonSamples.xaml.cs
@@ -34,7 +34,7 @@ public partial class FloatingNavigationButtonSamples
             config.AddNavigationButton(string.Empty, "Button 3",  IconName.ascending_fill, new Command(() => { }));
             config.AddNavigationButton(string.Empty, "Button 4", IconName.descending_fill, new Command(() => { }));
             config.AddNavigationButton(string.Empty, "Button 5", IconName.descending_fill, new Command(() => { }));
-            config.AddNavigationButton(string.Empty, "Close", IconName.descending_fill, new Command(FloatingNavigationButtonService.Close));
+            config.AddNavigationButton(string.Empty, "Close", IconName.descending_fill, new Command(FloatingNavigationButtonService.Close), isLast: true);
 
         });
     }

--- a/src/app/Components/ComponentsSamples/Navigation/FloatingNavigationButtonSamplesViewModel.cs
+++ b/src/app/Components/ComponentsSamples/Navigation/FloatingNavigationButtonSamplesViewModel.cs
@@ -70,6 +70,7 @@ public class FloatingNavigationButtonSamplesViewModel : ViewModel
     public ICommand ChangeBadgeColorCommand { get; }
     public ICommand RemoveNavigationMenuButtonCommand { get; }
     public ICommand AddNavigationMenuButtonCommand { get; }
+    public ICommand AddAButtonThat { get; }
 
     public List<string> ColorList { get; }
     public ICommand ToggleCommand { get; }

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/ExtendedNavigationMenuButton/ExtendedNavigationMenuButton.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/ExtendedNavigationMenuButton/ExtendedNavigationMenuButton.Properties.cs
@@ -69,6 +69,17 @@ internal partial class ExtendedNavigationMenuButton
         get => (Color)GetValue(BadgeColorProperty);
         set => SetValue(BadgeColorProperty, value);
     }
+
+    public static readonly BindableProperty IsLastProperty = BindableProperty.Create(
+        nameof(IsLast),
+        typeof(bool),
+        typeof(ExtendedNavigationMenuButton));
+
+    public bool IsLast
+    {
+        get => (bool)GetValue(IsLastProperty);
+        set => SetValue(IsLastProperty, value);
+    }
     
     public static readonly BindableProperty BadgeColorProperty = BindableProperty.Create(
         nameof(BadgeColor),

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
@@ -264,7 +264,15 @@ internal class FloatingNavigationButton : Grid
 
     public void AddNavigationMenuButton(ExtendedNavigationMenuButton.ExtendedNavigationMenuButton navigationMenuButton, int? index)
     {
-        var insertIndex = index ?? m_floatingNavigationButtonConfigurator.NavigationMenuButtons.Count;
+        var insertIndex = m_floatingNavigationButtonConfigurator.NavigationMenuButtons.Count;
+        if (index != null)
+        {
+            insertIndex = (int)index;
+        }else if (m_floatingNavigationButtonConfigurator.NavigationMenuButtons.FirstOrDefault(b => b.IsLast) != null)
+        {
+            insertIndex = m_floatingNavigationButtonConfigurator.NavigationMenuButtons.Count-1;
+        }
+        
         m_floatingNavigationButtonConfigurator.NavigationMenuButtons.Insert(insertIndex, navigationMenuButton);
         
         if(!m_isExpanded)

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButtonConfigurator.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButtonConfigurator.cs
@@ -12,13 +12,14 @@ internal class FloatingNavigationButtonConfigurator : IFloatingNavigationButtonC
 
     public List<Type> PagesThatHidesButton { get; } = new();
     
-    public void AddNavigationButton(string identifier, string title, IconName iconName, ICommand command)
+    public void AddNavigationButton(string identifier, string title, IconName iconName, ICommand command, bool isLast = false)
     {
         NavigationMenuButtons.Add(new ExtendedNavigationMenuButton.ExtendedNavigationMenuButton
         {
             AutomationId = identifier,
             Title = title,
             Icon = Icons.GetIcon(iconName),
+            IsLast = isLast,
             Command = command
         });
     }

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButtonService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButtonService.cs
@@ -101,13 +101,15 @@ public static partial class FloatingNavigationButtonService
     /// <param name="iconName">Sets the icon the button should have</param>
     /// <param name="command">Sets what should happen when the button is tapped</param>
     /// <param name="index">To what index it should be placed in</param>
-    public static void AddNavigationMenuButton(string identifier = "", string title = "", IconName iconName = IconName.arrow_right_s_line, ICommand? command = null, int? index = null)
+    /// <param name="isLast">Indicates that the button should always be last, this will be respected by other buttons getting added</param>
+    public static void AddNavigationMenuButton(string identifier = "", string title = "", IconName iconName = IconName.arrow_right_s_line, ICommand? command = null, int? index = null, bool isLast = false)
     {
         FloatingNavigationButton?.AddNavigationMenuButton(new ExtendedNavigationMenuButton.ExtendedNavigationMenuButton
         {
             AutomationId = identifier,
             Title = title,
             Icon = Icons.GetIcon(iconName),
+            IsLast = isLast,
             Command = command ?? new Command(() => {})
         }, index);
     }

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/IFloatingNavigationButtonConfigurator.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/IFloatingNavigationButtonConfigurator.cs
@@ -4,6 +4,6 @@ namespace DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton;
 
 public interface IFloatingNavigationButtonConfigurator
 {
-    void AddNavigationButton(string identifier, string title, IconName iconName, ICommand command);
+    void AddNavigationButton(string identifier, string title, IconName iconName, ICommand command, bool isLast = false);
     void AddPageThatHidesButton(Type page);
 }


### PR DESCRIPTION
### Description of Change

- [FloatingNavigationButton] Added option to add a navigation button as the last button. This will be respected if a new button is added after the button was added.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->