### PR TITLE
Improved barcode scanner on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [24.13.2]
+- [BarcodeScanner][iOS] Improved rect of interest
+- [BarcodeScanner][iOS] Improved recommended zoom factor
+- [BarcodeScanner][iOS] Made sure the components app does not stop and start between results, this makes it more stable on iOS.
+
 ## [24.13.1]
 - [Image][iOS] Made sure we do nessesary null-check when the image is ready to be tinted.
 

--- a/src/app/Components/ComponentsSamples/BarcodeScanning/BarcodeScanningSample.xaml.cs
+++ b/src/app/Components/ComponentsSamples/BarcodeScanning/BarcodeScanningSample.xaml.cs
@@ -28,15 +28,22 @@ public partial class BarcodeScanningSample
 
     private void DidFindBarcode(Barcode barcode)
     {
+        if (m_barCodeResultBottomSheet != null)
+        {
+            if (m_barCodeResultBottomSheet.BindingContext is Barcode)
+            {
+                return;
+            }
+        }
         m_barCodeResultBottomSheet = new BarcodeScanningResultBottomSheet();
         m_barCodeResultBottomSheet.Closed += BottomSheetClosed;
-        m_barcodeScanner.Stop();
+        // m_barcodeScanner.Stop();
         m_barCodeResultBottomSheet.OpenWithBarCode(barcode);
     }
 
     private async void BottomSheetClosed(object? sender, EventArgs e)
     {
-        _ = Start();
+        // _ = Start();
         if (m_barCodeResultBottomSheet != null)
         {
             m_barCodeResultBottomSheet.Closed -= BottomSheetClosed;

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScanner.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScanner.cs
@@ -42,7 +42,6 @@ public partial class BarcodeScanner
 
     internal void InvokeBarcodeFound(Barcode barcode)
     {
-        VibrationService.SelectionChanged();
         m_didFindBarcode?.Invoke(barcode);
     }
 


### PR DESCRIPTION
### Description of Change
We've noticed that the barcode scanner for iOS was unstable after a random amount of time when using it. This seem to be solved by not starting and stopping the capturing in between scans. This is not something the component is doing internally, but something the consumer is doing. To test this, the components app are not stopping and starting the capture session in between results.

We've also improved the rect of interest using the same algorithm that Apple is using. This makes the recommended zoom factor act differently, which results in better stability the first time people starts the scanning.

- Improved rect of interest
- Imroved zoom factor
- Made sure the components app does not stop and start between results, this makes it more stable on iOS.

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->