### PR TITLE
Made sure ListItem in line content never moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [17.19.3]
+- [ListItem] Margin and Paddings are now set on the underlying Border to prevent glitching placements of the containers contet.
+
 ## [17.19.2]
 - [iOS] Fixed an issue where Context menu would crash when in a CollectionView
 - Added 'IsVisible' property to ContextMenuItem

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -14,5 +14,5 @@
     </dui:ContentPage.BindingContext>
     <dui:ListItem BackgroundColor="Red"
                   CornerRadius="8"
-                  Margin="10,0"/>
+                  Margin="5,0"/>
 </dui:ContentPage>

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -12,5 +12,7 @@
     <dui:ContentPage.BindingContext>
         <håvardSamples:HåvardPageViewModel />
     </dui:ContentPage.BindingContext>
-    <dui:RadioButtonListItem Title="Teeeeeeeeeeeest dette her som er langt som bare det" />
+    <dui:ListItem BackgroundColor="Red"
+                  CornerRadius="8"
+                  Margin="10,0"/>
 </dui:ContentPage>

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
@@ -3,6 +3,7 @@ using System.Windows.Input;
 using DIPS.Mobile.UI.Components.ListItems.Options;
 using DIPS.Mobile.UI.Components.ListItems.Options.Dividers;
 using DIPS.Mobile.UI.Converters.ValueConverters;
+using Colors = Microsoft.Maui.Graphics.Colors;
 
 namespace DIPS.Mobile.UI.Components.ListItems
 {
@@ -148,6 +149,37 @@ namespace DIPS.Mobile.UI.Components.ListItems
             set => SetValue(HasBottomDividerProperty, value);
         }
     
+        /// <summary>
+        /// The background color of the <see cref="ListItem"/>
+        /// </summary>
+        public new Color BackgroundColor
+        {
+            get => (Color)GetValue(BackgroundColorProperty);
+            set => SetValue(BackgroundColorProperty, value);
+        }
+        
+        public new double Margin
+        {
+            get => (double)GetValue(MarginProperty);
+            set => SetValue(MarginProperty, value);
+        }
+        
+        public new double Padding
+        {
+            get => (double)GetValue(PaddingProperty);
+            set => SetValue(PaddingProperty, value);
+        }
+
+        public static readonly BindableProperty MarginProperty = BindableProperty.Create(
+            nameof(Margin),
+            typeof(double),
+            typeof(ListItem));
+
+        public static readonly BindableProperty PaddingProperty = BindableProperty.Create(
+            nameof(Padding),
+            typeof(double),
+            typeof(ListItem));
+        
         public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(
             nameof(CornerRadius),
             typeof(CornerRadius),
@@ -180,7 +212,7 @@ namespace DIPS.Mobile.UI.Components.ListItems
         public static new readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(
             nameof(BackgroundColor),
             typeof(Color),
-            typeof(ListItem));
+            typeof(ListItem), defaultValue: DIPS.Mobile.UI.Resources.Colors.Colors.GetColor(ColorName.color_system_white));
     
         public static readonly BindableProperty UnderlyingContentProperty = BindableProperty.Create(
             nameof(UnderlyingContent),
@@ -211,12 +243,6 @@ namespace DIPS.Mobile.UI.Components.ListItems
             typeof(IView),
             typeof(ListItem),
             propertyChanged: (bindable, _, _) => ((ListItem)bindable).AddInLineContent());
-        
-        public new Color BackgroundColor
-        {
-            get => (Color)GetValue(BackgroundColorProperty);
-            set => SetValue(BackgroundColorProperty, value);
-        }
 
         #region OptionBindableProperties
 

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
@@ -158,26 +158,26 @@ namespace DIPS.Mobile.UI.Components.ListItems
             set => SetValue(BackgroundColorProperty, value);
         }
         
-        public new double Margin
+        public new Thickness Margin
         {
-            get => (double)GetValue(MarginProperty);
+            get => (Thickness)GetValue(MarginProperty);
             set => SetValue(MarginProperty, value);
         }
         
-        public new double Padding
+        public new Thickness Padding
         {
-            get => (double)GetValue(PaddingProperty);
+            get => (Thickness)GetValue(PaddingProperty);
             set => SetValue(PaddingProperty, value);
         }
 
-        public static readonly BindableProperty MarginProperty = BindableProperty.Create(
+        public new static readonly BindableProperty MarginProperty = BindableProperty.Create(
             nameof(Margin),
-            typeof(double),
+            typeof(Thickness),
             typeof(ListItem));
 
-        public static readonly BindableProperty PaddingProperty = BindableProperty.Create(
+        public new static readonly BindableProperty PaddingProperty = BindableProperty.Create(
             nameof(Padding),
-            typeof(double),
+            typeof(Thickness),
             typeof(ListItem));
         
         public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
@@ -29,7 +29,7 @@ public partial class ListItem : ContentView
         {
             new(GridLength.Auto),
         },
-        Padding = new Thickness(Sizes.GetSize(SizeName.size_4), 
+        Margin = new Thickness(Sizes.GetSize(SizeName.size_4), 
             Sizes.GetSize(SizeName.size_3),
             Sizes.GetSize(SizeName.size_4),
             Sizes.GetSize(SizeName.size_3))

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
@@ -11,13 +11,13 @@ namespace DIPS.Mobile.UI.Components.ListItems;
 [ContentProperty(nameof(InLineContent))]
 public partial class ListItem : ContentView
 {
-    private VerticalStackLayout RootContent { get; } = new()
+    private VerticalStackLayout RootVerticalStackLayout { get; } = new()
     {
         BackgroundColor = Microsoft.Maui.Graphics.Colors.Transparent, 
         Spacing = 0
     };
     
-    internal Grid MainContent { get; } = new()
+    internal Grid ContainerGrid { get; } = new()
     {
         ColumnDefinitions = new ColumnDefinitionCollection
         {
@@ -62,21 +62,29 @@ public partial class ListItem : ContentView
 
     public ListItem()
     {
+        ((ContentView)this).BackgroundColor = Microsoft.Maui.Graphics.Colors.Transparent;
+        
         Border.StrokeShape = new RoundRectangle 
         { 
             CornerRadius = CornerRadius, 
             StrokeThickness = 0 
         };
         
-        BackgroundColor = Colors.GetColor(ColorName.color_system_white);
-        Border.SetBinding(Border.BackgroundColorProperty, new Binding { Source = this, Path = nameof(BackgroundColor)} );
-        
-        Border.Content = MainContent;
+        BindBorder();
 
-        MainContent.Add(m_titleAndLabelGrid, 1);
-        RootContent.Add(Border);
+        Border.Content = ContainerGrid;
+
+        ContainerGrid.Add(m_titleAndLabelGrid, 1);
+        RootVerticalStackLayout.Add(Border);
         
-        this.Content = RootContent;
+        this.Content = RootVerticalStackLayout;
+    }
+
+    private void BindBorder()
+    {
+        Border.SetBinding(Border.BackgroundColorProperty, new Binding {Source = this, Path = nameof(BackgroundColor)});
+        Border.SetBinding(Border.MarginProperty, new Binding {Source = this, Path = nameof(Margin)});
+        Border.SetBinding(Border.PaddingProperty, new Binding {Source = this, Path = nameof(Padding)});
     }
 
     protected override void OnPropertyChanged(string propertyName = null)
@@ -155,9 +163,9 @@ public partial class ListItem : ContentView
     
     private void AddIcon()
     {
-        if (MainContent.Contains(ImageIcon))
+        if (ContainerGrid.Contains(ImageIcon))
         {
-            MainContent.Remove(ImageIcon);
+            ContainerGrid.Remove(ImageIcon);
         }
         
         ImageIcon = new Image
@@ -167,7 +175,7 @@ public partial class ListItem : ContentView
         
         BindToOptions(IconOptions);
         
-        MainContent.Add(ImageIcon, 0);
+        ContainerGrid.Add(ImageIcon, 0);
     }
 
     protected virtual void AddInLineContent()
@@ -177,31 +185,31 @@ public partial class ListItem : ContentView
 
     protected void SetInLineContent(IView view)
     {
-        if(MainContent.Contains(m_oldInLineContent))
+        if(ContainerGrid.Contains(m_oldInLineContent))
         {
-            MainContent.Remove(m_oldInLineContent);
+            ContainerGrid.Remove(m_oldInLineContent);
         }
         
         BindToOptions(InLineContentOptions);
 
-        MainContent.Add(view, MainContent.ColumnDefinitions.Count - 1);
+        ContainerGrid.Add(view, ContainerGrid.ColumnDefinitions.Count - 1);
 
         m_oldInLineContent = view;
     }
 
     private void AddUnderlyingContent()
     {
-        if (MainContent.Contains(m_oldUnderlyingContent))
+        if (ContainerGrid.Contains(m_oldUnderlyingContent))
         {
-            MainContent.Remove(m_oldUnderlyingContent);
+            ContainerGrid.Remove(m_oldUnderlyingContent);
         }
         else
         {
-            MainContent.AddRowDefinition(new RowDefinition(GridLength.Auto));
+            ContainerGrid.AddRowDefinition(new RowDefinition(GridLength.Auto));
         }
         
-        MainContent.Add(UnderlyingContent, 0, 1);
-        MainContent.SetColumnSpan(UnderlyingContent, MainContent.ColumnDefinitions.Count);
+        ContainerGrid.Add(UnderlyingContent, 0, 1);
+        ContainerGrid.SetColumnSpan(UnderlyingContent, ContainerGrid.ColumnDefinitions.Count);
         
         m_oldUnderlyingContent = UnderlyingContent;
     }
@@ -216,19 +224,19 @@ public partial class ListItem : ContentView
         var divider = new Divider();
         if (top)
         {
-            if (RootContent.Contains(TopDivider))
-                RootContent.Remove(TopDivider);
+            if (RootVerticalStackLayout.Contains(TopDivider))
+                RootVerticalStackLayout.Remove(TopDivider);
             
             TopDivider = divider;
-            RootContent.Insert(0, divider);
+            RootVerticalStackLayout.Insert(0, divider);
         }
         else
         {
-            if (RootContent.Contains(BottomDivider))
-                RootContent.Remove(BottomDivider);
+            if (RootVerticalStackLayout.Contains(BottomDivider))
+                RootVerticalStackLayout.Remove(BottomDivider);
             
             BottomDivider = divider;
-            RootContent.Add(divider);
+            RootVerticalStackLayout.Add(divider);
         }
         
         BindToOptions(DividersOptions);

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/InLineContent/InLineContentOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/InLineContent/InLineContentOptions.cs
@@ -6,7 +6,7 @@ public partial class InLineContentOptions : ListItemOptions
 {
     public override void DoBind(ListItem listItem)
     { 
-        listItem.MainContent.ColumnDefinitions[2].Width = Width;
+        listItem.ContainerGrid.ColumnDefinitions[2].Width = Width;
 
         if (listItem.InLineContent is not View inLineContent)
         {

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
@@ -4,7 +4,7 @@ public partial class TitleOptions : ListItemOptions
 {
     public override void DoBind(ListItem listItem)
     {
-        listItem.MainContent.ColumnDefinitions[1].Width = Width;
+        listItem.ContainerGrid.ColumnDefinitions[1].Width = Width;
         
         if(listItem.TitleLabel is null)
             return;


### PR DESCRIPTION
### Description of Change

- [ListItem] Margin and Paddings are now set on the underlying Border to prevent glitching placements of the containers contet.
- [ListItem] The built in Padding was changed to Margin to prevent the in line content from moving when the title is about to wrap.
- 
Made sure ListItem in line content never moves

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->