### PR TITLE
Fix not being able to set LoadableListItem.ContextMenu on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [19.5.1]
+- Fix not being able to set `LoadableListItem.ContextMenu`
+
 ## [19.5.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
@@ -56,7 +56,7 @@ public partial class TouchPlatformEffect
     {
         if (m_touchMode is Touch.TouchMode.Tap or Touch.TouchMode.Both)
         {
-            if (Control.GestureRecognizers != null)
+            if (Control.GestureRecognizers != null && m_tapGestureRecognizer is not null)
             {
                 Control.RemoveGestureRecognizer(m_tapGestureRecognizer!);
             }
@@ -64,7 +64,7 @@ public partial class TouchPlatformEffect
 
         if (m_touchMode is Touch.TouchMode.LongPress or Touch.TouchMode.Both)
         {
-            if(Control.GestureRecognizers != null)
+            if(Control.GestureRecognizers != null && m_longPressGestureRecognizer is not null)
                 Control.RemoveGestureRecognizer(m_longPressGestureRecognizer!);
         }
     }


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [ ] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->