### PR TITLE
Task/hmo fixed buttoni os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [22.2.1]
+- [Button][iOS] Made sure setting size from the library only happens when the button has a text and a an image.
+
 ## [22.2.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/iOS/ButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/iOS/ButtonHandler.cs
@@ -31,12 +31,18 @@ public partial class ButtonHandler : Microsoft.Maui.Handlers.ButtonHandler
         {
             return desiredSize;
         }
-        if (uiButton.ImageView?.Image is not null &&
-            string.IsNullOrEmpty(uiButton.CurrentTitle)) //This is a ImageButton, the normal logic should run for a ImageButton
+
+        if (uiButton.ImageView.Image is not null && string.IsNullOrEmpty(uiButton.CurrentTitle)) //A button with only a image
         {
             return desiredSize;
         }
         
+        if (uiButton.ImageView.Image is null && !string.IsNullOrEmpty(uiButton.CurrentTitle)) //A button with only a title
+        {
+            return desiredSize;
+        }
+        
+        //A button with both title and image, which has the bug
         return new Size(uiButton.IntrinsicContentSize.Width, uiButton.IntrinsicContentSize.Height);
     }
 


### PR DESCRIPTION
### Description of Change

- [Button][iOS] Made sure setting size from the library only happens when the button has a text and a an image.

### Todos
- [X] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->