### PR TITLE
[ListItem] Fixes to Title and InLineContent width and added new properties to control truncation/wrapping of title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [17.18.0]
+- [ListItem] Title will wrap better for consumers.
+- [ListItem][TitleOptions] Added ability to control `LineBreakMode` and `MaxLines` to support truncation and wrapping properly.
+- [ListItem] Made sure width options are set even if the corresponding view for the options is not set.
+- [ComponentsApp] Made sure `none` is not added to animations page.
+
 ## [17.17.3]
 - [ImageButton] Made sure ImageButton padding is correctly set when IsVisible is flipped for Android
 

--- a/src/app/Components/Components.csproj
+++ b/src/app/Components/Components.csproj
@@ -41,11 +41,11 @@
         <!--DEBUG ON DEVICE-->
 
 
-        <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
+<!--        <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>-->
 
         <!--DEBUG ON SIMULATOR-->
 
-<!--                <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>-->
+                <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/app/Components/ResourcesSamples/Animations/AnimationsSamples.xaml.cs
+++ b/src/app/Components/ResourcesSamples/Animations/AnimationsSamples.xaml.cs
@@ -33,6 +33,7 @@ public partial class AnimationsSamples
         {
             if (Enum.TryParse<AnimationName>(animation.Key, out var theEnum))
             {
+                if (theEnum == AnimationName.none) continue;
                 m_allAnimations.Add(theEnum);
             }
         }

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -12,47 +12,6 @@
     <dui:ContentPage.BindingContext>
         <håvardSamples:HåvardPageViewModel />
     </dui:ContentPage.BindingContext>
-    <FlexLayout Wrap="Wrap"
-                AlignContent="Start"
-                AlignItems="Start">
-        <Switch x:Name="Switch"
-                IsToggled="True" />
-        <FlexLayout.Resources>
-            <Style x:Key="RoundedSmallButton"
-                   TargetType="{x:Type dui:ImageButton}">
-                <Setter Property="Padding"
-                        Value="{OnPlatform Android={dui:Sizes size_1}, iOS={dui:Sizes size_2}}" />
-                <Setter Property="BackgroundColor"
-                        Value="{dui:Colors color_primary_90}" />
-                <Setter Property="HeightRequest"
-                        Value="{dui:Sizes size_10}" />
-                <Setter Property="WidthRequest"
-                        Value="{dui:Sizes size_10}" />
-                <Setter Property="CornerRadius"
-                        Value="{dui:Sizes size_5}" />
-                <Setter Property="VerticalOptions"
-                        Value="Center" />
-                <Setter Property="HorizontalOptions"
-                        Value="Center" />
-                <Setter Property="TintColor"
-                        Value="{dui:Colors color_system_white}" />
-                <Setter Property="Margin"
-                        Value="{dui:Thickness Right=size_2}" />
-                <Setter Property="Command"
-                        Value="{Binding Source={RelativeSource AncestorType={x:Type håvardSamples:HåvardPage}}, Path=NavigateCommand}" />
-                <Setter Property="IsVisible"
-                        Value="{Binding Source={x:Reference Switch},Path=IsToggled}" />
-            </Style>
-        </FlexLayout.Resources>
-
-        <!-- Create document -->
-        <dui:ImageButton Style="{StaticResource RoundedSmallButton}"
-                         Source="{dui:Icons document_fill}" />
-        <dui:Button IsVisible="{Binding Source={x:Reference Switch}, Path=IsToggled}"
-                    Style="{dui:Styles Button=None}"
-                    Padding="20"
-                    Text="Test"
-                    HorizontalOptions="Center"
-                    VerticalOptions="Center" />
-    </FlexLayout>
+    <dui:NavigationListItem Title="Veeeeeeeery loooooong iteeeeeeesssssssm">
+    </dui:NavigationListItem>
 </dui:ContentPage>

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -12,6 +12,5 @@
     <dui:ContentPage.BindingContext>
         <håvardSamples:HåvardPageViewModel />
     </dui:ContentPage.BindingContext>
-    <dui:NavigationListItem Title="Veeeeeeeery loooooong iteeeeeeesssssssm">
-    </dui:NavigationListItem>
+    <dui:RadioButtonListItem Title="Teeeeeeeeeeeest dette her som er langt som bare det" />
 </dui:ContentPage>

--- a/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/ImageButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/ImageButton.cs
@@ -4,6 +4,7 @@ namespace DIPS.Mobile.UI.Components.Images.ImageButton;
 
 public partial class ImageButton : Microsoft.Maui.Controls.ImageButton
 {
+    //TODO: Fix when MAUI fixes: https://github.com/dotnet/maui/issues/18001
 #if __ANDROID__
     protected override void OnPropertyChanged(string propertyName = null)
     {

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Extensions/CheckmarkListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Extensions/CheckmarkListItem.cs
@@ -1,6 +1,8 @@
 using System.Windows.Input;
 using DIPS.Mobile.UI.API.Vibration;
 using DIPS.Mobile.UI.Components.ListItems.Options.Icon;
+using DIPS.Mobile.UI.Components.ListItems.Options.InLineContent;
+using DIPS.Mobile.UI.Components.ListItems.Options.Title;
 using DIPS.Mobile.UI.Components.Selection;
 using Colors = Microsoft.Maui.Graphics.Colors;
 using SelectionChangedEventArgs = DIPS.Mobile.UI.Components.Selection.SelectionChangedEventArgs;
@@ -24,6 +26,10 @@ public partial class CheckmarkListItem : ListItem, ISelectable
         });
         m_iconOptions = new IconOptions();
         IconOptions = m_iconOptions;
+        //Forces the title to take full width
+        TitleOptions = new TitleOptions() {Width = GridLength.Star}; 
+        InLineContentOptions = new InLineContentOptions() {Width = GridLength.Auto};
+        
 #if __ANDROID__
         m_iconOptions.Color = ISelectable.s_tintColor;
 #elif __IOS__

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Extensions/CheckmarkListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Extensions/CheckmarkListItem.cs
@@ -26,6 +26,7 @@ public partial class CheckmarkListItem : ListItem, ISelectable
         });
         m_iconOptions = new IconOptions();
         IconOptions = m_iconOptions;
+        
         //Forces the title to take full width
         TitleOptions = new TitleOptions() {Width = GridLength.Star}; 
         InLineContentOptions = new InLineContentOptions() {Width = GridLength.Auto};

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Extensions/NavigationListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Extensions/NavigationListItem.cs
@@ -1,3 +1,6 @@
+using DIPS.Mobile.UI.Components.ListItems.Options.InLineContent;
+using DIPS.Mobile.UI.Components.ListItems.Options.Title;
+
 namespace DIPS.Mobile.UI.Components.ListItems.Extensions;
 
 [ContentProperty(nameof(InLineContent))]
@@ -5,32 +8,33 @@ public partial class NavigationListItem : ListItem
 {
     private readonly Grid m_contentGrid = new()
     {
-        ColumnDefinitions = new ColumnDefinitionCollection
-        {
-            new (GridLength.Star),
-            new(GridLength.Auto)
-        },
-        RowDefinitions = new RowDefinitionCollection
-        {
-            new (GridLength.Auto)
-        },
+        ColumnDefinitions = new ColumnDefinitionCollection {new(GridLength.Star), new(GridLength.Auto)},
+        RowDefinitions = new RowDefinitionCollection {new(GridLength.Auto)},
         VerticalOptions = LayoutOptions.Center
     };
-    
+
     public NavigationListItem()
     {
-        m_contentGrid.Add(new Image
+        m_contentGrid.Add(
+            new Image
+            {
+                Source = Icons.GetIcon(IconName.arrow_right_s_line),
+                VerticalOptions = LayoutOptions.Center,
+                HorizontalOptions = LayoutOptions.End
+            }, 1);
+
+        TitleOptions = new TitleOptions()
         {
-            Source = Icons.GetIcon(IconName.arrow_right_s_line), 
-            VerticalOptions = LayoutOptions.Center, HorizontalOptions = LayoutOptions.End
-        }, 1);
+            Width = GridLength.Star, LineBreakMode = LineBreakMode.TailTruncation, MaxLines = 1
+        };
+        InLineContentOptions = new InLineContentOptions() {Width = GridLength.Auto};
     }
 
     protected override void OnHandlerChanged()
     {
         base.OnHandlerChanged();
-        
-        if(InLineContent is null)
+
+        if (InLineContent is null)
         {
             AddInLineContent();
         }
@@ -39,7 +43,7 @@ public partial class NavigationListItem : ListItem
     protected override void AddInLineContent()
     {
         var newInLineContent = InLineContent;
-            
+
         m_contentGrid.Insert(0, newInLineContent);
 
         SetInLineContent(m_contentGrid);

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Extensions/RadioButtonListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Extensions/RadioButtonListItem.cs
@@ -1,5 +1,7 @@
 using DIPS.Mobile.UI.API.Vibration;
 using DIPS.Mobile.UI.Components.ListItems.Options.Icon;
+using DIPS.Mobile.UI.Components.ListItems.Options.InLineContent;
+using DIPS.Mobile.UI.Components.ListItems.Options.Title;
 using DIPS.Mobile.UI.Components.Selection;
 using SelectionChangedEventArgs = DIPS.Mobile.UI.Components.Selection.SelectionChangedEventArgs;
 
@@ -13,6 +15,9 @@ public partial class RadioButtonListItem : ListItem, ISelectable
     {
         m_iconOptions = new IconOptions();
         IconOptions = m_iconOptions;
+        //Forces the title to take full width
+        TitleOptions = new TitleOptions() {Width = GridLength.Star}; 
+        InLineContentOptions = new InLineContentOptions() {Width = GridLength.Auto};
         
         Command = new Command(() =>
         {

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
@@ -49,7 +49,7 @@ public partial class ListItem : ContentView
         VerticalOptions = LayoutOptions.Center
     };
     
-    public Border Border { get; } = new();
+    internal Border Border { get; } = new();
     internal Image? ImageIcon { get; private set; }
     internal Label? TitleLabel { get; private set; }
     internal Label? SubtitleLabel { get; private set; }

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/InLineContent/InLineContentOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/InLineContent/InLineContentOptions.cs
@@ -6,12 +6,15 @@ public partial class InLineContentOptions : ListItemOptions
 {
     public override void DoBind(ListItem listItem)
     { 
-        if(listItem.InLineContent is not View inLineContent)
+        listItem.MainContent.ColumnDefinitions[2].Width = Width;
+
+        if (listItem.InLineContent is not View inLineContent)
+        {
             return;
+        }
 
         inLineContent.SetBinding(View.HorizontalOptionsProperty, new Binding(nameof(HorizontalOptions), source: this));
         inLineContent.SetBinding(View.VerticalOptionsProperty, new Binding(nameof(VerticalOptions), source: this));
-        listItem.MainContent.ColumnDefinitions[2].Width = Width;
     }
 
 }

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.Properties.cs
@@ -56,6 +56,28 @@ public partial class TitleOptions
         get => (Thickness)GetValue(MarginProperty);
         set => SetValue(MarginProperty, value);
     }
+
+    public static readonly BindableProperty MaxLinesProperty = BindableProperty.Create(
+        nameof(MaxLines),
+        typeof(int),
+        typeof(TitleOptions), defaultValue: Label.MaxLinesProperty.DefaultValue);
+
+    public int MaxLines
+    {
+        get => (int)GetValue(MaxLinesProperty);
+        set => SetValue(MaxLinesProperty, value);
+    }
+
+    public static readonly BindableProperty LineBreakModeProperty = BindableProperty.Create(
+        nameof(LineBreakMode),
+        typeof(LineBreakMode),
+        typeof(TitleOptions), defaultValue: Label.LineBreakModeProperty.DefaultValue);
+
+    public LineBreakMode LineBreakMode
+    {
+        get => (LineBreakMode)GetValue(LineBreakModeProperty);
+        set => SetValue(LineBreakModeProperty, value);
+    }
     
     public static readonly BindableProperty MarginProperty = BindableProperty.Create(
         nameof(Margin),

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
@@ -4,16 +4,19 @@ public partial class TitleOptions : ListItemOptions
 {
     public override void DoBind(ListItem listItem)
     {
+        listItem.MainContent.ColumnDefinitions[1].Width = Width;
+        
         if(listItem.TitleLabel is null)
             return;
 
-        listItem.TitleLabel.SetBinding(Labels.Label.FontAttributesProperty, new Binding(nameof(FontAttributes), source: this));
-        listItem.TitleLabel.SetBinding(Labels.Label.FontSizeProperty, new Binding(nameof(FontSize), source: this));
-        listItem.TitleLabel.SetBinding(Labels.Label.TextColorProperty, new Binding(nameof(TextColor), source: this));
-        listItem.TitleLabel.SetBinding(Labels.Label.HorizontalTextAlignmentProperty, new Binding(nameof(HorizontalTextAlignment), source: this));
-        listItem.TitleLabel.SetBinding(Labels.Label.VerticalTextAlignmentProperty, new Binding(nameof(VerticalTextAlignment), source: this));
+        listItem.TitleLabel.SetBinding(Label.FontAttributesProperty, new Binding(nameof(FontAttributes), source: this));
+        listItem.TitleLabel.SetBinding(Label.FontSizeProperty, new Binding(nameof(FontSize), source: this));
+        listItem.TitleLabel.SetBinding(Label.TextColorProperty, new Binding(nameof(TextColor), source: this));
+        listItem.TitleLabel.SetBinding(Label.HorizontalTextAlignmentProperty, new Binding(nameof(HorizontalTextAlignment), source: this));
+        listItem.TitleLabel.SetBinding(Label.VerticalTextAlignmentProperty, new Binding(nameof(VerticalTextAlignment), source: this));
+        listItem.TitleLabel.SetBinding(Label.MaxLinesProperty, new Binding(nameof(MaxLines), source: this));
+        listItem.TitleLabel.SetBinding(Label.LineBreakModeProperty, new Binding(nameof(LineBreakMode), source: this));
         listItem.TitleLabel.SetBinding(View.MarginProperty, new Binding(nameof(Margin), source: this));
-        listItem.MainContent.ColumnDefinitions[1].Width = Width;
         
     }
 

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
@@ -14,10 +14,13 @@ public partial class TitleOptions : ListItemOptions
         listItem.TitleLabel.SetBinding(Label.TextColorProperty, new Binding(nameof(TextColor), source: this));
         listItem.TitleLabel.SetBinding(Label.HorizontalTextAlignmentProperty, new Binding(nameof(HorizontalTextAlignment), source: this));
         listItem.TitleLabel.SetBinding(Label.VerticalTextAlignmentProperty, new Binding(nameof(VerticalTextAlignment), source: this));
-        listItem.TitleLabel.SetBinding(Label.MaxLinesProperty, new Binding(nameof(MaxLines), source: this));
         listItem.TitleLabel.SetBinding(Label.LineBreakModeProperty, new Binding(nameof(LineBreakMode), source: this));
         listItem.TitleLabel.SetBinding(View.MarginProperty, new Binding(nameof(Margin), source: this));
         
+        if (MaxLines > -1) //We can not trigger property changed for this if its -1 because it causes bugs on Android.
+        {
+            listItem.TitleLabel.MaxLines = MaxLines;
+        }
     }
 
 }


### PR DESCRIPTION
### Description of Change

- [ListItem] Title will wrap better for consumers.
- [ListItem][TitleOptions] Added ability to control `LineBreakMode` and `MaxLines` to support truncation and wrapping properly.
- [ListItem] Made sure width options are set even if the corresponding view for the options is not set.
- [ComponentsApp] Made sure `none` is not added to animations page.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->