### PR TITLE
Fixed an issue where the label inside `SaveView` would take up space when text empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [24.6.1]
+- Fixed an issue where the label inside `SaveView` would take up space when text empty.
+
 ## [24.6.0]
 - [GarbageCollecting] Added `ShouldGarbageCollectPreviousPage` to Shell for a simple way of monitoring the previous page.
 

--- a/src/app/Playground/MainPage.xaml
+++ b/src/app/Playground/MainPage.xaml
@@ -8,14 +8,14 @@
                  x:Class="Playground.MainPage"
                  Title="Welcome to Playground">
     <VerticalStackLayout>
-        <!-- <dui:NavigationListItem Title="Vetle" -->
-        <!--                         Tapped="GoToVetle" /> -->
-        <!-- <dui:NavigationListItem Title="Håvard" -->
-        <!--                         Tapped="GoToHåvard" /> -->
-        <!-- <dui:NavigationListItem Title="Sander" -->
-        <!--                         Tapped="GoToSander" /> -->
-        <!-- <dui:NavigationListItem Title="Eirik" -->
-        <!--                         Tapped="GoToEirik" /> -->
+        <dui:NavigationListItem Title="Vetle"
+                                Tapped="GoToVetle" />
+        <dui:NavigationListItem Title="Håvard" 
+                                 Tapped="GoToHåvard" />
+        <dui:NavigationListItem Title="Sander" 
+                                 Tapped="GoToSander" />
+        <dui:NavigationListItem Title="Eirik" 
+                            Tapped="GoToEirik" />
         <dui:Button Text="Tap me" Clicked="TapMe"/>
     </VerticalStackLayout>
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -15,6 +15,11 @@
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
    
-    <dui:Button Text="Hello" Command="{Binding Navigate}" />
+    <VerticalStackLayout>
+        <dui:SaveView BackgroundColor="Red"
+                      SavingCompletedText="S"/>
+        
+        <dui:Label Text="Signer her!" />
+    </VerticalStackLayout>
         
 </dui:ContentPage>

--- a/src/library/DIPS.Mobile.UI/Components/Saving/SaveView/SaveView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Saving/SaveView/SaveView.cs
@@ -58,11 +58,25 @@ public partial class SaveView : ContentView
     {
         base.OnHandlerChanged();
 
+        if (string.IsNullOrEmpty(SavingText))
+        {
+            m_stateLabel.IsVisible = false;
+            return;
+        }
+        
         m_stateLabel.Text = SavingText;
     }
 
     private void SetSavingCompletedText()
     {
+        if (string.IsNullOrEmpty(SavingCompletedText))
+        {
+            m_stateLabel.IsVisible = false;
+            return;
+        }
+
+        m_stateLabel.IsVisible = true;
+        
         m_stateLabel.Text = SavingCompletedText;
     }
 


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->