### PR TITLE
Make event for context menu item clicked be triggered before the command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [24.7.2]
+- Make event for context menu item clicked be triggered before the command is triggered
+
 ## [24.7.1]
 - [Android] Fixed an issue where application would crash if the `ShellToolbarAppearanceTracker` disposed itself before setting appearance
 

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
@@ -8,8 +8,8 @@ public partial class ContextMenuItem : Element, IContextMenuItem
     internal void SendClicked(ContextMenu contextMenu)
     {
         contextMenu.SendClicked(this);
+        ContextMenuEffect.ContextMenuItemClickedCallback?.Invoke(this);
         Command?.Execute(CommandParameter);
         DidClick?.Invoke(this, EventArgs.Empty);
-        ContextMenuEffect.ContextMenuItemClickedCallback?.Invoke(this);
     }
 }


### PR DESCRIPTION
### Description of Change

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility