### PR TITLE
[Android] Fixed a regression bug where the cursor would not be set at the end of the text when focusing Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [20.8.2]
+- [Android] Fixed a regression bug where the cursor would not be set at the end of the text when focusing Editor
+
 ## [20.8.1]
 - Fixed an issue where buttons in BottombarButtons (BottomSheet) did not take up full width
 - [Android] Fixed an issue where the Bottombar had too low height

--- a/src/library/DIPS.Mobile.UI/Components/TextFields/Editor/Android/EditorHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/TextFields/Editor/Android/EditorHandler.cs
@@ -23,6 +23,8 @@ public partial class EditorHandler
         {
             bottomSheetFragment.AttachInputView((VirtualView as InputView)!);
         }
+
+        platformView.FocusChange += OnFocusChanged;
     }
 
     private void OnFocusChanged(object? sender, View.FocusChangeEventArgs e)

--- a/src/library/DIPS.Mobile.UI/Components/TextFields/Entry/Android/EntryHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/TextFields/Entry/Android/EntryHandler.cs
@@ -23,6 +23,8 @@ public partial class EntryHandler
         {
             bottomSheetDialogFragment.AttachInputView((VirtualView as InputView)!);
         }
+        
+        platformView.FocusChange += OnFocusChanged;
     }
 
     private void OnFocusChanged(object? sender, View.FocusChangeEventArgs e)


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [X] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->