### PR TITLE
[SlidableLayout] Fixed a bug where you couldn't tap the next element (only the previous) in a slidable layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [22.1.2]
+- [SlidableLayout] Fixed a bug where you couldn't tap the next element (only the previous) in a slidable layout
+
 ## [22.1.1]
 - [Button] Fixed an issue when setting image to a button taking the entire parent space.
 

--- a/src/app/Playground/AppShell.xaml
+++ b/src/app/Playground/AppShell.xaml
@@ -7,6 +7,7 @@
     xmlns:håvardSamples="clr-namespace:Playground.HåvardSamples"
     xmlns:sanderSamples="clr-namespace:Playground.SanderSamples"
     xmlns:dui="http://dips.com/mobile.ui"
+    xmlns:eirikSamples="clr-namespace:Playground.EirikSamples"
     Shell.FlyoutBehavior="Disabled">
 
     <TabBar>
@@ -27,6 +28,12 @@
                 Title="Sander"
                 ContentTemplate="{DataTemplate sanderSamples:SanderPage}"
                 Route="Sander" />
+        </Tab>
+        <Tab Title="Eirik">
+            <ShellContent
+                Title="Eirik"
+                ContentTemplate="{DataTemplate eirikSamples:EirikPage}"
+                Route="Eirik"/>
         </Tab>
     </TabBar>
 </dui:Shell>

--- a/src/app/Playground/EirikSamples/EirikPage.xaml
+++ b/src/app/Playground/EirikSamples/EirikPage.xaml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:dui="http://dips.com/mobile.ui"
+             xmlns:eirikSamples="clr-namespace:Playground.EirikSamples"
+             x:Class="Playground.EirikSamples.EirikPage"
+             x:DataType="{x:Type eirikSamples:EirikPageViewModel}">
+    <dui:ContentPage.BindingContext>
+        <eirikSamples:EirikPageViewModel />
+    </dui:ContentPage.BindingContext>
+    <dui:SlidableContentLayout x:Name="SlidableContentLayout"
+                               ContentTapped="SlidableContentLayout_OnContentTapped"
+                               BindingContextFactory="{Binding DateViewModelFactory}"
+                               Config="{Binding Config}"
+                               SlideProperties="{Binding Properties}"
+                               ScaleDown="False"
+                               DisableTouchScroll="False">
+        <dui:SlidableContentLayout.ItemTemplate>
+            <DataTemplate x:DataType="{x:Type dui:SelectableDateViewModel}">
+                <dui:DateView />
+            </DataTemplate>
+        </dui:SlidableContentLayout.ItemTemplate>
+    </dui:SlidableContentLayout>
+</dui:ContentPage>

--- a/src/app/Playground/EirikSamples/EirikPage.xaml.cs
+++ b/src/app/Playground/EirikSamples/EirikPage.xaml.cs
@@ -1,0 +1,17 @@
+using DIPS.Mobile.UI.Components.Slidable;
+
+namespace Playground.EirikSamples;
+
+public partial class EirikPage
+{
+    public EirikPage()
+    {
+        InitializeComponent();
+    }
+
+    private void SlidableContentLayout_OnContentTapped(object sender, ContentTappedEventArgs e)
+    {
+        Console.WriteLine(e.Index);
+        SlidableContentLayout.ScrollTo(e.Index);
+    }
+}

--- a/src/app/Playground/EirikSamples/EirikPageViewModel.cs
+++ b/src/app/Playground/EirikSamples/EirikPageViewModel.cs
@@ -1,0 +1,33 @@
+using DIPS.Mobile.UI.Components.Pickers.DatePicker.HorizontalInLine;
+using DIPS.Mobile.UI.Components.Slidable;
+using DIPS.Mobile.UI.MVVM;
+
+namespace Playground.EirikSamples;
+
+public class EirikPageViewModel : ViewModel
+{
+    private readonly List<SelectableDateViewModel> m_dateViewModels =
+    [
+        new SelectableDateViewModel(DateTime.Now - new TimeSpan(4, 0, 0, 0)),
+        new SelectableDateViewModel(DateTime.Now - new TimeSpan(3, 0, 0, 0)),
+        new SelectableDateViewModel(DateTime.Now - new TimeSpan(2, 0, 0, 0)),
+        new SelectableDateViewModel(DateTime.Now - new TimeSpan(1, 0, 0, 0))
+    ];
+
+    private SliderConfig m_config = new(-3, 0);
+    private SlidableProperties m_properties = new(0);
+
+    public Func<int, SelectableDateViewModel> DateViewModelFactory => i => m_dateViewModels[Math.Abs(i)];
+
+    public SliderConfig Config
+    {
+        get => m_config;
+        set => RaiseWhenSet(ref m_config, value);
+    }
+
+    public SlidableProperties Properties
+    {
+        get => m_properties;
+        set => RaiseWhenSet(ref m_properties, value);
+    }
+}

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-ios;</TargetFrameworks>
+        <TargetFrameworks>net8.0-ios;net8.0-android;</TargetFrameworks>
 
         <OutputType>Exe</OutputType>
         <RootNamespace>Playground</RootNamespace>

--- a/src/library/DIPS.Mobile.UI/Components/Slidable/SlidableLayout.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Slidable/SlidableLayout.cs
@@ -43,9 +43,9 @@ namespace DIPS.Mobile.UI.Components.Slidable
             var point = eventArgs.GetPosition((Element)sender);
             if (point.HasValue)
             {
-                var nonRoundedIndex = Math.Max(Config.MinValue, Math.Min(Config.MaxValue, CalculateIndex(point.Value.X)));
+                var nonRoundedIndex = CalculateIndex(point.Value.X);
                 var relativeIndex = GetIndexFromValue(nonRoundedIndex);
-                var currentIndex = (int)SlideProperties.Position + relativeIndex;
+                var currentIndex = Math.Clamp((int)SlideProperties.Position + relativeIndex, Config.MinValue, Config.MaxValue);
                 Tapped?.Invoke(this, new TappedEventArgs(currentIndex));
                 OnTapped(currentIndex);
             }


### PR DESCRIPTION
### Description of Change

Fixed a bug where you couldn't tap the next element (only the previous) in a slidable layout

### Todos
- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility