### PR TITLE
Added a new control: 'ListItemContainer', fixed an issue where releasing the long-press context menu interaction too early would fire off the tap event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [20.11.0]
 - [iOS] Fixed an issue where releasing the long-press context menu interaction too early would fire off the tap event.
 - Added a new control: 'ListItemContainer'
+- Changed default padding of ListItem and dui:ContentPage
 
 ## [20.10.2]
 - Moved the sort icon to the left side of the text in SortControl, this implicitly also fixes that the text wont ever get truncated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [20.11.0]
+- [iOS] Fixed an issue where releasing the long-press context menu interaction too early would fire off the tap event.
+- Added a new control: 'ListItemContainer'
+
 ## [20.10.2]
 - Moved the sort icon to the left side of the text in SortControl, this implicitly also fixes that the text wont ever get truncated
 

--- a/src/app/Components/Components.csproj
+++ b/src/app/Components/Components.csproj
@@ -37,18 +37,18 @@
 
     <!-- Intellij Rider is unable to deploy to device for MAUI: https://youtrack.jetbrains.com/issue/RIDER-76794/Cannot-deploy-MAUI-project-to-physical-iOS-device-->
     <!-- TO fix this, we've done the following taken from this blog: https://msicc.net/deploy-maui-apps-with-rider-on-your-ios-device-after-these-xcode-errors/ -->
-<!--    <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">-->
-<!--        &lt;!&ndash;DEBUG ON DEVICE&ndash;&gt;-->
+    <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
+        <!--DEBUG ON DEVICE-->
 
 
-<!--        <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>-->
-<!--        -->
-<!--        &lt;!&ndash;DEBUG ON SIMULATOR&ndash;&gt;-->
+        <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
+        
+        <!--DEBUG ON SIMULATOR-->
 
-<!--&lt;!&ndash;-->
-<!--        <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>-->
-<!--&ndash;&gt;-->
-<!--    </PropertyGroup>-->
+<!--
+        <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
+-->
+    </PropertyGroup>
 
     <ItemGroup>
 

--- a/src/app/Components/ComponentsSamples/Alerting/AlertingSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Alerting/AlertingSamples.xaml
@@ -9,17 +9,14 @@
              xmlns:dialogs="clr-namespace:Components.ComponentsSamples.Alerting.Dialogs"
              x:Class="Components.ComponentsSamples.Alerting.AlertingSamples">
  
-    <dui:VerticalStackLayout Spacing="0">
+    <dui:ListItemContainer>
         
         <dui:NavigationListItem Title="{x:Static localizedStrings:LocalizedStrings.SystemMessage}"
-                                Command="{helpers:NavigationCommand {x:Type systemMessages:SystemMessageSamples}}"
-                                HasTopDivider="True"
-                                HasBottomDivider="True"/>
+                                Command="{helpers:NavigationCommand {x:Type systemMessages:SystemMessageSamples}}" />
         
         <dui:NavigationListItem Title="{x:Static localizedStrings:LocalizedStrings.Dialog}"
-                                Command="{helpers:NavigationCommand {x:Type dialogs:DialogSamples}}"
-                                HasBottomDivider="True"/>
+                                Command="{helpers:NavigationCommand {x:Type dialogs:DialogSamples}}" />
         
-    </dui:VerticalStackLayout>
+    </dui:ListItemContainer>
     
 </dui:ContentPage>

--- a/src/app/Components/ComponentsSamples/BottomSheets/BottomSheetSamples.xaml
+++ b/src/app/Components/ComponentsSamples/BottomSheets/BottomSheetSamples.xaml
@@ -8,22 +8,18 @@
                  xmlns:sheets="clr-namespace:Components.ComponentsSamples.BottomSheets.Sheets"
                  xmlns:localizedStrings="clr-namespace:Components.Resources.LocalizedStrings"
                  x:Class="Components.ComponentsSamples.BottomSheets.BottomSheetSamples">
-    <dui:VerticalStackLayout Spacing="0">
+    <dui:ListItemContainer Spacing="0">
         <dui:NavigationListItem Title="{x:Static localizedStrings:LocalizedStrings.BottomSheet_Open}"
-                                HasTopDivider="True"
-                                HasBottomDivider="True"
                                 Command="{dui:OpenBottomSheetCommand {x:Type sheets:SimpleBottomSheetView}}"
                                 VerticalOptions="Start" />
         
         <dui:NavigationListItem Title="{x:Static localizedStrings:LocalizedStrings.BottomSheet_OpenWithToolbar}"
                                 Command="{dui:OpenBottomSheetCommand {x:Type sheets:BottomSheetWithToolbar}}"
-                                VerticalOptions="Start"
-                                HasBottomDivider="True"/>
+                                VerticalOptions="Start" />
         
         <dui:NavigationListItem Title="{x:Static localizedStrings:LocalizedStrings.BottomSheet}"
                                 Subtitle="{x:Static localizedStrings:LocalizedStrings.BottomSheet_OpenNotClosableInteracting}"
                                 Command="{dui:OpenBottomSheetCommand {x:Type sheets:BottomSheetNotClosableByInteracting}}"
-                                VerticalOptions="Start"
-                                HasBottomDivider="True"/>
-    </dui:VerticalStackLayout>
+                                VerticalOptions="Start" />
+    </dui:ListItemContainer>
 </dui:ContentPage>

--- a/src/app/Components/ComponentsSamples/Buttons/ButtonsSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Buttons/ButtonsSamples.xaml
@@ -6,8 +6,7 @@
                  xmlns:localizedStrings="clr-namespace:Components.Resources.LocalizedStrings"
                  x:Class="Components.ComponentsSamples.Buttons.ButtonsSamples"
                  x:Name="This"
-                 Title="{x:Static localizedStrings:LocalizedStrings.Buttons}"
-                 Padding="{dui:Sizes size_4}">
+                 Title="{x:Static localizedStrings:LocalizedStrings.Buttons}">
     <dui:ScrollView>
         <Grid RowDefinitions="Auto, 20, Auto, 20, Auto">
 

--- a/src/app/Components/ComponentsSamples/Chips/ChipsSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Chips/ChipsSamples.xaml
@@ -5,9 +5,7 @@
 <dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                  xmlns:dui="http://dips.com/mobile.ui"
-                 x:Class="Components.ComponentsSamples.Chips.ChipsSamples"
-                 BackgroundColor="{dui:Colors color_system_white}"
-                 Padding="{dui:Sizes size_2}">
+                 x:Class="Components.ComponentsSamples.Chips.ChipsSamples">
     <dui:VerticalStackLayout>
         <dui:Label Text="Chip"
                    Margin="5" />

--- a/src/app/Components/ComponentsSamples/ContextMenus/ContextMenuSamples.xaml
+++ b/src/app/Components/ComponentsSamples/ContextMenus/ContextMenuSamples.xaml
@@ -7,10 +7,9 @@
     <dui:ContentPage.BindingContext>
         <contextMenu:ContextMenuSamplesViewModel />
     </dui:ContentPage.BindingContext>
-    <dui:VerticalStackLayout Spacing="0">
+    <dui:ListItemContainer>
         <!-- Single item -->
-        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_SingleAction}"
-                      HasTopDivider="True">
+        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_SingleAction}">
 
             <dui:ListItem.ContextMenuOptions>
                 <dui:ContextMenuOptions Mode="Pressed" />
@@ -37,8 +36,7 @@
         </dui:ListItem>
 
         <!-- Two items -->
-        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_TwoActions}"
-                      HasTopDivider="True">
+        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_TwoActions}">
 
             <dui:ListItem.ContextMenuOptions>
                 <dui:ContextMenuOptions Mode="Pressed" />
@@ -56,8 +54,7 @@
         </dui:ListItem>
 
         <!--Checkable items (all)-->
-        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_Choices_Multiple}"
-                      HasTopDivider="True">
+        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_Choices_Multiple}">
 
             <dui:ListItem.ContextMenuOptions>
                 <dui:ContextMenuOptions Mode="Pressed" />
@@ -79,8 +76,7 @@
         </dui:ListItem>
 
         <!-- Checkable items (single) -->
-        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_Choices_Single}"
-                      HasTopDivider="True">
+        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_Choices_Single}">
 
             <dui:ListItem.ContextMenuOptions>
                 <dui:ContextMenuOptions Mode="Pressed" />
@@ -100,8 +96,7 @@
         </dui:ListItem>
 
         <!-- Grouped items -->
-        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_GroupedActions}"
-                      HasTopDivider="True">
+        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_GroupedActions}">
 
             <dui:ListItem.ContextMenuOptions>
                 <dui:ContextMenuOptions Mode="Pressed" />
@@ -129,8 +124,7 @@
         </dui:ListItem>
 
         <!-- Checkable grouped items -->
-        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_Grouped_Choices_Single}"
-                      HasTopDivider="True">
+        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_Grouped_Choices_Single}">
 
             <dui:ListItem.ContextMenuOptions>
                 <dui:ContextMenuOptions Mode="Pressed" />
@@ -159,9 +153,7 @@
             </dui:ListItem.ContextMenu>
         </dui:ListItem>
 
-        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_LongPressWithAction}"
-                      HasTopDivider="True"
-                      HasBottomDivider="True">
+        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_LongPressWithAction}">
 
             <dui:ListItem.ContextMenu>
                 <dui:ContextMenu ItemClickedCommand="{Binding ItemClickedCommand}">
@@ -172,8 +164,7 @@
             </dui:ListItem.ContextMenu>
         </dui:ListItem>
 
-        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_LongPressWithDestructiveAction}"
-                      HasBottomDivider="True">
+        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_LongPressWithDestructiveAction}">
 
             <dui:ListItem.ContextMenu>
                 <dui:ContextMenu ItemClickedCommand="{Binding ItemClickedCommand}">
@@ -186,8 +177,7 @@
         </dui:ListItem>
         
         <!-- One item + one meny -->
-        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_LongPress_OneItemOneGroup}"
-                      HasBottomDivider="True">
+        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_LongPress_OneItemOneGroup}">
             <dui:ListItem.ContextMenu>
                 <dui:ContextMenu ItemClickedCommand="{Binding ItemClickedCommand}">
                     <dui:ContextMenuItem
@@ -211,8 +201,7 @@
             </dui:ListItem.ContextMenu>
         </dui:ListItem>
 
-        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_Divider}"
-                      HasBottomDivider="True">
+        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Context_Menu_Divider}">
             <dui:ListItem.ContextMenuOptions>
                 <dui:ContextMenuOptions Mode="Pressed" />
             </dui:ListItem.ContextMenuOptions>
@@ -241,5 +230,5 @@
             </dui:ListItem.ContextMenu>
         </dui:ListItem>
 
-    </dui:VerticalStackLayout>
+    </dui:ListItemContainer>
 </dui:ContentPage>

--- a/src/app/Components/ComponentsSamples/ListItems/ListItemsSamples.xaml
+++ b/src/app/Components/ComponentsSamples/ListItems/ListItemsSamples.xaml
@@ -16,20 +16,17 @@
         <listItems:ListItemsSamplesViewModel />
     </dui:ContentPage.BindingContext>
 
-    <dui:VerticalStackLayout Spacing="0">
-        <dui:NavigationListItem Title="Navigate"
-                                HasTopDivider="True"/>
+    <dui:ListItemContainer>
+        <dui:NavigationListItem Title="Navigate" />
         
         <dui:NavigationListItem Title="Navigate"
-                                Icon="{dui:Icons internalmessage_fill}"
-                                HasTopDivider="True">
+                                Icon="{dui:Icons internalmessage_fill}">
             <dui:NavigationListItem.IconOptions>
                 <icon:IconOptions Color="{dui:Colors color_primary_90}" />
             </dui:NavigationListItem.IconOptions>
         </dui:NavigationListItem>
 
-        <dui:ListItem Title="Person"
-                      HasTopDivider="True">
+        <dui:ListItem Title="Person">
             <dui:ListItem.BindingContext>
                 <pickers:ItemPickersSamplesViewModel />
             </dui:ListItem.BindingContext>
@@ -41,8 +38,7 @@
             </dui:ItemPicker>
         </dui:ListItem>
 
-        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Birthday}"
-                      HasTopDivider="True">
+        <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Birthday}">
             <dui:ListItem.BindingContext>
                 <pickers:DateTimePickerSamplesViewModel />
             </dui:ListItem.BindingContext>
@@ -58,8 +54,6 @@
                               IsError="{Binding IsError}"
                               OnErrorTappedCommand="{Binding RefreshCommand}"
                               Command="{Binding RefreshCommand}"
-                              HasBottomDivider="True"
-                              HasTopDivider="True"
                               FadeContentIn="True">
             
             <dui:Label Text="All systems working!"
@@ -72,5 +66,5 @@
             <dui:MultiItemsPicker ItemsSource="{x:Static sampleData:SampleDataStorage.People}">
             </dui:MultiItemsPicker>
         </dui:MultiItemsPickerListItem>
-    </dui:VerticalStackLayout>
+    </dui:ListItemContainer>
 </dui:ContentPage>

--- a/src/app/Components/ComponentsSamples/Loading/LoadingSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Loading/LoadingSamples.xaml
@@ -10,16 +10,10 @@
              xmlns:skeleton="clr-namespace:Components.ComponentsSamples.Loading.Skeleton"
              xmlns:activityIndicator="clr-namespace:Components.ComponentsSamples.Loading.ActivityIndicator"
              x:Class="Components.ComponentsSamples.Loading.LoadingSamples">
-    <dui:VerticalStackLayout Spacing="0">
+    <dui:ListItemContainer>
         <dui:NavigationListItem Title="{x:Static localizedStrings:LocalizedStrings.SkeletonLoading}"
-                                Command="{helpers:NavigationCommand {x:Type skeleton:SkeletonLoadingSamplesPage}}"
-                                HasTopDivider="True"
-                                HasBottomDivider="True"
-                                />
+                                Command="{helpers:NavigationCommand {x:Type skeleton:SkeletonLoadingSamplesPage}}" />
         <dui:NavigationListItem Title="{x:Static localizedStrings:LocalizedStrings.ActivityIndicator}"
-                                Command="{helpers:NavigationCommand {x:Type activityIndicator:ActivitiyIndicatorSamplesPage}}"
-                                HasTopDivider="True"
-                                HasBottomDivider="True"
-        />
-    </dui:VerticalStackLayout>
+                                Command="{helpers:NavigationCommand {x:Type activityIndicator:ActivitiyIndicatorSamplesPage}}" />
+    </dui:ListItemContainer>
 </dui:ContentPage>

--- a/src/app/Components/ComponentsSamples/Navigation/NavigationSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Navigation/NavigationSamples.xaml
@@ -6,11 +6,9 @@
              xmlns:navigation="clr-namespace:Components.ComponentsSamples.Navigation"
              xmlns:helpers="clr-namespace:Components.Helpers"
              x:Class="Components.ComponentsSamples.Navigation.NavigationSamples">
-    <dui:VerticalStackLayout Spacing="0">
+    <dui:ListItemContainer>
         <dui:NavigationListItem Title="Floating Navigation Button" 
-                                Command="{helpers:NavigationCommand {x:Type navigation:FloatingNavigationButtonSamples}}"
-                                HasTopDivider="True"
-                                HasBottomDivider="True" />
-    </dui:VerticalStackLayout>
+                                Command="{helpers:NavigationCommand {x:Type navigation:FloatingNavigationButtonSamples}}"/>
+    </dui:ListItemContainer>
     
 </dui:ContentPage>

--- a/src/app/Components/ComponentsSamples/Pickers/DateTimePickersSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Pickers/DateTimePickersSamples.xaml
@@ -7,9 +7,7 @@
                  xmlns:dui="http://dips.com/mobile.ui"
                  xmlns:pickers="clr-namespace:Components.ComponentsSamples.Pickers"
                  x:Class="Components.ComponentsSamples.Pickers.DateTimePickersSamples"
-                 Padding="{dui:Sizes size_3}"
-                 Title="Date / time pickers"
-                 BackgroundColor="{dui:Colors color_system_white}">
+                 Title="Date / time pickers">
     <dui:ContentPage.BindingContext>
         <pickers:DateTimePickerSamplesViewModel />
     </dui:ContentPage.BindingContext>

--- a/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
@@ -9,9 +9,7 @@
                  xmlns:localizedStrings="clr-namespace:Components.Resources.LocalizedStrings"
                  xmlns:sampleData="clr-namespace:Components.SampleData"
                  x:Class="Components.ComponentsSamples.Pickers.ItemPickersSamples"
-                 Title="Item pickers"
-                 Padding="{dui:Sizes size_4}"
-                 BackgroundColor="{dui:Colors color_system_white}">
+                 Title="Item pickers">
     <dui:ContentPage.BindingContext>
         <pickers:ItemPickersSamplesViewModel />
     </dui:ContentPage.BindingContext>

--- a/src/app/Components/ComponentsSamples/Pickers/PickersSample.xaml
+++ b/src/app/Components/ComponentsSamples/Pickers/PickersSample.xaml
@@ -9,13 +9,10 @@
                  xmlns:helpers="clr-namespace:Components.Helpers"
                  xmlns:extensions="clr-namespace:DIPS.Mobile.UI.Components.ListItems.Extensions;assembly=DIPS.Mobile.UI"
                  x:Class="Components.ComponentsSamples.Pickers.PickersSample">
-    <dui:VerticalStackLayout Spacing="0">
+    <dui:ListItemContainer>
         <extensions:NavigationListItem Title="Item pickers"
-                                Command="{helpers:NavigationCommand {x:Type pickers:ItemPickersSamples}}"
-                                HasTopDivider="True"
-                                HasBottomDivider="True"/>
+                                Command="{helpers:NavigationCommand {x:Type pickers:ItemPickersSamples}}" />
         <extensions:NavigationListItem Title="Date / time pickers"
-                                Command="{helpers:NavigationCommand {x:Type pickers:DateTimePickersSamples}}"
-                                HasBottomDivider="True"/>
-    </dui:VerticalStackLayout>
+                                Command="{helpers:NavigationCommand {x:Type pickers:DateTimePickersSamples}}" />
+    </dui:ListItemContainer>
 </dui:ContentPage>

--- a/src/app/Components/ComponentsSamples/Saving/SavingSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Saving/SavingSamples.xaml
@@ -18,12 +18,11 @@
         <saving:SavingSamplesViewModel />
     </dui:ContentSavePage.BindingContext>
 
-    <dui:VerticalStackLayout>
+    <dui:ListItemContainer>
         <dui:Label
             Text="The content of this page has random components inside of it to test the behavior when the user is saving"
             Padding="{dui:Thickness size_4}" />
-        <dui:ListItem Title="This is a chip:"
-                      Margin="{dui:Thickness Top=size_2}">
+        <dui:ListItem Title="This is a chip:">
             <dui:Chip Title="A chip" />
         </dui:ListItem>
         <dui:ListItem Title="Date">
@@ -38,6 +37,6 @@
         <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.Save}"
                       Command="{Binding SaveCommand}" />
 
-    </dui:VerticalStackLayout>
+    </dui:ListItemContainer>
 
 </dui:ContentSavePage>

--- a/src/app/Components/ComponentsSamples/Searching/SearchingSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Searching/SearchingSamples.xaml
@@ -4,14 +4,11 @@
                  xmlns:searching="clr-namespace:Components.ComponentsSamples.Searching"
                  xmlns:helpers="clr-namespace:Components.Helpers"
                  x:Class="Components.ComponentsSamples.Searching.SearchingSamples">
-    <dui:VerticalStackLayout Spacing="0">
+    <dui:ListItemContainer>
         <dui:NavigationListItem Title="Search bar"
-                                Command="{helpers:NavigationCommand {x:Type searching:SearchBarSamples}}"
-                                HasTopDivider="True"
-                                HasBottomDivider="True"/>
+                                Command="{helpers:NavigationCommand {x:Type searching:SearchBarSamples}}" />
 
         <dui:NavigationListItem Title="Search page"
-                                Command="{helpers:NavigationCommand {x:Type searching:SearchPageSamples}}"
-                                HasBottomDivider="True"/>
-    </dui:VerticalStackLayout>
+                                Command="{helpers:NavigationCommand {x:Type searching:SearchPageSamples}}" />
+    </dui:ListItemContainer>
 </dui:ContentPage>

--- a/src/app/Components/ComponentsSamples/Selection/SelectionSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Selection/SelectionSamples.xaml
@@ -5,8 +5,7 @@
 <dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                  xmlns:dui="http://dips.com/mobile.ui"
-                 x:Class="Components.ComponentsSamples.Selection.SelectionSamples"
-                 Padding="{dui:Sizes size_4}">
+                 x:Class="Components.ComponentsSamples.Selection.SelectionSamples">
     <VerticalStackLayout>
         <dui:Label Text="Switch"
                    Margin="5" />

--- a/src/app/Components/ComponentsSamples/TextFields/TextFieldsSamples.xaml
+++ b/src/app/Components/ComponentsSamples/TextFields/TextFieldsSamples.xaml
@@ -10,17 +10,14 @@
              xmlns:dui="http://dips.com/mobile.ui"
              x:Class="Components.ComponentsSamples.TextFields.TextFieldsSamples">
 
-    <dui:VerticalStackLayout Spacing="0">
+    <dui:ListItemContainer>
         <dui:NavigationListItem Title="Entry" 
-                                Command="{helpers:NavigationCommand {x:Type entry:EntrySamples}}"
-                                HasBottomDivider="True" />
+                                Command="{helpers:NavigationCommand {x:Type entry:EntrySamples}}"/>
         <dui:NavigationListItem Title="Editor" 
-                                Command="{helpers:NavigationCommand {x:Type editor:EditorSamples}}"
-                                HasBottomDivider="True" />
+                                Command="{helpers:NavigationCommand {x:Type editor:EditorSamples}}" />
         <dui:NavigationListItem Title="SingleLineInputField" 
-                                Command="{helpers:NavigationCommand {x:Type textArea:SingleLineInputFieldSamples}}"
-                                HasBottomDivider="True" />
+                                Command="{helpers:NavigationCommand {x:Type textArea:SingleLineInputFieldSamples}}" />
         <dui:NavigationListItem Title="MultiLineInputField" 
                                 Command="{helpers:NavigationCommand {x:Type multiLineTextArea:MultiLineInputFieldSamples}}" />
-    </dui:VerticalStackLayout>
+    </dui:ListItemContainer>
 </dui:ContentPage>

--- a/src/app/Components/MainPage.cs
+++ b/src/app/Components/MainPage.cs
@@ -1,19 +1,19 @@
 using Components.Resources.LocalizedStrings;
 using DIPS.Mobile.UI.Components.ListItems;
 using DIPS.Mobile.UI.Components.ListItems.Extensions;
+using DIPS.Mobile.UI.Components.ListItems.Options.Dividers;
 using DIPS.Mobile.UI.Resources.Sizes;
 
 namespace Components;
 
 public class MainPage : DIPS.Mobile.UI.Components.Pages.ContentPage
 {
-  
     public MainPage(IEnumerable<SampleType> sampleTypes, List<Sample> samples)
     {
         Title = $"{AppInfo.Current.Name} ({AppInfo.Current.VersionString})";
         Content = new DIPS.Mobile.UI.Components.Lists.CollectionView()
         {
-            ItemsSource = sampleTypes, ItemTemplate = new DataTemplate(() => new NavigateToSamplesItem(samples)),
+            ItemsSource = sampleTypes, ItemTemplate = new DataTemplate(() => new NavigateToSamplesItem(samples, sampleTypes)),
         };
     }
 }
@@ -21,13 +21,16 @@ public class MainPage : DIPS.Mobile.UI.Components.Pages.ContentPage
 public class NavigateToSamplesItem : NavigationListItem
 {
     private readonly List<Sample> m_samples;
+    private readonly IEnumerable<SampleType> m_sampleTypes;
     private SampleType m_sampleType;
 
-    public NavigateToSamplesItem(List<Sample> samples)
+    public NavigateToSamplesItem(List<Sample> samples, IEnumerable<SampleType> sampleTypes)
     {
         m_samples = samples;
+        m_sampleTypes = sampleTypes;
+        
         Command = new Command(TryNavigateToSamplesPage);
-        HasTopDivider = true;
+        
     }
 
     private void TryNavigateToSamplesPage()
@@ -54,6 +57,16 @@ public class NavigateToSamplesItem : NavigationListItem
                 SampleType.Resources => LocalizedStrings.Resources,
                 _ => "Unknown"
             };
+
+            if (m_sampleTypes.First() == sampleType)
+                CornerRadius = new CornerRadius(Sizes.GetSize(SizeName.size_2), Sizes.GetSize(SizeName.size_2), 0, 0);
+            else
+            {
+                HasTopDivider = true;
+                DividersOptions = new DividersOptions { TopDividerMargin = new Thickness(Sizes.GetSize(SizeName.size_2), 0, 0, 0) };
+                CornerRadius = new CornerRadius(0, 0, Sizes.GetSize(SizeName.size_2), Sizes.GetSize(SizeName.size_2));
+            }
+
         }
     }
 }

--- a/src/app/Components/SamplesPage.cs
+++ b/src/app/Components/SamplesPage.cs
@@ -1,6 +1,7 @@
 using Components.Resources.LocalizedStrings;
 using DIPS.Mobile.UI.Components.ListItems;
 using DIPS.Mobile.UI.Components.ListItems.Extensions;
+using DIPS.Mobile.UI.Components.ListItems.Options.Dividers;
 using DIPS.Mobile.UI.Resources.Sizes;
 
 namespace Components
@@ -19,19 +20,20 @@ namespace Components
             {
                 ItemSpacing = 0,
                 ItemsSource = samplePages,
-                ItemTemplate = new DataTemplate(() => new NavigateToSingleSampleItem()),
+                ItemTemplate = new DataTemplate(() => new NavigateToSingleSampleItem(samplePages)),
             };
         }
 
         public class NavigateToSingleSampleItem : NavigationListItem
         {
+            private readonly IEnumerable<Sample> m_samplePages;
             private Sample m_sample;
             
 
-            public NavigateToSingleSampleItem()
+            public NavigateToSingleSampleItem(IEnumerable<Sample> samplePages)
             {
+                m_samplePages = samplePages;
                 Command = new Command(TryNavigateToSingleSamplePage);
-                HasTopDivider = true;
             }
 
             private void TryNavigateToSingleSamplePage()
@@ -48,6 +50,22 @@ namespace Components
                 {
                     m_sample = sample;
                     Title = m_sample.Name;
+
+                    if (m_samplePages.First() == sample)
+                    {
+                        CornerRadius = new CornerRadius(Sizes.GetSize(SizeName.size_2), Sizes.GetSize(SizeName.size_2), 0, 0);
+                    }
+                    else if (m_samplePages.Last() == sample)
+                    {
+                        HasTopDivider = true;
+                        DividersOptions = new DividersOptions { TopDividerMargin = new Thickness(Sizes.GetSize(SizeName.size_2), 0, 0, 0) };
+                        CornerRadius = new CornerRadius(0, 0, Sizes.GetSize(SizeName.size_2), Sizes.GetSize(SizeName.size_2));
+                    }
+                    else
+                    {
+                        HasTopDivider = true;
+                        DividersOptions = new DividersOptions { TopDividerMargin = new Thickness(Sizes.GetSize(SizeName.size_2), 0, 0, 0) };
+                    }
                 }
             }
         }

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -4,6 +4,7 @@
                  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                  xmlns:vetleSamples="clr-namespace:Playground.VetleSamples"
                  xmlns:dui="http://dips.com/mobile.ui"
+                 xmlns:layout="clr-namespace:DIPS.Mobile.UI.Components.Layout;assembly=DIPS.Mobile.UI"
                  x:Class="Playground.VetleSamples.VetlePage"
                  x:DataType="{x:Type vetleSamples:VetlePageViewModel}"
                  Padding="20"
@@ -18,98 +19,30 @@
         <ToolbarItem Text="Test" Command="{dui:OpenBottomSheetCommand {x:Type vetleSamples:BottomSheetWithToolbar}}" />
     </dui:ContentPage.ToolbarItems>
     
-    <dui:ContentPage.Resources>
-        
-        <DataTemplate x:Key="Template1">
-
-            <dui:ListItem Title="Template1"
-                          IsDebugMode="True"
-                          Command="{Binding Source={x:Reference This}, Path=BindingContext.Navigate}">
-
-                <dui:ListItem.TitleOptions>
-                    <dui:TitleOptions Width="Auto"
-                                      Margin="{dui:Thickness Right=size_2}"
-                                      Style="{dui:Styles Label=UI300}"
-                                      MaxLines="2" />
-                </dui:ListItem.TitleOptions>
-                <dui:ListItem.InLineContentOptions>
-                    <dui:InLineContentOptions Width="*"
-                                              HorizontalOptions="Fill" 
-                                              VerticalOptions="Start"
-                                              SpanOverUnderlyingContent="True"/>
-                </dui:ListItem.InLineContentOptions>
-                        
-                <BoxView HeightRequest="500" WidthRequest="100"></BoxView>
-
-                <dui:ListItem.UnderlyingContent>
-                    <dui:VerticalStackLayout dui:Touch.Command="{Binding Source={x:Reference This}, Path=BindingContext.CompletedCommand}">
-                        <dui:Label Text="HOho"></dui:Label>
-                        <dui:Label Text="Hei"
-                                   >
-                        </dui:Label>
-                    </dui:VerticalStackLayout>
-                </dui:ListItem.UnderlyingContent>
-
-            </dui:ListItem>
-        </DataTemplate>
-        
-        <DataTemplate x:Key="Template2">
-
-            <dui:ListItem Title="Template2"
-                          IsDebugMode="True"
-                          Command="{Binding Source={x:Reference This}, Path=BindingContext.Navigate}">
-
-                <dui:ListItem.TitleOptions>
-                    <dui:TitleOptions Width="Auto"
-                                      Margin="{dui:Thickness Right=size_2}"
-                                      Style="{dui:Styles Label=UI300}"
-                                      MaxLines="2" />
-                </dui:ListItem.TitleOptions>
-                <dui:ListItem.InLineContentOptions>
-                    <dui:InLineContentOptions Width="*"
-                                              HorizontalOptions="Fill" 
-                                              VerticalOptions="Start"
-                                              SpanOverUnderlyingContent="True"/>
-                </dui:ListItem.InLineContentOptions>
-                        
-                <BoxView HeightRequest="100" WidthRequest="100"></BoxView>
-
-                <dui:ListItem.UnderlyingContent>
-                    <dui:VerticalStackLayout>
-                                
-                        <dui:Label Text="HOho"></dui:Label>
-                        <dui:Label Text="Hei"
-                                   dui:Touch.Command="{Binding Source={x:Reference This}, Path=BindingContext.CompletedCommand}">
-                        </dui:Label>
-                    </dui:VerticalStackLayout>
-                </dui:ListItem.UnderlyingContent>
-
-            </dui:ListItem>
-        </DataTemplate>
-        
-        
-        
-        <vetleSamples:TemplateSelector x:Key="TemplateSelector"
-                                       Test1="{StaticResource Template1}"
-                                       Test2="{StaticResource Template2}" />
-    </dui:ContentPage.Resources>
-
-    <dui:VerticalStackLayout Spacing="0">
-
-        <Grid ColumnDefinitions="Auto, *">
-            
-            <BoxView HeightRequest="20"
-                     WidthRequest="200"
-                     BackgroundColor="Red"></BoxView>
-            
-            <dui:SortControl Grid.Column="1" InitialSelectedItem="Lolaoisdmoiasjdoiajsoidjasoisdjoiasj" />
-            
-        </Grid>
-        
        
+       
+    <dui:ListItemContainer
+                             VerticalOptions="Start">
+        <dui:ListItem Title="lo"
+                      Command="{Binding Navigate}"
+                      dui:ContextMenuEffect.Mode="LongPressed">
+            <dui:ListItem.ContextMenu>
+                <dui:ContextMenu>
+                    <dui:ContextMenuItem Title="Hei og hå" Command="{Binding Navigate}" />
+                </dui:ContextMenu>
+            </dui:ListItem.ContextMenu>
+        </dui:ListItem>
+        
+      
+        <dui:ListItem Title="Default false" IsVisible="{Binding IsSaving}"  />
 
-
-    </dui:VerticalStackLayout>
+        <Switch IsToggled="{Binding IsSaving}" />
+        
+    </dui:ListItemContainer>
+    
+  
+    
+    
 
 
 </dui:ContentPage>

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.LongPressed.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.LongPressed.cs
@@ -30,13 +30,6 @@ public partial class ContextMenuPlatformEffect
 
     public class LongPressContextMenuDelegate : UIContextMenuInteractionDelegate
     {
-        public override void WillDisplayMenu(UIContextMenuInteraction interaction, UIContextMenuConfiguration configuration,
-            IUIContextMenuInteractionAnimating? animator)
-        {
-            
-            
-        }
-
         public override void WillEnd(UIContextMenuInteraction interaction, UIContextMenuConfiguration configuration,
             IUIContextMenuInteractionAnimating? animator)
         {

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.LongPressed.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.LongPressed.cs
@@ -1,5 +1,6 @@
 using CoreGraphics;
 using DIPS.Mobile.UI.Components.ContextMenus.iOS;
+using DIPS.Mobile.UI.Effects.Touch;
 using Microsoft.Maui.Platform;
 using UIKit;
 
@@ -24,16 +25,33 @@ public partial class ContextMenuPlatformEffect
         m_contextMenu.BindingContext = Element.BindingContext;
 
         m_interaction = new UIContextMenuInteraction(m_delegate);
-        
         Control.AddInteraction(m_interaction);
     }
 
     public class LongPressContextMenuDelegate : UIContextMenuInteractionDelegate
     {
+        public override void WillDisplayMenu(UIContextMenuInteraction interaction, UIContextMenuConfiguration configuration,
+            IUIContextMenuInteractionAnimating? animator)
+        {
+            
+            
+        }
+
+        public override void WillEnd(UIContextMenuInteraction interaction, UIContextMenuConfiguration configuration,
+            IUIContextMenuInteractionAnimating? animator)
+        {
+            if (interaction.View is not MauiView view)
+                return; 
+            
+            Touch.SetIsEnabled((VisualElement)view.View, true);
+        }
+
         public override UIContextMenuConfiguration? GetConfigurationForMenu(UIContextMenuInteraction interaction, CGPoint location)
         {
             if (interaction.View is not MauiView view)
                 return null; 
+            
+            Touch.SetIsEnabled((VisualElement)view.View, false);
 
             var contextMenu = ContextMenuEffect.GetMenu(((VisualElement)view.View!));
             

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
@@ -229,9 +229,9 @@ namespace DIPS.Mobile.UI.Components.ListItems
             typeof(Thickness),
             typeof(ListItem),
             new Thickness(
-            Sizes.GetSize(SizeName.size_3), 
+            Sizes.GetSize(SizeName.size_2), 
             Sizes.GetSize(SizeName.size_3),
-            Sizes.GetSize(SizeName.size_3),
+            Sizes.GetSize(SizeName.size_2),
             Sizes.GetSize(SizeName.size_3)));
         
         public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/CollectionView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/CollectionView.cs
@@ -42,6 +42,8 @@ public partial class CollectionView : Microsoft.Maui.Controls.CollectionView
             AddExtraSpaceAtTheEnd();
         }
     }
+    
+    
 
     private void AddExtraSpaceAtTheEnd()
     {

--- a/src/library/DIPS.Mobile.UI/Components/Lists/ListItemContainer.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/ListItemContainer.Properties.cs
@@ -1,0 +1,19 @@
+namespace DIPS.Mobile.UI.Components.Lists;
+
+public partial class ListItemContainer
+{
+    public static readonly BindableProperty DividerMarginProperty = BindableProperty.Create(
+        nameof(DividerMargin),
+        typeof(Thickness),
+        typeof(Lists.ListItemContainer),
+        defaultValue: new Thickness(Sizes.GetSize(SizeName.size_2), 0, 0, 0));
+
+    /// <summary>
+    /// Set the margin of the divider between ListItems
+    /// </summary>
+    public Thickness DividerMargin
+    {
+        get => (Thickness)GetValue(DividerMarginProperty);
+        set => SetValue(DividerMarginProperty, value);
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Components/Lists/ListItemContainer.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/ListItemContainer.cs
@@ -1,0 +1,63 @@
+using DIPS.Mobile.UI.Components.ListItems;
+using DIPS.Mobile.UI.Components.ListItems.Options.Dividers;
+
+namespace DIPS.Mobile.UI.Components.Lists;
+
+/// <summary>
+/// A container that automatically adds rounded corners to the first and last ListItems.
+/// Additionally, it sets a divider between ListItems and the margin of the divider
+/// </summary>
+public partial class ListItemContainer : VerticalStackLayout
+{
+    public ListItemContainer()
+    {
+        Spacing = 0;
+    }
+
+    protected override async void OnSizeAllocated(double width, double height)
+    {
+        base.OnSizeAllocated(width, height);
+
+        await Task.Delay(1);
+        
+        var visibleListItems = Children.Where(element => element is ListItem { IsVisible: true }).Cast<ListItem>().ToList();
+        
+        ResetAndSetListItemDefaultValues(visibleListItems);
+
+        var firstListItem = visibleListItems.FirstOrDefault();
+        
+        if (firstListItem is not null)
+        {
+            if (visibleListItems.Count == 1)
+            {
+                firstListItem.CornerRadius = new CornerRadius(Sizes.GetSize(SizeName.size_2));
+                return;
+            }
+            
+            firstListItem.CornerRadius = new CornerRadius(Sizes.GetSize(SizeName.size_2), Sizes.GetSize(SizeName.size_2), 0, 0);
+        }
+
+        var lastListItem = visibleListItems.LastOrDefault();
+        
+        if (lastListItem is not null)
+        {
+            lastListItem.CornerRadius = new CornerRadius(0, 0, Sizes.GetSize(SizeName.size_2), Sizes.GetSize(SizeName.size_2));
+        }
+    }
+
+    private void ResetAndSetListItemDefaultValues(List<ListItem> visibleListItems)
+    {
+        foreach (var visibleListItem in visibleListItems)
+        {
+            visibleListItem.CornerRadius = new CornerRadius(0);
+            if(visibleListItem.HasTopDivider)
+                visibleListItem.HasTopDivider = false;
+
+            if (visibleListItems.IndexOf(visibleListItem) == 0)
+                continue;
+
+            visibleListItem.HasTopDivider = true;
+            visibleListItem.DividersOptions = new DividersOptions { TopDividerMargin = DividerMargin };
+        }
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Components/Pages/ContentPage.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pages/ContentPage.cs
@@ -16,6 +16,8 @@ namespace DIPS.Mobile.UI.Components.Pages
             SetColors(Application.Current.RequestedTheme);
             Application.Current.RequestedThemeChanged +=
                 OnRequestedThemeChanged; //Can not use AppThemeBindings because that makes the navigation page bar background flash on Android, so we listen to changes and set the color our self
+
+            Padding = Sizes.GetSize(SizeName.size_3);
         }
 
         private void SetColors(AppTheme osAppTheme)

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
@@ -48,6 +48,9 @@ public partial class TouchPlatformEffect
 
     private void OnTap()
     {
+        if(!Touch.GetIsEnabled(Element))
+            return;
+        
         if (Touch.GetCommand(Element).CanExecute(Touch.GetCommandParameter(Element)))
             Touch.GetCommand(Element).Execute(Touch.GetCommandParameter(Element));
     }


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->