### PR TITLE
Set default `MaxLines` and `LineBreakMode` for subtitle on `ListItem`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [24.5.2]
+- Set default `MaxLines` and `LineBreakMode` for subtitle on `ListItem`.
+
 ## [24.5.1]
 - [Android] Added null check to `CornerRadius` effect. 
 

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Subtitle/SubtitleOptions.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Subtitle/SubtitleOptions.Properties.cs
@@ -62,12 +62,12 @@ public partial class SubtitleOptions
     public static readonly BindableProperty LineBreakModeProperty = BindableProperty.Create(
         nameof(LineBreakMode),
         typeof(LineBreakMode),
-        typeof(SubtitleOptions));
+        typeof(SubtitleOptions), defaultValue: Label.LineBreakModeProperty.DefaultValue);
     
     public static readonly BindableProperty MaxLinesProperty = BindableProperty.Create(
         nameof(MaxLines),
         typeof(int),
-        typeof(SubtitleOptions));
+        typeof(SubtitleOptions), defaultValue: Label.MaxLinesProperty.DefaultValue);
     
     public static readonly BindableProperty FontAttributesProperty = BindableProperty.Create(
         nameof(FontAttributes),


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->