### PR TITLE
[StateView] Fixed an issue where RefreshCommand would get executed several times when consumer enabling RefreshView for default implementations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [24.0.3]
-- Test
+- [StateView] Fixed an issue where RefreshCommand would get executed several times when consumer enabling RefreshView for default implementations.
 
 ## [24.0.2]
 - Reset before memory leak.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [24.0.3]
+- Test
+
 ## [24.0.2]
 - Reset before memory leak.
 

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0-ios</TargetFramework>
+        <TargetFramework>net8.0-android</TargetFramework>
 
         <OutputType>Exe</OutputType>
         <RootNamespace>Playground</RootNamespace>


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->