### PR TITLE
[Image][iOS] Made sure we do nessesary null-check when the image is ready.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [24.13.1]
+- [Image][iOS] Made sure we do nessesary null-check when the image is ready to be tinted.
+
 ## [24.13.0]
 - [BarcodeScanner][Android] Added slider for zooming.
 

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -12,21 +12,9 @@
     <dui:ContentPage.BindingContext>
         <håvardSamples:HåvardPageViewModel />
     </dui:ContentPage.BindingContext>
-    <Grid RowDefinitions="Auto, *">
-        <Grid ColumnDefinitions="Auto, Auto"
-              HorizontalOptions="Center"
-              Grid.Row="0">
-            <dui:Button Clicked="StartScanning"
-                        Text="Start scanning"
-                        Grid.Column="0" />
-            <dui:Button Clicked="StopScanning"
-                        Text="Stop scanning"
-                        Grid.Column="1" />
-        </Grid>
-        <dui:Preview Grid.Row="1"
-                     Height="400"
-                     Width="200"
-                     x:Name="Preview" />
-
-    </Grid>
+    <VerticalStackLayout>
+        <dui:Switch x:Name="Switch"
+                    Toggled="Switch_OnToggled"/>
+        <ContentView x:Name="ContentView"/>
+    </VerticalStackLayout>
 </dui:ContentPage>

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml.cs
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
 using System.Windows.Input;
 using DIPS.Mobile.UI.API.Camera.BarcodeScanning;
+using DIPS.Mobile.UI.Resources.Icons;
+using Image = DIPS.Mobile.UI.Components.Images.Image.Image;
 using PropertyChangingEventArgs = Microsoft.Maui.Controls.PropertyChangingEventArgs;
 
 namespace Playground.HåvardSamples;
@@ -11,6 +13,7 @@ public partial class HåvardPage
     {
         InitializeComponent();
         m_barcodeScanner = new BarcodeScanner();
+        m_image = new Image() {Source = Icons.GetIcon(IconName.document_fill)};
     }
 
     public ICommand NavigateCommand => new Command<string>(async s =>
@@ -61,6 +64,7 @@ public partial class HåvardPage
         typeof(HåvardPage));
 
     private readonly BarcodeScanner m_barcodeScanner;
+    private readonly Image m_image;
 
     public bool HideText
     {
@@ -68,25 +72,15 @@ public partial class HåvardPage
         set => SetValue(HideTextProperty, value);
     }
 
-    private async void StartScanning(object sender, EventArgs e)
+    private void Switch_OnToggled(object sender, ToggledEventArgs e)
     {
-        try
+        if (ContentView.Content is null)
         {
-            await m_barcodeScanner.Start(Preview, barcode =>
-            {
-                Application.Current.MainPage.DisplayAlert("Woah!", barcode.RawValue, "Ok");
-                m_barcodeScanner.Stop();
-            });
+            ContentView.Content = m_image;
         }
-        catch (Exception exception)
+        else
         {
-            Application.Current.MainPage.DisplayAlert("Failed, check console!", exception.Message, "Ok");
-            Console.WriteLine(exception);
+            ContentView.Content = null;
         }
-    }
-
-    private void StopScanning(object sender, EventArgs e)
-    {
-        m_barcodeScanner.Stop();
     }
 }

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -74,6 +74,7 @@
     
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.3" />
+        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.3" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0"/>
     </ItemGroup>
     

--- a/src/library/DIPS.Mobile.UI/Components/Images/Image/iOS/ImageHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Images/Image/iOS/ImageHandler.cs
@@ -5,10 +5,9 @@ namespace DIPS.Mobile.UI.Components.Images.Image;
 
 public partial class ImageHandler
 {
+
     private static async partial void TrySetTintColor(ImageHandler handler, Image image)
     {
-        if (image.TintColor == null) return;
-        
         var tries = 0;
         // Wait for Image to be set
         while (handler.PlatformView.Image is null)
@@ -19,6 +18,8 @@ public partial class ImageHandler
             await Task.Delay(1);
             tries++;
         }
+        
+        if (image.TintColor == null) return;
         handler.PlatformView.Image = handler.PlatformView.Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
         handler.PlatformView.TintColor = image.TintColor.ToPlatform();
     }


### PR DESCRIPTION
### Description of Change

- We've observed cases where the image is redrawn, and the tint is not completely cleared after some time. To guard against this crash we've moved the null-check when setting tint color to after the image is ready.

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->