### PR TITLE
[iOS] Fixed an issue where releasing the long-press context menu interaction too early would fire off the tap event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [20.12.0]
+- [iOS] Fixed an issue where releasing the long-press context menu interaction too early would fire off the tap event.
+- Changed default padding of ListItem
+
 ## [20.11.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.LongPressed.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.LongPressed.cs
@@ -1,5 +1,6 @@
 using CoreGraphics;
 using DIPS.Mobile.UI.Components.ContextMenus.iOS;
+using DIPS.Mobile.UI.Effects.Touch;
 using Microsoft.Maui.Platform;
 using UIKit;
 
@@ -30,10 +31,21 @@ public partial class ContextMenuPlatformEffect
 
     public class LongPressContextMenuDelegate : UIContextMenuInteractionDelegate
     {
+        public override void WillEnd(UIContextMenuInteraction interaction, UIContextMenuConfiguration configuration,
+            IUIContextMenuInteractionAnimating? animator)
+        {
+            if (interaction.View is not MauiView view)
+                return; 
+
+            Touch.SetIsEnabled((VisualElement)view.View, true);
+        }
+        
         public override UIContextMenuConfiguration? GetConfigurationForMenu(UIContextMenuInteraction interaction, CGPoint location)
         {
             if (interaction.View is not MauiView view)
                 return null; 
+            
+            Touch.SetIsEnabled((VisualElement)view.View, false);
 
             var contextMenu = ContextMenuEffect.GetMenu(((VisualElement)view.View!));
             

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
@@ -229,9 +229,9 @@ namespace DIPS.Mobile.UI.Components.ListItems
             typeof(Thickness),
             typeof(ListItem),
             new Thickness(
-            Sizes.GetSize(SizeName.size_3), 
+            Sizes.GetSize(SizeName.size_2), 
             Sizes.GetSize(SizeName.size_3),
-            Sizes.GetSize(SizeName.size_3),
+            Sizes.GetSize(SizeName.size_2),
             Sizes.GetSize(SizeName.size_3)));
         
         public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->