### PR TITLE
Fix BottomSheet.ShouldFitToContent not working when Title is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [17.32.3]
+## [17.23.3]
 - [iOS] Fixed ShouldFitToContent on BottomSheet ignoring height of navigation bar
 
 ## [17.23.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [17.32.3]
+- [iOS] Fixed ShouldFitToContent on BottomSheet ignoring height of navigation bar
+
 ## [17.23.2]
 - [iOS] Possible fix for crash when using long press context menu
 

--- a/src/app/Components/ComponentsSamples/BottomSheets/Sheets/BottomSheetWithToolbar.xaml
+++ b/src/app/Components/ComponentsSamples/BottomSheets/Sheets/BottomSheetWithToolbar.xaml
@@ -6,6 +6,7 @@
              xmlns:sheets="clr-namespace:Components.ComponentsSamples.BottomSheets.Sheets"
              x:Class="Components.ComponentsSamples.BottomSheets.Sheets.BottomSheetWithToolbar"
              x:Name="BottomSheet"
+             ShouldFitToContent="True"
              Title="The title">
     <dui:BottomSheet.BindingContext>
         <sheets:BottomSheetWithToolbarViewModel/>

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/iOS/BottomSheetContentPage.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/iOS/BottomSheetContentPage.cs
@@ -105,7 +105,14 @@ internal class BottomSheetContentPage : ContentPage
                     resolver  =>
                     {
                         var r = m_bottomSheet.Content.Measure(UIScreen.MainScreen.Bounds.Width, resolver.MaximumDetentValue);
-                        return (float)(r.Request.Height+m_bottomSheet.Padding.Bottom+m_bottomSheet.Padding.Top);
+                        double navBarHeight = 0;
+                        if (m_bottomSheet.ShouldHaveNavigationBar)
+                        {
+                            var navigationController = m_viewController!.NavigationController;
+                            navBarHeight = navigationController!.NavigationBar.Frame.Height;
+                        }
+                        
+                        return (float)(r.Request.Height+m_bottomSheet.Padding.Bottom+m_bottomSheet.Padding.Top+navBarHeight);
                     });
                 preferredDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Unknown;
             }


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->