### PR TITLE
DateViewBase and its inheritors now changes its view based on the device orientation, bugfixes in HorizontalInlineDatePicker  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [22.3.1] 
+- Fixed an issue where HorizontalInlineDatePicker took too much height when in landscape mode.
+- Fixed an issue where HorizontalInlineDatePicker would instantly snap to dates when scrolling.
+- HorizontalInlineDatePicker now changes its view based on its orientation.
+
 ## [22.3.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [22.3.1] 
 - Fixed an issue where HorizontalInlineDatePicker took too much height when in landscape mode.
 - Fixed an issue where HorizontalInlineDatePicker would instantly snap to dates when scrolling.
-- HorizontalInlineDatePicker now changes its view based on its orientation.
+- DateView now changes its view based on its orientation.
 
 ## [22.3.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0-android</TargetFramework>
+        <TargetFramework>net8.0-ios</TargetFramework>
 
         <OutputType>Exe</OutputType>
         <RootNamespace>Playground</RootNamespace>

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-ios;net8.0-android;</TargetFrameworks>
+        <TargetFramework>net8.0-android</TargetFramework>
 
         <OutputType>Exe</OutputType>
         <RootNamespace>Playground</RootNamespace>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -13,6 +13,6 @@
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
    
-    <dui:HorizontalInlineDatePicker />
-
+    <dui:HorizontalInlineDatePicker  />
+    
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -12,34 +12,7 @@
     <dui:ContentPage.BindingContext>
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
-    <VerticalStackLayout>
-<ScrollView Orientation="Horizontal">
-    <dui:HorizontalStackLayout BindableLayout.ItemsSource="{Binding TestStrings}"
-                               Spacing="5"
-                               x:Name="HorizontalStackLayout">
-        
-        <BindableLayout.ItemTemplate>
-            <DataTemplate>
-                <!--<Grid>
-                <dui:Button ImageSource="{dui:Icons arrow_back_line}"
-                            Text="{Binding . }"
-                            ImagePlacement="Right" />
-                </Grid>-->
-                <Grid>
-                <dui:Chip IsCloseable="True"
-                          Title="{Binding .}"
-                          VerticalOptions="Center"
-                          CloseCommand="{Binding Source={RelativeSource AncestorType={x:Type vetleSamples:VetlePageViewModel}}, Path=RemoveStringCommand}"
-                          CloseCommandParameter="{Binding .}"/>
-                </Grid>
-            </DataTemplate>
-            
-        </BindableLayout.ItemTemplate>
-
-    </dui:HorizontalStackLayout>
-</ScrollView>
-        <dui:Button Text="Update"
-                    Clicked="Button_OnClicked"></dui:Button>
-    </VerticalStackLayout>
+   
+    <dui:HorizontalInlineDatePicker />
 
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml.cs
@@ -41,8 +41,5 @@ public partial class VetlePage
         ShouldHideFloatingNavigationMenuButton = e.Value;
     }
 
-    private void Button_OnClicked(object sender, EventArgs e)
-    {
-        HorizontalStackLayout.InvalidateMeasureNonVirtual(InvalidationTrigger.HorizontalOptionsChanged);
-    }
+    
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/HorizontalInLine/DateTimeView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/HorizontalInLine/DateTimeView.cs
@@ -20,6 +20,13 @@ public class DateTimeView : DateViewBase
         timeOfDayLabel.SetBinding(Microsoft.Maui.Controls.Label.TextProperty,
             new Binding(nameof(SelectableDateViewModel.FormattedTime)));
 
-        this.Add(timeOfDayLabel, 0, 2);
+        if (DeviceDisplay.MainDisplayInfo.Orientation == DisplayOrientation.Portrait)
+        {
+            this.Add(timeOfDayLabel, 0, 2);
+        }
+        else
+        {
+            this.Add(timeOfDayLabel, 2);
+        }
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/HorizontalInLine/DateView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/HorizontalInLine/DateView.cs
@@ -23,6 +23,13 @@ public class DateView : DateViewBase
         dayNameLabel.SetBinding(Microsoft.Maui.Controls.Label.TextProperty,
             new Binding(nameof(SelectableDateViewModel.DayName)));
 
-        this.Add(dayNameLabel, 0, 2);
+        if (DeviceDisplay.MainDisplayInfo.Orientation == DisplayOrientation.Portrait)
+        {
+            this.Add(dayNameLabel, 0, 2);
+        }
+        else
+        {
+            this.Add(dayNameLabel, 2);
+        }
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/HorizontalInLine/DateViewBase.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/HorizontalInLine/DateViewBase.cs
@@ -17,13 +17,8 @@ public abstract class DateViewBase : Grid
         Loaded += CreateView;
     }
 
-    private void CreateView(object? sender, EventArgs e)
+    private void CreateView(object? sender, EventArgs eventArgs)
     {
-        RowSpacing = Sizes.GetSize(SizeName.size_2);
-        RowDefinitions =
-            new RowDefinitionCollection(new RowDefinition(GridLength.Auto), new RowDefinition(GridLength.Auto),
-                new RowDefinition(GridLength.Auto));
-
         SetBinding(BackgroundColorProperty,
             new Binding(nameof(SelectableDateViewModel.IsSelected),
                 converter: new BoolToObjectConverter()
@@ -32,7 +27,25 @@ public abstract class DateViewBase : Grid
                     FalseObject = Colors.GetColor(ColorName.color_neutral_05)
                 }));
         
+        if (DeviceDisplay.MainDisplayInfo.Orientation == DisplayOrientation.Portrait)
+        {
+            CreatePortraitView();
+        }
+        else
+        {
+            CreateLandscapeView();
+        }
         
+        Loaded -= CreateView;
+    }
+    
+    private void CreatePortraitView()
+    {
+        RowSpacing = Sizes.GetSize(SizeName.size_2);
+        RowDefinitions =
+            new RowDefinitionCollection(new RowDefinition(GridLength.Auto), new RowDefinition(GridLength.Auto),
+                new RowDefinition(GridLength.Auto));
+
         //Month header
         this.Add(CreateMonthHeaderContentControl(), 0, 0);
 
@@ -52,7 +65,32 @@ public abstract class DateViewBase : Grid
 
         OnViewCreated();
         
-        Loaded -= CreateView;
+    }
+
+    private void CreateLandscapeView()
+    {
+        ColumnDefinitions =
+            new ColumnDefinitionCollection(new ColumnDefinition(new GridLength(2, GridUnitType.Star)), 
+                new ColumnDefinition(GridLength.Star), new ColumnDefinition(new GridLength(2, GridUnitType.Star)));
+        
+        //Month header
+        this.Add(CreateMonthHeaderContentControl());
+        
+        //Day number label
+        var dayLabel = CreateLabel(new Label());
+        dayLabel.SetBinding(Microsoft.Maui.Controls.Label.TextColorProperty,
+            new Binding(nameof(SelectableDateViewModel.IsSelected),
+                converter: new BoolToObjectConverter()
+                {
+                    TrueObject = Colors.GetColor(ColorName.color_system_white),
+                    FalseObject = Colors.GetColor(ColorName.color_system_black),
+                }));
+        dayLabel.SetBinding(Microsoft.Maui.Controls.Label.TextProperty,
+            new Binding(nameof(SelectableDateViewModel.Day)));
+
+        this.Add(dayLabel, 1, 0);
+
+        OnViewCreated();
     }
     
     protected virtual void OnViewCreated() {}
@@ -61,7 +99,7 @@ public abstract class DateViewBase : Grid
     {
         var contentControl = new ContentControl();
         contentControl.Padding = new Thickness(Sizes.GetSize(SizeName.size_2));
-        
+
         contentControl.SetBinding(BackgroundColorProperty,
             new Binding(nameof(SelectableDateViewModel.IsSelected),
                 converter: new BoolToObjectConverter()
@@ -69,6 +107,7 @@ public abstract class DateViewBase : Grid
                     TrueObject = Colors.GetColor(ColorName.color_secondary_90),
                     FalseObject = Colors.GetColor(ColorName.color_neutral_05)
                 }));
+        
         contentControl.SetBinding(ContentControl.SelectorItemProperty,
             new Binding(nameof(SelectableDateViewModel.IsCurrentYear)));
         contentControl.TemplateSelector = new BooleanDataTemplateSelector()
@@ -80,6 +119,18 @@ public abstract class DateViewBase : Grid
                 monthLabel.TextTransform = TextTransform.Uppercase;
                 monthLabel.SetBinding(Microsoft.Maui.Controls.Label.TextProperty,
                     new Binding(nameof(SelectableDateViewModel.MonthName)));
+
+                if (DeviceDisplay.MainDisplayInfo.Orientation == DisplayOrientation.Landscape)
+                {
+                    monthLabel.SetBinding(Microsoft.Maui.Controls.Label.TextColorProperty,
+                        new Binding(nameof(SelectableDateViewModel.IsSelected),
+                            converter: new BoolToObjectConverter()
+                            {
+                                TrueObject = Colors.GetColor(ColorName.color_system_white),
+                                FalseObject = Colors.GetColor(ColorName.color_system_black),
+                            }));
+                }
+
                 return monthLabel;
             }),
             FalseTemplate = new DataTemplate(() =>
@@ -96,6 +147,18 @@ public abstract class DateViewBase : Grid
                     new Binding(nameof(SelectableDateViewModel.YearName)));
                 monthAndYearLabel.FormattedText =
                     new FormattedString() {Spans = {monthNameSpan, blankSpan, yearNameSpan}};
+
+                if (DeviceDisplay.MainDisplayInfo.Orientation == DisplayOrientation.Landscape)
+                {
+                    monthAndYearLabel.SetBinding(Microsoft.Maui.Controls.Label.TextColorProperty,
+                        new Binding(nameof(SelectableDateViewModel.IsSelected),
+                            converter: new BoolToObjectConverter()
+                            {
+                                TrueObject = Colors.GetColor(ColorName.color_system_white),
+                                FalseObject = Colors.GetColor(ColorName.color_system_black),
+                            }));
+                }
+
                 return monthAndYearLabel;
             })
         };

--- a/src/library/DIPS.Mobile.UI/Components/Slidable/SlidableContentLayout.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Slidable/SlidableContentLayout.cs
@@ -31,7 +31,7 @@ namespace DIPS.Mobile.UI.Components.Slidable
         /// <summary>
         ///     Signals to the control that its content should be redrawn.
         /// </summary>
-        public void Redraw()
+        public override void Redraw()
         {
             ResetAll();
         }

--- a/src/library/DIPS.Mobile.UI/Components/Slidable/SlidableLayout.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Slidable/SlidableLayout.Properties.cs
@@ -2,7 +2,7 @@ using System.Windows.Input;
 
 namespace DIPS.Mobile.UI.Components.Slidable;
 
-public partial class SlidableLayout
+public abstract partial class SlidableLayout
 {
      /// <summary>
         /// <see cref="Config"/>


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->