### PR TITLE
Added extra space at bottom of scroll view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [20.10.0]
+- [ScrollView] Added additional space at the bottom of scroll view to make sure the last item is scrolled to approx half the size of the scrollview for better UX.
+
 ## [20.9.0]
 - [SearchPage] Made sure keyboard will disapear when scrolling the result.
 - [SearchPage] Keyboard is now removed when people tap the cancel button.

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -12,11 +12,10 @@
     <dui:ContentPage.BindingContext>
         <håvardSamples:HåvardPageViewModel />
     </dui:ContentPage.BindingContext>
-    <Grid Grid.RowDefinitions="Auto, Auto, *">
-        <Border Grid.Row="0" HeightRequest="85" BackgroundColor="Red" />
-        <Border Grid.Row="1" HeightRequest="50" BackgroundColor="Blue" />
-        <dui:CollectionView Grid.Row="2" ItemsSource="{Binding Items}">
-            <dui:CollectionView.ItemTemplate>
+    <dui:ScrollView>
+        <dui:VerticalStackLayout Grid.Row="2"
+                                 BindableLayout.ItemsSource="{Binding Items}">
+            <BindableLayout.ItemTemplate>
                 <DataTemplate>
                     <Border Padding="50"
                             BackgroundColor="Green"
@@ -24,8 +23,7 @@
                         <dui:Label Text="Dette er en test" />
                     </Border>
                 </DataTemplate>
-            </dui:CollectionView.ItemTemplate>
-        </dui:CollectionView>
-        
-    </Grid>
+            </BindableLayout.ItemTemplate>
+        </dui:VerticalStackLayout>
+    </dui:ScrollView>
 </dui:ContentPage>

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -12,6 +12,7 @@
     <dui:ContentPage.BindingContext>
         <håvardSamples:HåvardPageViewModel />
     </dui:ContentPage.BindingContext>
+    
     <dui:ScrollView>
         <dui:VerticalStackLayout Grid.Row="2"
                                  BindableLayout.ItemsSource="{Binding Items}">

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-android;</TargetFrameworks>
+        <TargetFrameworks>net8.0-ios;</TargetFrameworks>
 
         <OutputType>Exe</OutputType>
         <RootNamespace>Playground</RootNamespace>

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-ios;</TargetFrameworks>
+        <TargetFrameworks>net8.0-android;</TargetFrameworks>
 
         <OutputType>Exe</OutputType>
         <RootNamespace>Playground</RootNamespace>
@@ -26,20 +26,20 @@
 
     <!-- Intellij Rider is unable to deploy to device for MAUI: https://youtrack.jetbrains.com/issue/RIDER-76794/Cannot-deploy-MAUI-project-to-physical-iOS-device-->
     <!-- TO fix this, we've done the following taken from this blog: https://msicc.net/deploy-maui-apps-with-rider-on-your-ios-device-after-these-xcode-errors/ -->
-<!--    <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">-->
-<!--        &lt;!&ndash;DEBUG ON DEVICE&ndash;&gt;-->
+    <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
+        <!--DEBUG ON DEVICE-->
 
-<!--        <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>-->
+        <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
 
-<!--        &lt;!&ndash;DEBUG ON SIMULATOR&ndash;&gt;-->
-
-
-<!--&lt;!&ndash;-->
-<!--        <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>-->
-<!--&ndash;&gt;-->
+        <!--DEBUG ON SIMULATOR-->
 
 
-<!--    </PropertyGroup>-->
+<!--
+        <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
+-->
+
+
+    </PropertyGroup>
 
     <ItemGroup>
         <!-- App Icon -->

--- a/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.Properties.cs
@@ -16,4 +16,15 @@ public partial class ScrollView
         get => (bool)GetValue(ShouldBounceProperty);
         set => SetValue(ShouldBounceProperty, value);
     }
+
+    public static readonly BindableProperty HasAdditionalSpaceAtTheEndProperty = BindableProperty.Create(
+        nameof(HasAdditionalSpaceAtTheEnd),
+        typeof(bool),
+        typeof(ScrollView), defaultValue:true);
+
+    public bool HasAdditionalSpaceAtTheEnd
+    {
+        get => (bool)GetValue(HasAdditionalSpaceAtTheEndProperty);
+        set => SetValue(HasAdditionalSpaceAtTheEndProperty, value);
+    }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.Properties.cs
@@ -31,7 +31,7 @@ public partial class ScrollView
     public static readonly BindableProperty AndroidAdditionalSpaceAtEndProperty = BindableProperty.Create(
         nameof(AndroidAdditionalSpaceAtEnd),
         typeof(double),
-        typeof(ScrollView), defaultValue:Sizes.GetSize(SizeName.size_25) * 4);
+        typeof(ScrollView), defaultValue: (double)Sizes.GetSize(SizeName.size_25) * 4);
 
     /// <summary>
     /// Additional space at the end for Android is hardcoded, this can be set by adjusting this property.

--- a/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.Properties.cs
@@ -27,4 +27,19 @@ public partial class ScrollView
         get => (bool)GetValue(HasAdditionalSpaceAtTheEndProperty);
         set => SetValue(HasAdditionalSpaceAtTheEndProperty, value);
     }
+
+    public static readonly BindableProperty AndroidAdditionalSpaceAtEndProperty = BindableProperty.Create(
+        nameof(AndroidAdditionalSpaceAtEnd),
+        typeof(double),
+        typeof(ScrollView), defaultValue:Sizes.GetSize(SizeName.size_25) * 4);
+
+    /// <summary>
+    /// Additional space at the end for Android is hardcoded, this can be set by adjusting this property.
+    /// </summary>
+    /// <remarks>iOS calculates its own size. Half the size of the entire scroll view.</remarks>
+    public double AndroidAdditionalSpaceAtEnd
+    {
+        get => (double)GetValue(AndroidAdditionalSpaceAtEndProperty);
+        set => SetValue(AndroidAdditionalSpaceAtEndProperty, value);
+    }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.cs
@@ -2,5 +2,18 @@ namespace DIPS.Mobile.UI.Components.Lists;
 
 public partial class ScrollView : Microsoft.Maui.Controls.ScrollView
 {
-    
+    private bool m_hasAddedSpaceToBottom;
+
+    protected override void OnSizeAllocated(double width, double height)
+    {
+        base.OnSizeAllocated(width, height);
+        var oldPadding = Padding;
+        if (height > 0 && !m_hasAddedSpaceToBottom && HasAdditionalSpaceAtTheEnd)
+        {
+            m_hasAddedSpaceToBottom = true;
+            var newPadding = new Thickness(oldPadding.Left, oldPadding.Top, oldPadding.Right,
+                oldPadding.Bottom + (height / 2));
+            Padding = newPadding;    
+        }
+    }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.cs
@@ -3,17 +3,34 @@ namespace DIPS.Mobile.UI.Components.Lists;
 public partial class ScrollView : Microsoft.Maui.Controls.ScrollView
 {
     private bool m_hasAddedSpaceToBottom;
+    private double m_originalHeight;
 
+    public ScrollView()
+    {
+#if __ANDROID__ //Not possible to set padding on scroll view after its rendered
+        AdjustPadding(Sizes.GetSize(SizeName.size_25) * 4);
+#endif
+        
+    }
+
+#if __IOS__
     protected override void OnSizeAllocated(double width, double height)
     {
         base.OnSizeAllocated(width, height);
+        AdjustPadding(height);
+    }
+#endif
+
+
+    private void AdjustPadding(double height)
+    {
         var oldPadding = Padding;
         if (height > 0 && !m_hasAddedSpaceToBottom && HasAdditionalSpaceAtTheEnd)
         {
             m_hasAddedSpaceToBottom = true;
             var newPadding = new Thickness(oldPadding.Left, oldPadding.Top, oldPadding.Right,
-                oldPadding.Bottom + (height / 2));
-            Padding = newPadding;    
+                (int)(oldPadding.Bottom + (height / 2)));
+            Padding = newPadding;
         }
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.cs
@@ -3,14 +3,12 @@ namespace DIPS.Mobile.UI.Components.Lists;
 public partial class ScrollView : Microsoft.Maui.Controls.ScrollView
 {
     private bool m_hasAddedSpaceToBottom;
-    private double m_originalHeight;
 
     public ScrollView()
     {
 #if __ANDROID__ //Not possible to set padding on scroll view after its rendered
-        AdjustPadding(Sizes.GetSize(SizeName.size_25) * 4);
+        AdjustPadding(AndroidAdditionalSpaceAtEnd);
 #endif
-        
     }
 
 #if __IOS__
@@ -31,6 +29,6 @@ public partial class ScrollView : Microsoft.Maui.Controls.ScrollView
             var newPadding = new Thickness(oldPadding.Left, oldPadding.Top, oldPadding.Right,
                 (int)(oldPadding.Bottom + (height / 2)));
             Padding = newPadding;
-        }
+        } 
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/iOS/ScrollViewHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/iOS/ScrollViewHandler.cs
@@ -11,7 +11,14 @@ public partial class ScrollViewHandler
         {
             if (virtualView is ScrollView scrollView)
             {
-                uiScrollView.Bounces = scrollView.ShouldBounce;
+                if (handler.VirtualView.Orientation == ScrollOrientation.Vertical)
+                {
+                    uiScrollView.AlwaysBounceVertical = scrollView.ShouldBounce;
+                }
+                else if (handler.VirtualView.Orientation == ScrollOrientation.Horizontal)
+                {
+                    uiScrollView.AlwaysBounceHorizontal = scrollView.ShouldBounce;
+                }
             }
         }
     }


### PR DESCRIPTION
### Description of Change

- [ScrollView] Added additional space at the bottom of scroll view to make sure the last item is scrolled to approx half the size of the scrollview for better UX.


### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->