### PR TITLE
Fixed an issue where title and description on EmptyView and ErrorView were not horizontally aligned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [23.2.2]
+- asd
+
 ## [23.2.1]
 - [Label] Fixed an issue where label would not be shown if text was set after view was loaded.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [23.2.2]
-- asd
+- Fixed an issue where title and description on EmptyView and ErrorView were not horizontally aligned
 
 ## [23.2.1]
 - [Label] Fixed an issue where label would not be shown if text was set after view was loaded.

--- a/src/library/DIPS.Mobile.UI/Components/Loading/StateView/EmptyView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Loading/StateView/EmptyView.cs
@@ -28,6 +28,7 @@ internal class EmptyView : VerticalStackLayout
         {
             VerticalOptions = LayoutOptions.Center,
             HorizontalOptions = LayoutOptions.Center,
+            HorizontalTextAlignment = TextAlignment.Center,
             Margin = new Thickness(0, 0, 0, Sizes.GetSize(SizeName.size_3)),
             TextColor = Colors.GetColor(ColorName.color_neutral_80),
             Style = Styles.GetLabelStyle(LabelStyle.UI300)
@@ -38,7 +39,8 @@ internal class EmptyView : VerticalStackLayout
         {
             TextColor = Colors.GetColor(ColorName.color_neutral_70),
             VerticalOptions = LayoutOptions.Center,
-            HorizontalOptions = LayoutOptions.Center
+            HorizontalOptions = LayoutOptions.Center,
+            HorizontalTextAlignment = TextAlignment.Center
         };
         descriptionLabel.SetBinding(Microsoft.Maui.Controls.Label.TextProperty, new Binding(nameof(EmptyViewModel.Description)));
         

--- a/src/library/DIPS.Mobile.UI/Components/Loading/StateView/ErrorView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Loading/StateView/ErrorView.cs
@@ -32,6 +32,7 @@ internal class ErrorView : RefreshView
         {
             VerticalOptions = LayoutOptions.Center,
             HorizontalOptions = LayoutOptions.Center,
+            HorizontalTextAlignment = TextAlignment.Center,
             Margin = new Thickness(0, 0, 0, Sizes.GetSize(SizeName.size_3)),
             TextColor = Colors.GetColor(ColorName.color_neutral_80),
             Style = Styles.GetLabelStyle(LabelStyle.UI300)
@@ -44,6 +45,7 @@ internal class ErrorView : RefreshView
             TextColor = Colors.GetColor(ColorName.color_neutral_70),
             VerticalOptions = LayoutOptions.Center,
             HorizontalOptions = LayoutOptions.Center,
+            HorizontalTextAlignment = TextAlignment.Center
         };
         descriptionLabel.SetBinding(Label.TextProperty, new Binding(nameof(ErrorViewModel.Description)));
 


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->