### PR TITLE
SaveView will now only vibrate on success when user actually taps the SaveView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [20.8.3]
+- SaveView will now only vibrate on success when user actually taps the
+SaveView (Added new property 'Command' to SaveView)
+
 ## [20.8.2]
 - [Android] Fixed a regression bug where the cursor would not be set at the end of the text when focusing Editor
 

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -40,11 +40,6 @@
 
 
     </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-      <MtouchDebug>true</MtouchDebug>
-      <DeviceSpecificBuild>true</DeviceSpecificBuild>
-    </PropertyGroup>
-
 
     <ItemGroup>
         <!-- App Icon -->

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-android;</TargetFrameworks>
+        <TargetFrameworks>net8.0-ios;</TargetFrameworks>
 
         <OutputType>Exe</OutputType>
         <RootNamespace>Playground</RootNamespace>

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -40,6 +40,10 @@
 
 
     </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+      <MtouchDebug>true</MtouchDebug>
+      <DeviceSpecificBuild>true</DeviceSpecificBuild>
+    </PropertyGroup>
 
 
     <ItemGroup>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -14,7 +14,7 @@
     </dui:ContentPage.BindingContext>
 
     <dui:ContentPage.ToolbarItems>
-        <ToolbarItem IconImageSource="{dui:Icons bell_fill}" Command="{Binding CompletedCommand}" />
+        <ToolbarItem IconImageSource="{dui:Icons bell_fill}" Command="{Binding Navigate}" />
         <ToolbarItem Text="Test" Command="{dui:OpenBottomSheetCommand {x:Type vetleSamples:BottomSheetWithToolbar}}" />
     </dui:ContentPage.ToolbarItems>
     

--- a/src/app/Playground/VetleSamples/VetleTestPage1.xaml
+++ b/src/app/Playground/VetleSamples/VetleTestPage1.xaml
@@ -20,48 +20,10 @@
     </dui:ContentPage.ToolbarItems>
     
     <Grid RowDefinitions="Auto, *">
-        <ContentView>
-        <Grid RowDefinitions="Auto, *, Auto"
-              RowSpacing="0">
-        
-            <dui:Divider Grid.Row="0" />
-        
-            <Grid Grid.Row="1"
-                  Padding="{dui:Thickness Left=size_4, Right=size_4, Top=size_3, Bottom=size_3}"
-                  ColumnDefinitions="*, Auto">
-                <dui:Label Grid.Column="0"
-                           Text="GHehe"
-                           Style="{dui:Styles Label=UI300}"
-                           LineBreakMode="TailTruncation"
-                           VerticalTextAlignment="Center" />
-
-                <dui:Label Text="hehe"
-                           HorizontalOptions="End"
-                           VerticalTextAlignment="Center"
-                           HorizontalTextAlignment="End"
-                           TextColor="{dui:Colors color_neutral_80}"
-                           Grid.Column="1"
-                           Style="{dui:Styles Label=Body200}" />
-            </Grid>
-        
-            <dui:Divider Grid.Row="2" />
-        </Grid>   
-        </ContentView>
-        
-        <dui:ScrollView Grid.Row="1">
-            <dui:VerticalStackLayout x:Name="Indeterminate">
-    
-                <dui:Editor HasBorder="False" ShouldSelectAllTextOnFocused="True" />
-    
-                <BoxView HeightRequest="50"
-                         WidthRequest="50"
-                         BackgroundColor="Red"></BoxView>
-    
-                <dui:Editor HasBorder="False" Placeholder="Skriv inn tekst..."
-                            ShouldSelectAllTextOnFocused="True" />
-
-            </dui:VerticalStackLayout>
-        </dui:ScrollView>
+       
+        <dui:SaveView Command="{Binding SaveCommand}"
+                      IsSaving="{Binding IsSaving}"
+                      IsSavingCompleted="{Binding IsSavingCompleted}"/>
         
     </Grid>
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetleTestPage1ViewModel.cs
+++ b/src/app/Playground/VetleSamples/VetleTestPage1ViewModel.cs
@@ -1,17 +1,43 @@
 using System.Windows.Input;
 using DIPS.Mobile.UI.Components.Alerting.Dialog;
+using DIPS.Mobile.UI.MVVM;
 
 namespace Playground.VetleSamples;
 
-public class VetleTestPage1ViewModel
+public class VetleTestPage1ViewModel : ViewModel
 {
+    private bool m_isSavingCompleted;
+    private bool m_isSaving;
+
     public VetleTestPage1ViewModel()
     {
         Navigate = new Command(() => Shell.Current.Navigation.PushModalAsync(new VetleTestPage2()));
         Test = new Command(() => Shell.Current.Navigation.PopModalAsync());
+
+        SaveCommand = new Command(async () =>
+        {
+            IsSaving = true;
+            await Task.Delay(2000);
+            IsSavingCompleted = true;
+            IsSaving = false;
+        });
     }
     
     public ICommand Navigate { get; }
     
     public ICommand Test { get; }
+
+    public bool IsSavingCompleted
+    {
+        get => m_isSavingCompleted;
+        set => RaiseWhenSet(ref m_isSavingCompleted, value);
+    }
+
+    public bool IsSaving
+    {
+        get => m_isSaving;
+        set => RaiseWhenSet(ref m_isSaving, value);
+    }
+
+    public ICommand SaveCommand { get; }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Saving/SaveView/SaveView.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Saving/SaveView/SaveView.Properties.cs
@@ -48,6 +48,24 @@ public partial class SaveView
         get => (ICommand)GetValue(SavingCompletedCommandProperty);
         set => SetValue(SavingCompletedCommandProperty, value);
     }
+
+    /// <summary>
+    /// The Command to be executed when <see cref="SaveView"/> is tapped
+    /// </summary>
+    public ICommand? Command
+    {
+        get => (ICommand?)GetValue(CommandProperty);
+        set => SetValue(CommandProperty, value);
+    }
+
+    /// <summary>
+    /// The CommandParameter to be sent with <see cref="Command"/>
+    /// </summary>
+    public object? CommandParameter
+    {
+        get => (object?)GetValue(CommandParameterProperty);
+        set => SetValue(CommandParameterProperty, value);
+    }
     
     public static readonly BindableProperty IsSavingProperty = BindableProperty.Create(
         nameof(IsSaving),
@@ -76,4 +94,15 @@ public partial class SaveView
         nameof(SavingCompletedCommand),
         typeof(ICommand), 
         typeof(SaveView));
+    
+    public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(
+        nameof(CommandParameter),
+        typeof(object),
+        typeof(SaveView));
+    
+    public static readonly BindableProperty CommandProperty = BindableProperty.Create(
+        nameof(Command),
+        typeof(ICommand),
+        typeof(SaveView),
+        propertyChanged: (bindable, _, _) => ((SaveView)bindable).OnCommandChanged());
 }

--- a/src/library/DIPS.Mobile.UI/Components/Saving/SaveView/SaveView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Saving/SaveView/SaveView.cs
@@ -12,15 +12,16 @@ namespace DIPS.Mobile.UI.Components.Saving.SaveView;
 public partial class SaveView : ContentView
 {
     private readonly Label m_stateLabel;
+    private readonly FilledCheckBox m_filledCheckBox;
 
     public SaveView()
     {
-        var filledCheckBox = new FilledCheckBox {VerticalOptions = LayoutOptions.Center,};
+        m_filledCheckBox = new FilledCheckBox {VerticalOptions = LayoutOptions.Center,};
 
-        filledCheckBox.SetBinding(FilledCheckBox.IsCheckedProperty,
+        m_filledCheckBox.SetBinding(FilledCheckBox.IsCheckedProperty,
             new Binding(nameof(IsSavingCompleted), source: this));
-        filledCheckBox.SetBinding(FilledCheckBox.IsProgressingProperty, new Binding(nameof(IsSaving), source: this));
-        filledCheckBox.SetBinding(FilledCheckBox.CompletedCommandProperty,
+        m_filledCheckBox.SetBinding(FilledCheckBox.IsProgressingProperty, new Binding(nameof(IsSaving), source: this));
+        m_filledCheckBox.SetBinding(FilledCheckBox.CompletedCommandProperty,
             new Binding(nameof(SavingCompletedCommand), source: this));
 
         m_stateLabel = new Label
@@ -37,19 +38,19 @@ public partial class SaveView : ContentView
             HorizontalOptions = LayoutOptions.Center,
             VerticalOptions = LayoutOptions.Center,
             Spacing = Sizes.GetSize(SizeName.size_12),
-            Children = {filledCheckBox, m_stateLabel}
+            Children = {m_filledCheckBox, m_stateLabel}
         };
 
         Content = content;
         
-        Touch.SetCommand(this, new Command(() =>
+        Touch.SetCommand(m_filledCheckBox, new Command(() =>
         {
             Command?.Execute(CommandParameter);
             DidTapToSave = true;
         }));
         
         // The SaveView should default to not being tappable, only when Command is set should the view be tappable
-        Touch.SetIsEnabled(this, false);
+        Touch.SetIsEnabled(m_filledCheckBox, false);
     }
     
     private bool DidTapToSave { get; set; }
@@ -84,6 +85,6 @@ public partial class SaveView : ContentView
 
     private void OnCommandChanged()
     {
-        Touch.SetIsEnabled(this, Command is not null);
+        Touch.SetIsEnabled(m_filledCheckBox, Command is not null);
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Saving/SaveView/SaveView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Saving/SaveView/SaveView.cs
@@ -1,5 +1,6 @@
 using DIPS.Mobile.UI.API.Vibration;
 using DIPS.Mobile.UI.Components.CheckBoxes;
+using DIPS.Mobile.UI.Effects.Touch;
 using DIPS.Mobile.UI.Resources.Styles;
 using DIPS.Mobile.UI.Resources.Styles.Label;
 using Colors = Microsoft.Maui.Graphics.Colors;
@@ -40,8 +41,18 @@ public partial class SaveView : ContentView
         };
 
         Content = content;
+        
+        Touch.SetCommand(this, new Command(() =>
+        {
+            Command?.Execute(CommandParameter);
+            DidTapToSave = true;
+        }));
+        
+        // The SaveView should default to not being tappable, only when Command is set should the view be tappable
+        Touch.SetIsEnabled(this, false);
     }
-
+    
+    private bool DidTapToSave { get; set; }
 
     protected override void OnHandlerChanged()
     {
@@ -63,8 +74,16 @@ public partial class SaveView : ContentView
         if (newValue is true)
         {
             saveView.SetSavingCompletedText();
-            VibrationService.Success();
+            if (saveView.DidTapToSave)
+            {
+                VibrationService.Success();
+                saveView.DidTapToSave = false;
+            }
         }
     }
 
+    private void OnCommandChanged()
+    {
+        Touch.SetIsEnabled(this, Command is not null);
+    }
 }


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->