### PR TITLE
Added profiling for loading pages

### DIFF
--- a/src/app/Components/MauiProgram.cs
+++ b/src/app/Components/MauiProgram.cs
@@ -36,6 +36,7 @@ public static class MauiProgram
 #endif
 #if DEBUG
         builder.Logging.AddDebug();
+        DUI.IsDebug = true;
 #endif
         return builder.Build();
     }

--- a/src/app/MemoryLeakTests/MauiProgram.cs
+++ b/src/app/MemoryLeakTests/MauiProgram.cs
@@ -1,4 +1,5 @@
 ﻿using DIPS.Mobile.UI.API.Builder;
+using DIPS.Mobile.UI.API.Library;
 using Microsoft.Extensions.Logging;
 
 namespace MemoryLeakTests;
@@ -19,6 +20,7 @@ public static class MauiProgram
 
 #if DEBUG
         builder.Logging.AddDebug();
+        DUI.IsDebug = true;
 #endif
         //Handlers
         builder.ConfigureMauiHandlers(handlers =>

--- a/src/app/MemoryLeakTests/Tests/ListItemPage.xaml
+++ b/src/app/MemoryLeakTests/Tests/ListItemPage.xaml
@@ -2,12 +2,13 @@
     version="1.0"
     encoding="utf-8"?>
 
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:dui="http://dips.com/mobile.ui"
              xmlns:tests="clr-namespace:MemoryLeakTests.Tests"
              x:Class="MemoryLeakTests.Tests.ListItemPage"
              Padding="10"
+             ShouldLogLoadingTime="True"
              >
     <ContentPage.BindingContext>
         <tests:TestPageViewModel />
@@ -15,4 +16,4 @@
 
     <dui:ListItem Title="{Binding Title}"
                   Command="{Binding Command}" />
-</ContentPage>
+</dui:ContentPage>

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -12,16 +12,17 @@
     <dui:ContentPage.BindingContext>
         <håvardSamples:HåvardPageViewModel />
     </dui:ContentPage.BindingContext>
-
-    <Grid RowDefinitions="Auto, *">
-        <BoxView Grid.Row="0"
-                 WidthRequest="100"
-                 HeightRequest="40"
-                 BackgroundColor="Blue"
-                 HorizontalOptions="Center"
-                 VerticalOptions="Start" />
-        <dui:Button Grid.Row="1"
-                    Text="Tap me"
-                    Clicked="Button_OnClicked" />
-    </Grid>
+    <dui:Label
+        Grid.Row="1"
+        Rotation="-45"
+        MaxLines="1"
+        Style="{dui:Styles Label=Header800}"
+        InputTransparent="True"
+        VerticalOptions="Center"
+        HorizontalOptions="Center"
+        Opacity="0.1"
+        Scale="1.25"
+        BackgroundColor="Red"
+        Text="Ikke godkjent"
+        TextColor="{dui:Colors color_system_black}"/>
 </dui:ContentPage>

--- a/src/app/Playground/MauiProgram.cs
+++ b/src/app/Playground/MauiProgram.cs
@@ -24,6 +24,7 @@ public static class MauiProgram
         
 #if DEBUG
         builder.Logging.AddDebug();
+        DUI.IsDebug = true;
 #endif
 
         return builder.Build();

--- a/src/library/DIPS.Mobile.UI/API/Library/DUI.cs
+++ b/src/library/DIPS.Mobile.UI/API/Library/DUI.cs
@@ -10,6 +10,8 @@ namespace DIPS.Mobile.UI.API.Library
         {
             PlatformInit();
         }
+        
+        public static bool IsDebug { get; set; }
 
         private static partial void PlatformInit();
         

--- a/src/library/DIPS.Mobile.UI/Components/Pages/ContentPage.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pages/ContentPage.Properties.cs
@@ -1,4 +1,5 @@
 using System.Windows.Input;
+using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.Components.Saving.SaveView;
 
 namespace DIPS.Mobile.UI.Components.Pages;
@@ -29,13 +30,19 @@ public partial class ContentPage
     /// <summary>
     /// Determines if the content page should force garbage collection and log it to the console when navigated to.
     /// </summary>
-    /// <remarks>This will only run when debugging.</remarks>
+    /// <remarks>This will only run when <see cref="DUI.IsDebug"/>.</remarks>
     public bool ShouldGarbageCollectAndLogWhenNavigatedTo { get; set; }
     
     /// <summary>
     /// Will log to Console when the finalizer has run. This happens when the object was garbage collected.
     /// </summary>
-    /// <remarks>This will only run in Debug</remarks>
+    /// <remarks>This will only run when <see cref="DUI.IsDebug"/>.</remarks>
     public bool ShouldLogWhenGarbageCollected { get; set; }
+
+    /// <summary>
+    /// Will log to the Console when the OnLoaded event occured. This can be useful to profile changes to the page that affects the time it takes for people to see the page.
+    /// </summary>
+    /// <remarks>This will only run when <see cref="DUI.IsDebug"/>.</remarks>
+    public bool ShouldLogLoadingTime { get; set; }
 
 }   

--- a/src/library/DIPS.Mobile.UI/Components/Pages/ContentPage.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pages/ContentPage.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton;
 using DIPS.Mobile.UI.MemoryManagement;
 using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
@@ -9,9 +11,16 @@ namespace DIPS.Mobile.UI.Components.Pages
         public static readonly ColorName BackgroundColorName = ColorName.color_neutral_10;
 
         private CancellationTokenSource? m_garbageCollectionCts;
+        private readonly Stopwatch m_loadedTimer;
 
         public ContentPage()
         {
+            if (DUI.IsDebug) //Always start the time, as checking for ShouldLogLoadingTime wont work in the constructor
+            {
+                m_loadedTimer = new Stopwatch();
+                m_loadedTimer.Start();    
+            }
+            
             if (Application.Current == null)
             {
                 return;
@@ -20,16 +29,33 @@ namespace DIPS.Mobile.UI.Components.Pages
             SetColors(Application.Current.RequestedTheme);
             Application.Current.RequestedThemeChanged +=
                 OnRequestedThemeChanged; //Can not use AppThemeBindings because that makes the navigation page bar background flash on Android, so we listen to changes and set the color our self
+            
+            Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object? sender, EventArgs e)
+        {
+            if (DUI.IsDebug)
+            {
+                m_loadedTimer.Stop();
+                if (ShouldLogLoadingTime)
+                {
+                    Console.WriteLine($@"⏰ Time taken to '{GetType().Namespace}': {m_loadedTimer.Elapsed:m\:ss\.fff}");    
+                }    
+            }
         }
 
         ~ContentPage()
         {
-#if DEBUG
+            if (!DUI.IsDebug)
+            {
+                return;
+            }
+
             if (ShouldGarbageCollectAndLogWhenNavigatedTo || ShouldLogWhenGarbageCollected)
             {
                 GarbageCollection.Print($"Called finalizer an instance of {GetType().Name}");
-            }   
-#endif
+            }
         }
 
         protected override void OnAppearing()
@@ -44,8 +70,8 @@ namespace DIPS.Mobile.UI.Components.Pages
         protected override void OnNavigatedTo(NavigatedToEventArgs args)
         {
             base.OnNavigatedTo(args);
-#if DEBUG
-            if (ShouldGarbageCollectAndLogWhenNavigatedTo)
+            
+            if (DUI.IsDebug && ShouldGarbageCollectAndLogWhenNavigatedTo)
             {
                 m_garbageCollectionCts = new CancellationTokenSource();
                 Task.Run(async () =>
@@ -68,18 +94,15 @@ namespace DIPS.Mobile.UI.Components.Pages
                     }
                 });
             }
-#endif
         }
 
         protected override void OnNavigatingFrom(NavigatingFromEventArgs args)
         {
-#if DEBUG
-            if (ShouldGarbageCollectAndLogWhenNavigatedTo)
+            if (DUI.IsDebug && ShouldGarbageCollectAndLogWhenNavigatedTo)
             {
                 m_garbageCollectionCts?.Dispose();
                 m_garbageCollectionCts = null;
             }
-#endif
             base.OnNavigatingFrom(args);
         }
 

--- a/src/library/DIPS.Mobile.UI/MVVM/ViewModel.cs
+++ b/src/library/DIPS.Mobile.UI/MVVM/ViewModel.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.MemoryManagement;
 
 namespace DIPS.Mobile.UI.MVVM;
@@ -11,18 +12,17 @@ public abstract class ViewModel : INotifyPropertyChanged
 {
     ~ViewModel()
     {
-#if DEBUG
+        if (!DUI.IsDebug) return;
         if (ShouldLogWhenGarbageCollected)
         {
             GarbageCollection.Print($"Called finalizer an instance of {GetType().Name}");
         }
-#endif
     }
 
     /// <summary>
     /// Will log to Console when the finalizer has run. This happens when the object was garbage collected.
     /// </summary>
-    /// <remarks>This will only run in Debug</remarks>
+    /// <remarks>This will only run in <see cref="DUI.IsDebug"/></remarks>
     public bool ShouldLogWhenGarbageCollected { get; set; }
 
     /// <summary>

--- a/src/library/DIPS.Mobile.UI/MemoryManagement/GCCollectionMonitor.cs
+++ b/src/library/DIPS.Mobile.UI/MemoryManagement/GCCollectionMonitor.cs
@@ -1,4 +1,6 @@
-﻿namespace DIPS.Mobile.UI.MemoryManagement;
+﻿using DIPS.Mobile.UI.API.Library;
+
+namespace DIPS.Mobile.UI.MemoryManagement;
 
 /// <summary>
 /// Use this class to monitor an object at a point where it should be garbage collected.
@@ -14,6 +16,7 @@ public class GCCollectionMonitor
     /// <param name="target"></param>
     public void Observe(object target)
     {
+        if (!DUI.IsDebug) return;
         var targetType = target.GetType().Name;
         m_references.Add(new Tuple<string, WeakReference<object>>(targetType, new WeakReference<object>(target)));
     }
@@ -29,7 +32,7 @@ public class GCCollectionMonitor
     /// </remarks>
     public async void CheckAliveness(bool shouldPrintTotalMemory = true)
     {
-#if DEBUG
+        if (!DUI.IsDebug) return;
 
         const int maxCollections = 5;
         var currentCollection = 0;
@@ -76,6 +79,5 @@ public class GCCollectionMonitor
                 }    
             }
         }
-#endif
     }
 }

--- a/src/library/DIPS.Mobile.UI/MemoryManagement/GarbageCollection.cs
+++ b/src/library/DIPS.Mobile.UI/MemoryManagement/GarbageCollection.cs
@@ -1,3 +1,5 @@
+using DIPS.Mobile.UI.API.Library;
+
 namespace DIPS.Mobile.UI.MemoryManagement;
 
 /// <summary>
@@ -12,6 +14,7 @@ public static class GarbageCollection
     /// <param name="message"></param>
     public static void Print(string message)
     {
+        if (!DUI.IsDebug) return;
         Console.WriteLine($@"{nameof(GarbageCollection)}: {message}");
     }
 
@@ -21,10 +24,9 @@ public static class GarbageCollection
     /// <remarks>This will only run in Debug as its recommended.</remarks>
     public static void CollectAndWaitForPendingFinalizers()
     {
-#if DEBUG
+        if (!DUI.IsDebug) return;
         Print("Force Collect");
         GC.Collect();
         GC.WaitForPendingFinalizers();
-#endif
     }
 }


### PR DESCRIPTION
made sure we have a DUI.IsDebug property that consumers needs to set in #debug


### Description of Change

- Added profiling for loading pages
- Added a `DUI.IsDebug` property that needs to be set when #debug for consumers.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->