### PR TITLE
Made sure iOS Date/AndTimePicker use the correct default colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-## [17.17.2]
-- Changed event of drawing of slidablelayout.
-
 ## [17.17.1]
 - [ContentSavePage] Setting IsSaving back to 'false' will now switch the content back to the original content
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [17.17.2]
+- Changed event of drawing of slidablelayout.
+
 ## [17.17.1]
 - [ContentSavePage] Setting IsSaving back to 'false' will now switch the content back to the original content
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [17.17.2]
+- [DatePicker][DateAndTimePicker] Fixed default colors being broken on iOS.
+
 ## [17.17.1]
 - [ContentSavePage] Setting IsSaving back to 'false' will now switch the content back to the original content
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ the [wiki](https://github.com/DIPSAS/DIPS.Mobile.UI/wiki) section.
 Please make sure to read the [Getting started](https://github.com/DIPSAS/DIPS.Mobile.UI/wiki/Getting-Started) before
 using the library for your app.
 
+# Compatibility
+
+- The library supports developing on `.NET MAUI` for mobile.
+- This library is aimed at mobile development and it supports `iOS` and `Android` applications. 
+    - The library is compatible with the latest `iOS` and `Android` versions minus 2.
+
 ## Build status
 
 ![Nuget](https://img.shields.io/nuget/v/dips.mobile.ui?color=success&logoColor=white&logo=NuGet) ![GitHub last commit](https://img.shields.io/github/last-commit/Dipsas/DIPS.Mobile.UI)

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -12,13 +12,6 @@
     <dui:ContentPage.BindingContext>
         <håvardSamples:HåvardPageViewModel />
     </dui:ContentPage.BindingContext>
+    <dui:DateAndTimePicker VerticalOptions="Center" />
     
-    <dui:VerticalStackLayout>
-        <dui:Switch x:Name="Switch"
-                    IsToggled="False" />
-        <dui:Switch x:Name="Switch2"
-                    IsToggled="False" />
-        <dui:SaveView IsSaving="{Binding Source={x:Reference Switch2}, Path=IsToggled}"
-                      IsSavingCompleted="{Binding Source={x:Reference Switch}, Path=IsToggled}" />
-    </dui:VerticalStackLayout>
 </dui:ContentPage>

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml.cs
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml.cs
@@ -1,9 +1,5 @@
 using System.ComponentModel;
 using System.Windows.Input;
-using DIPS.Mobile.UI.API.Library;
-using DIPS.Mobile.UI.Components.Chips;
-using DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton;
-using SkiaSharp.Extended.UI.Controls;
 
 namespace Playground.HåvardSamples;
 
@@ -16,7 +12,6 @@ public partial class HåvardPage
 
     public ICommand SearchCommand => new Command<string>(async s =>
     {
-        
     });
 
     private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/iOS/BottomSheetContentPage.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/iOS/BottomSheetContentPage.cs
@@ -49,8 +49,14 @@ internal class BottomSheetContentPage : ContentPage
         Content = grid;
     }
 
+#pragma warning disable CA1416
     private void SetupViewController()
     {
+        if (!OperatingSystem.IsIOSVersionAtLeast(15))
+        {
+            return;
+        }
+        
         var mauiContext = DUI.GetCurrentMauiContext;
         
         if (mauiContext == null)
@@ -78,8 +84,8 @@ internal class BottomSheetContentPage : ContentPage
         
         m_navigationViewController.RestorationIdentifier = BottomSheetService.BottomSheetRestorationIdentifier;
         m_navigationViewController.ModalPresentationStyle = UIModalPresentationStyle.PageSheet;
-
-        if (!OperatingSystem.IsIOSVersionAtLeast(15) || m_viewController.SheetPresentationController == null) //Can use bottom sheet
+        
+        if (m_viewController.SheetPresentationController == null) //Can use bottom sheet
             return;
         
         if(m_bottomSheet.ShouldHaveNavigationBar)        
@@ -103,7 +109,7 @@ internal class BottomSheetContentPage : ContentPage
                     });
                 preferredDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Unknown;
             }
-            else if (OperatingSystem.IsIOSVersionAtLeast(15)) //Select large detent if the content is bigger than medium detent
+            else //Select large detent if the content is bigger than medium detent
             {
                 if (m_bottomSheet.Content.Height > m_bottomSheet.Height / 2) //if the content is larger than half the screen when the detent is medium, it means that something is outside of bounds
                 {
@@ -112,30 +118,28 @@ internal class BottomSheetContentPage : ContentPage
                 }
             }
         }
+        
+        m_sheetPresentationController.Detents = (m_bottomSheet.ShouldFitToContent)
 
-        if (OperatingSystem.IsIOSVersionAtLeast(15))
-        {
-            m_sheetPresentationController.Detents = (m_bottomSheet.ShouldFitToContent)
-                ? new[] {preferredDetent}
-                : new[] {preferredDetent, UISheetPresentationControllerDetent.CreateLargeDetent(),};
+            ? new[] {preferredDetent}
+            : new[] {preferredDetent, UISheetPresentationControllerDetent.CreateLargeDetent(),};
 
-            //Add grabber
-            m_sheetPresentationController.PrefersGrabberVisible = true;
+        //Add grabber
+        m_sheetPresentationController.PrefersGrabberVisible = true;
 
-            m_sheetPresentationController.SelectedDetentIdentifier = preferredDetentIdentifier;
+        m_sheetPresentationController.SelectedDetentIdentifier = preferredDetentIdentifier;
 
-            m_sheetPresentationController.PrefersScrollingExpandsWhenScrolledToEdge = true;
+        m_sheetPresentationController.PrefersScrollingExpandsWhenScrolledToEdge = true;
             
 
-            var bottom = (UIApplication.SharedApplication.KeyWindow?.SafeAreaInsets.Bottom) == 0
-                    ? Sizes.GetSize(SizeName.size_4) //There is a physical home button
-                    : Sizes.GetSize(SizeName.size_1) //There is no phyiscal home button, but we need some air between the safe area and the content
-                ;
-            // view.Bounds = view.Frame.Inset(Sizes.GetSize(SizeName.size_4), bottom);
-            this.Padding = new Thickness(0, m_bottomSheet.ShouldHaveNavigationBar ? 0 : Sizes.GetSize(SizeName.size_4), 0,
-                bottom); //Respect grabber and make sure we add some padding to the bottom, depending on if Safe Area (non physical home button) is visible.
-        }
+        var bottom = (UIApplication.SharedApplication.KeyWindow?.SafeAreaInsets.Bottom) == 0
+                ? Sizes.GetSize(SizeName.size_4) //There is a physical home button
+                : Sizes.GetSize(SizeName.size_1) //There is no phyiscal home button, but we need some air between the safe area and the content
+            ;
+        this.Padding = new Thickness(0, m_bottomSheet.ShouldHaveNavigationBar ? 0 : Sizes.GetSize(SizeName.size_4), 0,
+            bottom); //Respect grabber and make sure we add some padding to the bottom, depending on if Safe Area (non physical home button) is visible.
     }
+#pragma warning restore CA1416
 
     private void ConfigureToolbar()
     {

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/iOS/DUIDatePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/iOS/DUIDatePicker.cs
@@ -1,6 +1,8 @@
 using CoreAnimation;
 using CoreGraphics;
 using DIPS.Mobile.UI.Components.Chips;
+using DIPS.Mobile.UI.Resources.Styles;
+using DIPS.Mobile.UI.Resources.Styles.Chip;
 using Foundation;
 using Microsoft.Maui.Platform;
 using UIKit;
@@ -20,17 +22,15 @@ public class DUIDatePicker : UIDatePicker
     {
         if (PreferredDatePickerStyle == UIDatePickerStyle.Inline) return; //Changing these colors when the style is inline will change the entire in line date picker. Which messes up the colors.
         
+        //Tested on iOS 15,16,17
+        
+        //In line date picker
         var inlineDateViewLayer = this.Subviews.FirstOrDefault()?.Subviews.FirstOrDefault()?.Subviews
             .FirstOrDefault();
         SetDefaultLayerAttributes(inlineDateViewLayer);
         
-        var inLineTimeView = this.Subviews.FirstOrDefault()?.Subviews.LastOrDefault(); //Tested with physical device iOS 15 and 16, does not work with simulator iOS 14
-        
-        if (inLineTimeView is {BackgroundColor: null}) //TODO: iOS 14 (remove when iOS 17 is out). 
-            //This happens for at least iOS 14, we then grab the first subview to set the layer color
-        {
-            inLineTimeView = inLineTimeView.Subviews.FirstOrDefault();
-        }
+        //In line time picker
+        var inLineTimeView = this.Subviews.FirstOrDefault()?.Subviews.LastOrDefault();
         SetDefaultLayerAttributes(inLineTimeView);
         
     }
@@ -42,11 +42,8 @@ public class DUIDatePicker : UIDatePicker
             return;
         }
 
-        if (Chip.ColorProperty.DefaultValue is not Color defaultColor ||
-            Chip.CornerRadiusProperty.DefaultValue is not int defaultCornerRadius)
-        {
-            return;
-        }
+        var defaultColor = DIPS.Mobile.UI.Resources.Colors.Colors.GetColor(ColorName.color_secondary_30);
+        var defaultCornerRadius = DIPS.Mobile.UI.Resources.Sizes.Sizes.GetSize(SizeName.size_2);
 
         view.BackgroundColor = defaultColor.ToPlatform();
         view.Layer.CornerRadius = defaultCornerRadius;

--- a/src/library/DIPS.Mobile.UI/Components/Slidable/SlidableLayout.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Slidable/SlidableLayout.cs
@@ -36,6 +36,13 @@ namespace DIPS.Mobile.UI.Components.Slidable
             var tapGestureRecognizer = new TapGestureRecognizer();
             GestureRecognizers.Add(tapGestureRecognizer);
             tapGestureRecognizer.Tapped += OnEntireLayoutTapped;
+            Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object? sender, EventArgs e)
+        {
+            Loaded -= OnLoaded;
+            OnScrolledInternal(true);
         }
 
         private void OnEntireLayoutTapped(object? sender, Microsoft.Maui.Controls.TappedEventArgs eventArgs)
@@ -60,17 +67,6 @@ namespace DIPS.Mobile.UI.Components.Slidable
             }
 
             me.OnScrolledInternal();
-        }
-
-        /// <summary>
-        /// <inheritdoc/>
-        /// </summary>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
-        protected override void OnSizeAllocated(double width, double height)
-        {
-            base.OnSizeAllocated(width, height);
-            OnScrolledInternal(true);
         }
 
         private static int s_scrollToId = -42;

--- a/src/library/DIPS.Mobile.UI/Components/Slidable/SlidableLayout.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Slidable/SlidableLayout.cs
@@ -36,13 +36,6 @@ namespace DIPS.Mobile.UI.Components.Slidable
             var tapGestureRecognizer = new TapGestureRecognizer();
             GestureRecognizers.Add(tapGestureRecognizer);
             tapGestureRecognizer.Tapped += OnEntireLayoutTapped;
-            Loaded += OnLoaded;
-        }
-
-        private void OnLoaded(object? sender, EventArgs e)
-        {
-            Loaded -= OnLoaded;
-            OnScrolledInternal(true);
         }
 
         private void OnEntireLayoutTapped(object? sender, Microsoft.Maui.Controls.TappedEventArgs eventArgs)
@@ -67,6 +60,17 @@ namespace DIPS.Mobile.UI.Components.Slidable
             }
 
             me.OnScrolledInternal();
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="width"></param>
+        /// <param name="height"></param>
+        protected override void OnSizeAllocated(double width, double height)
+        {
+            base.OnSizeAllocated(width, height);
+            OnScrolledInternal(true);
         }
 
         private static int s_scrollToId = -42;

--- a/src/library/DIPS.Mobile.UI/DIPS.Mobile.UI.csproj
+++ b/src/library/DIPS.Mobile.UI/DIPS.Mobile.UI.csproj
@@ -151,7 +151,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-rc.1.9171" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-rc.2.9373" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/library/DIPS.Mobile.UI/DIPS.Mobile.UI.csproj
+++ b/src/library/DIPS.Mobile.UI/DIPS.Mobile.UI.csproj
@@ -7,7 +7,7 @@
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
 
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.1</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.7.9</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">31.0</SupportedOSPlatformVersion>
         <Nullable>enable</Nullable>
         <RepositoryType>github</RepositoryType>


### PR DESCRIPTION
### Description of Change

The bug has been introduced when we changed Chip from having default properties to using styles. iOS UIDatePicker was using the Chip ColorProperty default color, which made sense before styles, but not now as we are supporting styles.

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->