### PR TITLE
Empty/Error view is now public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [26.1.0]
+- [EmptyView] is now public
+- [EmptyView] Added EmptyViewModel as a property
+- [ErrorView] is now public
+- [ErrorView] Added ErrorViewModel as a property
+
 ## [26.0.0]
 - [BreakingChange][Camera] Renamed `Preview` to `CameraPreview`
 

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -12,9 +12,17 @@
     <dui:ContentPage.BindingContext>
         <håvardSamples:HåvardPageViewModel />
     </dui:ContentPage.BindingContext>
-    <VerticalStackLayout>
-        <dui:Switch x:Name="Switch"
-                    Toggled="Switch_OnToggled"/>
-        <ContentView x:Name="ContentView"/>
-    </VerticalStackLayout>
+    <dui:VerticalStackLayout>
+        <dui:EmptyView>
+            <dui:EmptyView.EmptyViewModel>
+                <dui:EmptyViewModel Title="Ukjent strekkode"
+                                    Description="Strekkoden må inneholde fødselsnummer eller nettadresser"
+                                    Icon="{dui:Icons failure_fill}">
+                </dui:EmptyViewModel>
+            </dui:EmptyView.EmptyViewModel>
+        </dui:EmptyView>
+        <dui:Button Margin="{dui:Thickness Top=size_3}"
+                    Text="Se strekkode"
+                    Style="{dui:Styles Button=SecondarySmall}" />
+    </dui:VerticalStackLayout>
 </dui:ContentPage>

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml.cs
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml.cs
@@ -71,16 +71,4 @@ public partial class HåvardPage
         get => (bool)GetValue(HideTextProperty);
         set => SetValue(HideTextProperty, value);
     }
-
-    private void Switch_OnToggled(object sender, ToggledEventArgs e)
-    {
-        if (ContentView.Content is null)
-        {
-            ContentView.Content = m_image;
-        }
-        else
-        {
-            ContentView.Content = null;
-        }
-    }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Loading/StateView/EmptyView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Loading/StateView/EmptyView.cs
@@ -8,7 +8,7 @@ using VerticalStackLayout = DIPS.Mobile.UI.Components.Lists.VerticalStackLayout;
 
 namespace DIPS.Mobile.UI.Components.Loading.StateView;
 
-internal class EmptyView : ScrollView
+public class EmptyView : ScrollView
 {
     public EmptyView()
     {
@@ -50,4 +50,15 @@ internal class EmptyView : ScrollView
         Content = verticalStackLayout;
     }
 
+    public static readonly BindableProperty EmptyViewModelProperty = BindableProperty.Create(
+        nameof(EmptyViewModel),
+        typeof(EmptyViewModel),
+        typeof(EmptyView), propertyChanged:(bindable, _, _) =>
+            ((EmptyView)bindable).BindingContext = ((EmptyView)bindable).EmptyViewModel);
+
+    public EmptyViewModel EmptyViewModel
+    {
+        get => (EmptyViewModel)GetValue(EmptyViewModelProperty);
+        set => SetValue(EmptyViewModelProperty, value);
+    }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Loading/StateView/ErrorView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Loading/StateView/ErrorView.cs
@@ -6,11 +6,11 @@ using VerticalStackLayout = DIPS.Mobile.UI.Components.Lists.VerticalStackLayout;
 
 namespace DIPS.Mobile.UI.Components.Loading.StateView;
 
-internal class ErrorView : ScrollView
+public class ErrorView : ScrollView
 {
     public ErrorView()
     {
-        var verticalStackLayout = new VerticalStackLayout { Spacing = 0, VerticalOptions = LayoutOptions.Center };
+        var verticalStackLayout = new VerticalStackLayout {Spacing = 0, VerticalOptions = LayoutOptions.Center};
 
         var icon = new Images.Image.Image
         {
@@ -19,8 +19,9 @@ internal class ErrorView : ScrollView
             Margin = new Thickness(0, 0, 0, Sizes.GetSize(SizeName.size_4))
         };
         icon.SetBinding(Image.SourceProperty, new Binding(nameof(ErrorViewModel.Icon)));
-        icon.SetBinding(IsVisibleProperty, new Binding(nameof(ErrorViewModel.Icon), converter: new IsEmptyConverter{ Inverted = true }));
-        
+        icon.SetBinding(IsVisibleProperty,
+            new Binding(nameof(ErrorViewModel.Icon), converter: new IsEmptyConverter {Inverted = true}));
+
         var titleLabel = new Labels.Label
         {
             VerticalOptions = LayoutOptions.Center,
@@ -47,5 +48,18 @@ internal class ErrorView : ScrollView
         verticalStackLayout.Add(descriptionLabel);
 
         Content = verticalStackLayout;
+    }
+
+    public static readonly BindableProperty ErrorViewModelProperty = BindableProperty.Create(
+        nameof(ErrorViewModel),
+        typeof(ErrorViewModel),
+        typeof(ErrorView),
+        propertyChanged: (bindable, _, _) =>
+            ((ErrorView)bindable).BindingContext = ((ErrorView)bindable).ErrorViewModel);
+
+    public ErrorViewModel ErrorViewModel
+    {
+        get => (ErrorViewModel)GetValue(ErrorViewModelProperty);
+        set => SetValue(ErrorViewModelProperty, value);
     }
 }


### PR DESCRIPTION
### Description of Change

To reuse our empty and error views, we've now made sure they are public. Additionally we've added their ViewModels as its own bindable properties. This does not break the component as people can use `BindingContext` for the view models.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->