### PR TITLE
Fixed an issue where Label would crash application if Text was not set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [23.1.2]
+- [Label] Fixed an issue where Label would crash application if Text was not set.
+
 ## [23.1.1]
 - [StateView] Fixed an issue where the starting state was not set
 - [StateView] Fixed an issue where the default views would always reference to the same object in memory, even though user has navigated back from the page and navigated in again

--- a/src/library/DIPS.Mobile.UI/Components/Labels/Android/MauiTextView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Labels/Android/MauiTextView.cs
@@ -77,7 +77,11 @@ public class MauiTextView : Microsoft.Maui.Platform.MauiTextView
     public bool CheckIfTruncated(string? stringToCheck = null)
     {
         var text = stringToCheck ?? GetTextFromLabel();
-
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+        
         var tempPaint = new TextPaint(Paint)
         {
             TextSize = TextSize,
@@ -97,7 +101,7 @@ public class MauiTextView : Microsoft.Maui.Platform.MauiTextView
         return staticLayout.LineCount > m_label.MaxLines;
     }
     
-    private string GetTextFromLabel()
+    private string? GetTextFromLabel()
     {
         if (!string.IsNullOrEmpty(m_label.Text))
             return m_label.Text;


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->