### PR TITLE
Safe Area and FloatingNavigationButton improvements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [17.12.0] 
 - [Layout] Made sure all layouts ignore safe area when its not set by the consumer. Grid, StackLayout etc.
+- [FloatingNavigationButton] Made sure people can tap the background of the FAB to close it.
 
 ## [17.11.0] 
 - Changed touch effect color on Android for dui:Buttons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [Layout] Made sure all layouts ignore safe area when its not set by the consumer. Grid, StackLayout etc.
 - [FloatingNavigationButton] Made sure people can tap the background of the FAB to close it.
 - [FloatingNavigationButton] Made sure sizes of the icons are smaller for better UX.
+- [FloatingNavigationButton] Made sure its accesibile for text readers.
 
 ## [17.11.0] 
 - Changed touch effect color on Android for dui:Buttons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [17.12.0] 
 - [Layout] Made sure all layouts ignore safe area when its not set by the consumer. Grid, StackLayout etc.
 - [FloatingNavigationButton] Made sure people can tap the background of the FAB to close it.
+- [FloatingNavigationButton] Made sure sizes of the icons are smaller for better UX.
 
 ## [17.11.0] 
 - Changed touch effect color on Android for dui:Buttons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [17.12.0] 
+## [17.11.1] 
 - [Layout] Made sure all layouts ignore safe area when its not set by the consumer. Grid, StackLayout etc.
 - [FloatingNavigationButton] Made sure people can tap the background of the FAB to close it.
 - [FloatingNavigationButton] Made sure sizes of the icons are smaller for better UX.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [17.12.0] 
+- [Layout] Made sure all layouts ignore safe area when its not set by the consumer. Grid, StackLayout etc.
+
 ## [17.11.0] 
 - Changed touch effect color on Android for dui:Buttons
 - Icon size on buttons will now scale down with the Button's height

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -29,12 +29,12 @@
     <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
         <!--DEBUG ON DEVICE-->
 
-        <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
+<!--        <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>-->
 
         <!--DEBUG ON SIMULATOR-->
-<!--
+
             <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
--->
+
     </PropertyGroup>
 
 

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -15,10 +15,6 @@
 
 
     <dui:VerticalStackLayout Padding="20">
-
-        <!--<Button Text="Hello" 
-                BackgroundColor="Red"
-                CornerRadius="27" />-->
         
         <dui:Button Style="{dui:Styles Button=PrimaryLarge}"
                     Text="Test"
@@ -32,10 +28,7 @@
                     Style="{dui:Styles Button=SecondaryLarge}"
                     IsEnabled="{Binding Disabled, Converter={dui:InvertedBoolConverter}}"
                     Command="{Binding Navigate}"/>
-
-        <!--<Button Command="{Binding DisableCommand}"
-                Text="hei"
-                Background="Green"/>-->
+        
         
     </dui:VerticalStackLayout>
 

--- a/src/library/DIPS.Mobile.UI/API/Builder/AppHostBuilderExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Builder/AppHostBuilderExtensions.cs
@@ -3,6 +3,7 @@ using DIPS.Mobile.UI.Components.Chips;
 using DIPS.Mobile.UI.Components.ContextMenus;
 using DIPS.Mobile.UI.Components.Images.NativeIcon;
 using DIPS.Mobile.UI.Components.Lists;
+using DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton;
 using DIPS.Mobile.UI.Components.Pickers.DateAndTimePicker;
 
 using DIPS.Mobile.UI.Effects.Touch;
@@ -55,6 +56,7 @@ public static partial class AppHostBuilderExtensions
             handlers.AddHandler<Label, LabelHandler>();
             handlers.AddHandler<CollectionView, CollectionViewHandler>();
             handlers.AddHandler<ScrollView, ScrollViewHandler>();
+            handlers.AddHandler<FloatingNavigationButton, FloatingNavigationButtonHandler>();
             
             AddPlatformHandlers(handlers);
         });

--- a/src/library/DIPS.Mobile.UI/API/Builder/iOS/AppHostBuilderExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Builder/iOS/AppHostBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.Components.CheckBoxes;
+using DIPS.Mobile.UI.Components.Layout;
 using DIPS.Mobile.UI.Components.Pickers.DatePicker.Inline;
 using DIPS.Mobile.UI.Components.Pickers.DatePicker.Inline.iOS;
 using Foundation;
@@ -14,6 +15,7 @@ public static partial class AppHostBuilderExtensions
     {
         handlers.AddHandler(typeof(DIPS.Mobile.UI.Components.Searching.iOS.InternalSearchBar), typeof(DIPS.Mobile.UI.Components.Searching.iOS.InternalSearchBarHandler));
         handlers.AddHandler<InlineDatePicker, InlineDatePickerHandler>();
+        handlers.AddHandler<Layout, LayoutHandler>();
     }
 
     static partial void ConfigurePlatformLifecycleEvents(ILifecycleBuilder events)

--- a/src/library/DIPS.Mobile.UI/Components/Layout/LayoutHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Layout/LayoutHandler.cs
@@ -1,0 +1,6 @@
+namespace DIPS.Mobile.UI.Components.Layout;
+
+public partial class LayoutHandler
+{
+    
+}

--- a/src/library/DIPS.Mobile.UI/Components/Layout/iOS/LayoutHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Layout/iOS/LayoutHandler.cs
@@ -7,10 +7,10 @@ public partial class LayoutHandler : Microsoft.Maui.Handlers.LayoutHandler
     protected override void ConnectHandler(LayoutView platformView)
     {
         base.ConnectHandler(platformView);
-        DoNotIgnoreSafeArea();
+        IgnoreSafeArea();
     }
 
-    private void DoNotIgnoreSafeArea()
+    private void IgnoreSafeArea()
     {
         if (VirtualView is Microsoft.Maui.Controls.Layout layout)
         {

--- a/src/library/DIPS.Mobile.UI/Components/Layout/iOS/LayoutHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Layout/iOS/LayoutHandler.cs
@@ -1,0 +1,20 @@
+using Microsoft.Maui.Platform;
+
+namespace DIPS.Mobile.UI.Components.Layout;
+
+public partial class LayoutHandler : Microsoft.Maui.Handlers.LayoutHandler
+{
+    protected override void ConnectHandler(LayoutView platformView)
+    {
+        base.ConnectHandler(platformView);
+        DoNotIgnoreSafeArea();
+    }
+
+    private void DoNotIgnoreSafeArea()
+    {
+        if (VirtualView is Microsoft.Maui.Controls.Layout layout)
+        {
+            layout.IgnoreSafeArea = true;
+        }
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/Android/FloatingNavigationButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/Android/FloatingNavigationButtonHandler.cs
@@ -1,0 +1,34 @@
+using Microsoft.Maui.Handlers;
+using Button = Android.Widget.Button;
+
+namespace DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton;
+
+public partial class FloatingNavigationButtonHandler
+{
+    private static partial void MapIsClickable(FloatingNavigationButtonHandler handler,
+        FloatingNavigationButton floatingNavigationButton)
+    {
+        if (handler.PlatformView is not global::Android.Views.View aView) return;
+        if (handler.VirtualView is not FloatingNavigationButton fab) return;
+        
+        if (floatingNavigationButton.IsClickable)
+        {
+            aView.Clickable = true;
+            aView.Focusable = true;
+            aView.FocusableInTouchMode = true;
+            aView.SetOnClickListener(new global::DIPS.Mobile.UI.Effects.Touch.TouchPlatformEffect.ClickListener(() =>
+            {
+                _ = fab.Close();
+            }));    
+        }
+        else
+        {
+            aView.Clickable = false;
+            aView.Focusable = false;
+            aView.FocusableInTouchMode = false;
+        }
+        
+
+        
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/Android/FloatingNavigationButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/Android/FloatingNavigationButtonHandler.cs
@@ -14,9 +14,7 @@ public partial class FloatingNavigationButtonHandler
         if (floatingNavigationButton.IsClickable)
         {
             aView.Clickable = true;
-            aView.Focusable = true;
-            aView.FocusableInTouchMode = true;
-            aView.SetOnClickListener(new global::DIPS.Mobile.UI.Effects.Touch.TouchPlatformEffect.ClickListener(() =>
+            aView.SetOnClickListener(new Effects.Touch.TouchPlatformEffect.ClickListener(() =>
             {
                 _ = fab.Close();
             }));    
@@ -24,11 +22,6 @@ public partial class FloatingNavigationButtonHandler
         else
         {
             aView.Clickable = false;
-            aView.Focusable = false;
-            aView.FocusableInTouchMode = false;
         }
-        
-
-        
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/Android/FloatingNavigationButtonMenuFragment.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/Android/FloatingNavigationButtonMenuFragment.cs
@@ -18,7 +18,8 @@ internal class FloatingNavigationButtonMenuFragment : AndroidX.Fragment.App.Frag
     
     public override View OnCreateView(LayoutInflater inflater, ViewGroup? container, Bundle? savedInstanceState)
     {
-        return m_fab.ToPlatform(DUI.GetCurrentMauiContext!);
+        var view =  m_fab.ToPlatform(DUI.GetCurrentMauiContext!);
+        return view;
     }
     
 }

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/ExtendedNavigationMenuButton/ExtendedNavigationMenuButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/ExtendedNavigationMenuButton/ExtendedNavigationMenuButton.cs
@@ -1,6 +1,8 @@
 using DIPS.Mobile.UI.Converters.ValueConverters;
+using DIPS.Mobile.UI.Resources.Styles.Button;
 using Microsoft.Maui.Controls.Shapes;
 using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
+using Button = DIPS.Mobile.UI.Components.Buttons.Button;
 
 namespace DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton.ExtendedNavigationMenuButton;
 
@@ -13,39 +15,36 @@ internal partial class ExtendedNavigationMenuButton : HorizontalStackLayout
     {
         Spacing = 8;
         
-        var label = new Label
+        var labelButton = new Button()
         {
+            Style = DIPS.Mobile.UI.Resources.Styles.Styles.GetButtonStyle(ButtonStyle.SecondarySmall),
             TextColor = Colors.GetColor(ColorName.color_primary_90),
-            VerticalTextAlignment = TextAlignment.Center,
-            HorizontalTextAlignment = TextAlignment.Center,
+            BackgroundColor = Colors.GetColor(ColorName.color_system_white), 
             VerticalOptions = LayoutOptions.Center,
             HorizontalOptions = LayoutOptions.Center
         };
-        label.SetBinding(Label.TextProperty, new Binding(nameof(Title), source: this));
-        
-        TextBorder = new Border
-        {
-            BackgroundColor = Colors.GetColor(ColorName.color_system_white),
-            StrokeShape = new RoundRectangle { CornerRadius = Sizes.GetSize(SizeName.size_2) },
-            Padding = new Thickness(Sizes.GetSize(SizeName.size_2)),
-            VerticalOptions = LayoutOptions.Center,
-            Content = label
-        };
-        TextBorder.SetBinding(OpacityProperty, new Binding(nameof(IsEnabled), converter: new BoolToObjectConverter{TrueObject = (double)1, FalseObject = 0.5}, source: this));
+        labelButton.SetBinding(Microsoft.Maui.Controls.Button.TextProperty, new Binding(nameof(Title), source: this));
+        labelButton.SetBinding(IsEnabledProperty,
+            new Binding(nameof(IsEnabled), source: this));
 
 
         var floatingActionButton = new NavigationMenuButton.NavigationMenuButton();
-        floatingActionButton.SetBinding(NavigationMenuButton.NavigationMenuButton.IconProperty, new Binding(nameof(Icon), source: this));
-        floatingActionButton.SetBinding(NavigationMenuButton.NavigationMenuButton.CommandProperty, new Binding(nameof(Command), source: this));
-        floatingActionButton.SetBinding(NavigationMenuButton.NavigationMenuButton.ButtonBackgroundColorProperty, new Binding(nameof(ButtonBackgroundColor), source: this));
-        floatingActionButton.SetBinding(NavigationMenuButton.NavigationMenuButton.BadgeCountProperty, new Binding(nameof(BadgeCount), source: this));
-        floatingActionButton.SetBinding(NavigationMenuButton.NavigationMenuButton.BadgeColorProperty, new Binding(nameof(BadgeColor), source: this));
+        AutomationProperties.SetExcludedWithChildren(floatingActionButton, true);
+        floatingActionButton.SetBinding(NavigationMenuButton.NavigationMenuButton.IconProperty,
+            new Binding(nameof(Icon), source: this));
+        floatingActionButton.SetBinding(NavigationMenuButton.NavigationMenuButton.CommandProperty,
+            new Binding(nameof(Command), source: this));
+        floatingActionButton.SetBinding(NavigationMenuButton.NavigationMenuButton.ButtonBackgroundColorProperty,
+            new Binding(nameof(ButtonBackgroundColor), source: this));
+        floatingActionButton.SetBinding(NavigationMenuButton.NavigationMenuButton.BadgeCountProperty,
+            new Binding(nameof(BadgeCount), source: this));
+        floatingActionButton.SetBinding(NavigationMenuButton.NavigationMenuButton.BadgeColorProperty,
+            new Binding(nameof(BadgeColor), source: this));
         floatingActionButton.SetBinding(IsEnabledProperty, new Binding(nameof(IsEnabled), source: this));
         
-        Add(TextBorder);
+
+
+        Add(labelButton);
         Add(floatingActionButton);
     }
-
-    public Border TextBorder { get; set; }
-
 }

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
@@ -25,33 +25,18 @@ internal class FloatingNavigationButton : Grid
         Add(m_contentGrid);
         
         Padding = new Thickness(0, 0, Sizes.GetSize(SizeName.size_3), Sizes.GetSize(SizeName.size_13));
-        // CascadeInputTransparent = false;
         
         m_contentGrid.RowDefinitions = new RowDefinitionCollection { new() { Height = GridLength.Star } };
         m_contentGrid.ColumnDefinitions = new ColumnDefinitionCollection { new() { Width = GridLength.Auto } };
         m_contentGrid.HorizontalOptions = LayoutOptions.End;
-        // m_contentGrid.CascadeInputTransparent = false;
 
         AddMainButton();
         CreateAnimations();
-        Loaded += OnLoaded;
-    }
-
-    private void OnLoaded(object? sender, EventArgs e)
-    {
-        Loaded -= OnLoaded;
-        MakeBackgroundNonClickable();
-    }
-
-    private void MakeBackgroundNonClickable()
-    {
-        IsClickable = false;
     }
     
     
     private void MakeBackgroundClickable()
     {
-        // InputTransparent = false;
         IsClickable = true;
     }
 
@@ -155,9 +140,6 @@ internal class FloatingNavigationButton : Grid
         if(!m_isExpanded)
             return;
         
-        // InputTransparent = true;
-        
-
         IsClickable = false;
         
         m_isExpanded = false;
@@ -318,7 +300,7 @@ internal class FloatingNavigationButton : Grid
     public static readonly BindableProperty IsClickableProperty = BindableProperty.Create(
         nameof(IsClickable),
         typeof(bool),
-        typeof(FloatingNavigationButton));
+        typeof(FloatingNavigationButton), defaultValue:false);
 
     public bool IsClickable
     {

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
@@ -13,7 +13,7 @@ internal class FloatingNavigationButton : Grid
     private bool m_isExpanded;
     
 #nullable disable
-    private NavigationMenuButton.NavigationMenuButton m_mainButton;
+    internal NavigationMenuButton.NavigationMenuButton m_mainButton;
     private Microsoft.Maui.Controls.Animation m_fadeOutColorAnimation;
     private Microsoft.Maui.Controls.Animation m_fadeInColorAnimation;
 #nullable restore
@@ -25,23 +25,34 @@ internal class FloatingNavigationButton : Grid
         Add(m_contentGrid);
         
         Padding = new Thickness(0, 0, Sizes.GetSize(SizeName.size_3), Sizes.GetSize(SizeName.size_13));
-        CascadeInputTransparent = false;
+        // CascadeInputTransparent = false;
         
         m_contentGrid.RowDefinitions = new RowDefinitionCollection { new() { Height = GridLength.Star } };
         m_contentGrid.ColumnDefinitions = new ColumnDefinitionCollection { new() { Width = GridLength.Auto } };
         m_contentGrid.HorizontalOptions = LayoutOptions.End;
-        m_contentGrid.CascadeInputTransparent = false;
-        m_contentGrid.InputTransparent = true;
+        // m_contentGrid.CascadeInputTransparent = false;
 
         AddMainButton();
         CreateAnimations();
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object? sender, EventArgs e)
+    {
+        Loaded -= OnLoaded;
+        MakeBackgroundNonClickable();
+    }
+
+    private void MakeBackgroundNonClickable()
+    {
+        IsClickable = false;
     }
     
-    protected override void OnHandlerChanged()
+    
+    private void MakeBackgroundClickable()
     {
-        base.OnHandlerChanged();
-        
-        InputTransparent = true;
+        // InputTransparent = false;
+        IsClickable = true;
     }
 
     public async Task Show(bool shouldAnimate)
@@ -71,11 +82,6 @@ internal class FloatingNavigationButton : Grid
         }
         
         IsVisible = false;
-    }
-
-    private void OnTappedBackground()
-    {
-        _ = Close();
     }
 
     private void CreateAnimations()
@@ -126,14 +132,9 @@ internal class FloatingNavigationButton : Grid
 
     private void Expand()
     {
-        InputTransparent = false;
-        
+        MakeBackgroundClickable();
+
         m_isExpanded = true;
-        
-        GestureRecognizers.Add(new TapGestureRecognizer
-        {
-            Command = new Command(OnTappedBackground)
-        });
         
         this.AbortAnimation("FadeOut");
         m_fadeInColorAnimation.Commit(this, "FadeIn", easing: Easing.CubicOut);
@@ -148,16 +149,18 @@ internal class FloatingNavigationButton : Grid
         }
     }
 
+
     public async Task Close()
     {
         if(!m_isExpanded)
             return;
         
-        InputTransparent = true;
+        // InputTransparent = true;
+        
+
+        IsClickable = false;
         
         m_isExpanded = false;
-        
-        GestureRecognizers.RemoveAt(0);
         
         this.AbortAnimation("FadeIn");
         m_fadeOutColorAnimation.Commit(this, "FadeOut", easing: Easing.CubicIn);
@@ -180,8 +183,6 @@ internal class FloatingNavigationButton : Grid
         {
             m_contentGrid.Remove(navigationMenuButton);
         }
-        
-        
     }
 
     private void AnimateExpand(int index)
@@ -313,5 +314,16 @@ internal class FloatingNavigationButton : Grid
     
     private ExtendedNavigationMenuButton.ExtendedNavigationMenuButton? GetButtonFromIdentifier(string identifier) => 
         m_floatingNavigationButtonConfigurator.NavigationMenuButtons.FirstOrDefault(navButton => navButton.AutomationId.Equals(identifier));
+
+    public static readonly BindableProperty IsClickableProperty = BindableProperty.Create(
+        nameof(IsClickable),
+        typeof(bool),
+        typeof(FloatingNavigationButton));
+
+    public bool IsClickable
+    {
+        get => (bool)GetValue(IsClickableProperty);
+        set => SetValue(IsClickableProperty, value);
+    }
 
 }

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
@@ -1,3 +1,4 @@
+using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
 using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 
 namespace DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton;
@@ -88,6 +89,7 @@ internal class FloatingNavigationButton : Grid
             IconRotation = 270,
             
         };
+        SemanticProperties.SetDescription(m_mainButton, DUILocalizedStrings.Accessability_FloatingNavigationButton_Description);
         
         m_contentGrid.Add(m_mainButton);
 

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
@@ -14,8 +14,8 @@ internal class FloatingNavigationButton : Grid
     
 #nullable disable
     internal NavigationMenuButton.NavigationMenuButton m_mainButton;
-    private Microsoft.Maui.Controls.Animation m_fadeOutColorAnimation;
-    private Microsoft.Maui.Controls.Animation m_fadeInColorAnimation;
+    private Animation m_fadeOutColorAnimation;
+    private Animation m_fadeInColorAnimation;
 #nullable restore
 
     public FloatingNavigationButton(FloatingNavigationButtonConfigurator floatingNavigationButtonConfigurator)
@@ -71,8 +71,8 @@ internal class FloatingNavigationButton : Grid
 
     private void CreateAnimations()
     {
-        m_fadeOutColorAnimation = new Microsoft.Maui.Controls.Animation(alpha => BackgroundColor = new Color(0, 0, 0, (int)alpha), 100, 0);
-        m_fadeInColorAnimation = new Microsoft.Maui.Controls.Animation(alpha => BackgroundColor = new Color(0, 0, 0, (int)alpha), 0, 100);
+        m_fadeOutColorAnimation = new Animation(alpha => BackgroundColor = new Color(0, 0, 0, (int)alpha), 100, 0);
+        m_fadeInColorAnimation = new Animation(alpha => BackgroundColor = new Color(0, 0, 0, (int)alpha), 0, 100);
     }
 
     private void AddMainButton()

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButtonHandler.cs
@@ -1,0 +1,18 @@
+using Microsoft.Maui.Handlers;
+
+namespace DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton;
+
+public partial class FloatingNavigationButtonHandler : LayoutHandler
+{
+    public FloatingNavigationButtonHandler():base(s_propertyMapper)
+    {
+        
+    }
+    
+    internal static IPropertyMapper<FloatingNavigationButton, FloatingNavigationButtonHandler> s_propertyMapper = new PropertyMapper<FloatingNavigationButton, FloatingNavigationButtonHandler>(LayoutHandler.ViewMapper)
+    {
+        [nameof(FloatingNavigationButton.IsClickable)] = MapIsClickable,
+    };
+
+    private static partial void MapIsClickable(FloatingNavigationButtonHandler handler, FloatingNavigationButton floatingNavigationButton);
+}

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/NavigationMenuButton/NavigationMenuButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/NavigationMenuButton/NavigationMenuButton.cs
@@ -1,6 +1,7 @@
 using DIPS.Mobile.UI.Converters.ValueConverters;
 using DIPS.Mobile.UI.Effects.Touch;
 using Microsoft.Maui.Controls.Shapes;
+using Button = DIPS.Mobile.UI.Components.Buttons.Button;
 using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 
 namespace DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton.NavigationMenuButton;
@@ -12,35 +13,29 @@ internal partial class NavigationMenuButton : Grid
         RowDefinitions = new RowDefinitionCollection { new() { Height = GridLength.Auto } };
         ColumnDefinitions = new ColumnDefinitionCollection { new() { Width = GridLength.Auto } };
         
-        ImageButton = new Images.ImageButton.ImageButton()
+        Button = new Button()
         {
             BorderColor = Colors.GetColor(ColorName.color_system_white),
             BorderWidth = 3,
-            TintColor = Colors.GetColor(ColorName.color_system_white)
+            // TintColor = Colors.GetColor(ColorName.color_system_white) TODO: LEGG TIL ImageColor på Button
         };
 
     // Workaround for a bug in Android where the circle gets clipped left, top, right and bottom
 #if __ANDROID__
-        ImageButton.Clip = new EllipseGeometry
-        {
-            RadiusX = 30,
-            RadiusY = 30,
-            Center = new Point(new Size(30))
-        };
-        ImageButton.BorderWidth = 6;
+        Button.BorderWidth = 3;
 #endif
         
-        ImageButton.SetBinding(ImageButton.SourceProperty, new Binding(nameof(Icon), source: this));
-        ImageButton.SetBinding(BackgroundColorProperty, new Binding(nameof(ButtonBackgroundColor), source: this));
-        ImageButton.SetBinding(IsEnabledProperty, new Binding(nameof(IsEnabled), source: this));
-        ImageButton.SetBinding(OpacityProperty, new Binding(nameof(IsEnabled), converter: new BoolToObjectConverter{TrueObject = (double)1, FalseObject = 0.5}, source:this));
-        ImageButton.SetBinding(ImageButton.CommandProperty, new Binding(nameof(Command), source: this));
+        Button.SetBinding(Microsoft.Maui.Controls.Button.ImageSourceProperty, new Binding(nameof(Icon), source: this));
+        Button.SetBinding(BackgroundColorProperty, new Binding(nameof(ButtonBackgroundColor), source: this));
+        Button.SetBinding(IsEnabledProperty, new Binding(nameof(IsEnabled), source: this));
+        Button.SetBinding(OpacityProperty, new Binding(nameof(IsEnabled), converter: new BoolToObjectConverter{TrueObject = (double)1, FalseObject = 0.5}, source:this));
+        Button.SetBinding(Microsoft.Maui.Controls.Button.CommandProperty, new Binding(nameof(Command), source: this));
 
         // Can not use design system here, because we need to set corner radius to half of the width/height
-        ImageButton.WidthRequest = 60;
-        ImageButton.HeightRequest = 60;
-        ImageButton.CornerRadius = 30;
-        ImageButton.Padding = DeviceInfo.Platform == DevicePlatform.Android ? Sizes.GetSize(SizeName.size_1) : Sizes.GetSize(SizeName.size_3);
+        Button.WidthRequest = Sizes.GetSize(SizeName.size_15);
+        Button.HeightRequest = Sizes.GetSize(SizeName.size_15);
+        Button.CornerRadius = (int)(Button.HeightRequest/2);
+        Button.Padding = DeviceInfo.Platform == DevicePlatform.Android ? Sizes.GetSize(SizeName.size_1) : Sizes.GetSize(SizeName.size_3);
 
         BadgeLabel = new Label
         {
@@ -49,7 +44,7 @@ internal partial class NavigationMenuButton : Grid
             BackgroundColor = Microsoft.Maui.Graphics.Colors.Transparent,
             FontSize = Sizes.GetSize(SizeName.size_3),
             HorizontalTextAlignment = TextAlignment.Center,
-            VerticalTextAlignment = TextAlignment.Center
+            VerticalTextAlignment = TextAlignment.Center,
         };
         
         Badge = new Border
@@ -69,7 +64,7 @@ internal partial class NavigationMenuButton : Grid
 #endif
         Badge.SetBinding(BackgroundColorProperty, new Binding(nameof(BadgeColor), source: this));
 
-        Add(ImageButton);
+        Add(Button);
         Add(Badge);
         
     }
@@ -78,14 +73,14 @@ internal partial class NavigationMenuButton : Grid
 
     private Label BadgeLabel { get; }
     
-    private ImageButton ImageButton { get; }
+    private Button Button { get; }
 
     protected override async void OnHandlerChanged()
     {
         base.OnHandlerChanged();
 
         // We must set this here, because on Android, the ImageButton disappears when binding rotation
-        ImageButton.Rotation = IconRotation;
+        Button.Rotation = IconRotation;
         
         if(BadgeCount is not 0)
             ShowBadge();
@@ -96,7 +91,7 @@ internal partial class NavigationMenuButton : Grid
 
     public void RotateIconTo(float rotation)
     {
-        ImageButton.RotateTo(rotation, 125U);
+        Button.RotateTo(rotation, 125U);
     }
 
     private static void OnBadgeCountChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/NavigationMenuButton/NavigationMenuButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/NavigationMenuButton/NavigationMenuButton.cs
@@ -17,7 +17,6 @@ internal partial class NavigationMenuButton : Grid
         {
             BorderColor = Colors.GetColor(ColorName.color_system_white),
             BorderWidth = 3,
-            // TintColor = Colors.GetColor(ColorName.color_system_white) TODO: LEGG TIL ImageColor på Button
         };
 
     // Workaround for a bug in Android where the circle gets clipped left, top, right and bottom

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/NavigationMenuButton/NavigationMenuButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/NavigationMenuButton/NavigationMenuButton.cs
@@ -44,7 +44,9 @@ internal partial class NavigationMenuButton : Grid
             FontSize = Sizes.GetSize(SizeName.size_3),
             HorizontalTextAlignment = TextAlignment.Center,
             VerticalTextAlignment = TextAlignment.Center,
+            
         };
+        
         
         Badge = new Border
         {

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/dotnet/FloatingNavigationButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/dotnet/FloatingNavigationButtonHandler.cs
@@ -1,0 +1,12 @@
+using Microsoft.Maui.Handlers;
+
+namespace DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton;
+
+public partial class FloatingNavigationButtonHandler
+{
+    private static partial void MapIsClickable(FloatingNavigationButtonHandler handler,
+        FloatingNavigationButton floatingNavigationButton)
+    {
+        
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/iOS/FloatingNavigationButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/iOS/FloatingNavigationButtonHandler.cs
@@ -1,0 +1,31 @@
+using Microsoft.Maui.Handlers;
+using UIKit;
+
+namespace DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton;
+
+public partial class FloatingNavigationButtonHandler
+{
+    private static partial void MapIsClickable(FloatingNavigationButtonHandler handler,
+        FloatingNavigationButton floatingNavigationButton)
+    {
+        if (handler.PlatformView is not UIView uiView) return;
+        if (handler.VirtualView is not FloatingNavigationButton fab) return;
+        
+        if (floatingNavigationButton.IsClickable)
+        {
+            uiView.UserInteractionEnabled = true;
+            uiView.GestureRecognizers = new UIGestureRecognizer[]
+            {
+                new UITapGestureRecognizer(() =>
+                {
+                    _ = fab.Close();
+                })
+            };
+        }
+        else
+        {
+            uiView.UserInteractionEnabled = false;
+            uiView.GestureRecognizers = Array.Empty<UIGestureRecognizer>();
+        }
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
@@ -20,7 +20,7 @@ public partial class TouchPlatformEffect
     {
         if(Control is UIButton)
             return;
-
+        
         m_isEnabled = Touch.GetIsEnabled(Element);
         m_touchMode = Touch.GetTouchMode(Element);
 

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.Designer.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.Designer.cs
@@ -122,5 +122,11 @@ namespace DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings {
                 return ResourceManager.GetString("Choose", resourceCulture);
             }
         }
+        
+        internal static string Accessability_FloatingNavigationButton_Description {
+            get {
+                return ResourceManager.GetString("Accessability.FloatingNavigationButton.Description", resourceCulture);
+            }
+        }
     }
 }

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.nb.resx
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.nb.resx
@@ -50,4 +50,7 @@
     <data name="Choose" xml:space="preserve">
         <value>Velg</value>
     </data>
+    <data name="Accessability.FloatingNavigationButton.Description" xml:space="preserve">
+        <value>Navigasjonsmeny, knapp</value>
+    </data>
 </root>

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.resx
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.resx
@@ -57,4 +57,7 @@
     <data name="Choose" xml:space="preserve">
         <value>Choose</value>
     </data>
+    <data name="Accessability.FloatingNavigationButton.Description" xml:space="preserve">
+        <value>Navigation menu, button</value>
+    </data>
 </root>

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Styles.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Styles.cs
@@ -1,0 +1,19 @@
+using DIPS.Mobile.UI.Resources.Styles.Button;
+using DIPS.Mobile.UI.Resources.Styles.Chip;
+
+namespace DIPS.Mobile.UI.Resources.Styles;
+
+public static class Styles
+{
+    public static Style GetButtonStyle(ButtonStyle style)
+    {
+        return ButtonStyleResources.Styles.TryGetValue(style, out var buttonStyle)
+            ? buttonStyle
+            : new Style(typeof(View));
+    }
+
+    public static Style GetChipStyle(ChipStyle style)
+    {
+        return ChipStyleResources.Styles.TryGetValue(style, out var chipStyle) ? chipStyle : new Style(typeof(View));
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/StylesExtension.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/StylesExtension.cs
@@ -19,14 +19,12 @@ namespace DIPS.Mobile.UI.Resources.Styles
         {
             if (Chip != ChipStyle.None)
             {
-                return ChipStyleResources.Styles.TryGetValue(Chip, out var chipStyle) ? chipStyle : new Style(typeof(View));
+                return Styles.GetChipStyle(Chip);
             }
 
             if(Button != ButtonStyle.None)
             {
-                return ButtonStyleResources.Styles.TryGetValue(Button, out var buttonStyle)
-                    ? buttonStyle
-                    : new Style(typeof(View));
+                return Styles.GetButtonStyle(Button);
             }
 
             return new Style(typeof(View));


### PR DESCRIPTION
### Description of Change

- [Layout] Made sure all layouts ignore safe area when its not set by the consumer. Grid, StackLayout etc.
- [FloatingNavigationButton] Made sure people can tap the background of the FAB to close it.
- [FloatingNavigationButton] Made sure sizes of the icons are smaller for better UX.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->