### PR TITLE
Made toolbar item text nullable on Android for BottomSheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [20.10.1]
+- [BottomSheet][Android] Made sure consumers do not need to set the text of a toolbar item to add the toolbar item on Android.
+
 ## [20.10.0]
 - [ScrollView] Added additional space at the bottom of scroll view to make sure the last item is scrolled to approx half the size of the scrollview for better UX.
 

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetHandler.cs
@@ -202,8 +202,12 @@ public partial class BottomSheetHandler : ContentViewHandler
             var color = Colors.GetColor(BottomSheet.ToolbarActionButtonsName).ToPlatform();
 
             var text = toolbarItem.Text;
-            var titleTinted = new SpannableString(text);
-            titleTinted.SetSpan(new ForegroundColorSpan(color), 0, titleTinted.Length(), 0);
+            SpannableString? titleTinted = null;
+            if (!string.IsNullOrEmpty(text))
+            {
+                titleTinted = new SpannableString(text);
+                titleTinted.SetSpan(new ForegroundColorSpan(color), 0, titleTinted.Length(), 0);    
+            }
 
             var menuItem = toolbar.Menu.Add(0, AView.GenerateViewId(), (int)toolbarItem.Order, titleTinted);
             menuItem!.SetShowAsAction(ShowAsAction.IfRoom);


### PR DESCRIPTION
### Description of Change

- [BottomSheet][Android] Made sure consumers do not need to set the text of a toolbar item to add the toolbar item on Android.

### Todos
- [X] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->