### PR TITLE
Non clickthrough on iOS floating navigation button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [17.12.2] 
+- [FloatingNavigationButton] Fixed an bug where the entire page of the app was not clickable until you opened the Floating Navigation.
+
 ## [17.12.1] 
 - [Layout] Made sure all layouts ignore safe area when its not set by the consumer. Grid, StackLayout etc.
 - [FloatingNavigationButton] Made sure people can tap the background of the FAB to close it.

--- a/src/app/Components/Components.csproj
+++ b/src/app/Components/Components.csproj
@@ -41,12 +41,11 @@
         <!--DEBUG ON DEVICE-->
 
 
-        <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
+<!--        <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>-->
 
         <!--DEBUG ON SIMULATOR-->
-<!--
+
                 <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
--->
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
@@ -33,9 +33,13 @@ internal class FloatingNavigationButton : Grid
 
         AddMainButton();
         CreateAnimations();
+#if __IOS__
+        InputTransparent = true;
+        CascadeInputTransparent = false;
+#endif
     }
-    
-    
+
+
     private void MakeBackgroundClickable()
     {
         IsClickable = true;

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/FloatingNavigationButton.cs
@@ -33,7 +33,8 @@ internal class FloatingNavigationButton : Grid
 
         AddMainButton();
         CreateAnimations();
-#if __IOS__
+        
+#if __IOS__ //Somehow this is needed on iOS when the view draws to make it input transparent, the handler code was not enough.
         InputTransparent = true;
         CascadeInputTransparent = false;
 #endif


### PR DESCRIPTION
… you opened the Floating Navigation on iOS.


### Description of Change

Fixed an bug where the entire page of the app was not clickable until you opened the Floating Navigation on iOS.

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->