### PR TITLE
[Android] Fixed an issue where application would crash if the `ShellToolbarAppearanceTracker` disposed itself before setting appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [24.6.3]
+- [Android] Fixed an issue where application would crash if the `ShellToolbarAppearanceTracker` disposed itself before setting appearance
+
 ## [24.6.2]
 - [Android] Fixed an issue where toolbar items with icon added later to the page would be black.
 

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Android/ShellRenderer.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Android/ShellRenderer.cs
@@ -15,8 +15,8 @@ public class ShellRenderer : Microsoft.Maui.Controls.Handlers.Compatibility.Shel
 
 internal class CustomToolbarAppearanceTracker : ShellToolbarAppearanceTracker
 {
-    private Toolbar m_toolbar;
-    private ShellAppearance m_appearance;
+    private Toolbar? m_toolbar;
+    private ShellAppearance? m_appearance;
 
     public override void SetAppearance(Toolbar toolbar, IShellToolbarTracker toolbarTracker, ShellAppearance appearance)
     {
@@ -24,6 +24,7 @@ internal class CustomToolbarAppearanceTracker : ShellToolbarAppearanceTracker
 
         m_toolbar = toolbar;
         m_appearance = appearance;
+        
         toolbar.LayoutChange += ToolbarOnLayoutChange;  
         
         SetToolbarItemsTint();
@@ -31,11 +32,11 @@ internal class CustomToolbarAppearanceTracker : ShellToolbarAppearanceTracker
 
     private void SetToolbarItemsTint()
     {
-        for (var i = 0; i < m_toolbar.Menu?.Size(); i++)
+        for (var i = 0; i < m_toolbar?.Menu?.Size(); i++)
         {
             var toolbarItem = m_toolbar.Menu.GetItem(i);
             
-            toolbarItem!.SetIconTintList(m_appearance.ForegroundColor.ToDefaultColorStateList());
+            toolbarItem!.SetIconTintList(m_appearance?.ForegroundColor.ToDefaultColorStateList());
         }
     }
 
@@ -52,6 +53,9 @@ internal class CustomToolbarAppearanceTracker : ShellToolbarAppearanceTracker
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);
+        
+        if(m_toolbar is null)
+            return;
         
         m_toolbar.LayoutChange -= ToolbarOnLayoutChange;  
     }


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [X] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->