### PR TITLE
Added HeaderPositioning to dui:CollectionView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [26.6.0]
+- [CollectionView] Added `HeaderPositioning` to specify how the CollectionView header should position itself while scrolling
+
 ## [26.5.0]
 - [Tip] Added a new `TipService` to attach a tip to a view and show it.
 - [Tip] Added `TipCommand`to easily show a tip with your view.

--- a/src/app/Playground/EirikSamples/ScrollTest.xaml
+++ b/src/app/Playground/EirikSamples/ScrollTest.xaml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:dui="http://dips.com/mobile.ui"
+             xmlns:system="clr-namespace:System;assembly=mscorlib"
+             x:Class="Playground.EirikSamples.ScrollTest">
+    <dui:ContentPage.Resources>
+        <x:Array x:Key="StringArray"
+                 Type="{x:Type system:String}">
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+            <system:String>Hello</system:String>
+        </x:Array>
+    </dui:ContentPage.Resources>
+        <dui:CollectionView Grid.Row="0"
+                            ItemsSource="{StaticResource StringArray}"
+                            HeaderPositioning="PartialSticky">
+            <dui:CollectionView.Header>
+                <dui:ListItem Title="This is a header"
+                              Subtitle="Check it out!"
+                              HasBottomDivider="True"
+                              Tapped="Header_OnTapped">
+                </dui:ListItem>
+            </dui:CollectionView.Header>
+            <dui:CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="system:String">
+                    <dui:ListItem Title="{Binding}"
+                                  HasBottomDivider="True"/>
+                </DataTemplate>
+            </dui:CollectionView.ItemTemplate>
+        </dui:CollectionView>
+</dui:ContentPage>

--- a/src/app/Playground/EirikSamples/ScrollTest.xaml.cs
+++ b/src/app/Playground/EirikSamples/ScrollTest.xaml.cs
@@ -1,0 +1,16 @@
+using DIPS.Mobile.UI.Components.Alerting.Dialog;
+
+namespace Playground.EirikSamples;
+
+public partial class ScrollTest
+{
+    public ScrollTest()
+    {
+        InitializeComponent();
+    }
+    
+    private void Header_OnTapped(object sender, EventArgs e)
+    {
+        DialogService.ShowMessage("You tapped it!", "Great job!", "Thanks!");
+    }
+}

--- a/src/app/Playground/MainPage.xaml.cs
+++ b/src/app/Playground/MainPage.xaml.cs
@@ -29,7 +29,7 @@ public partial class MainPage
 
     private void GoToEirik(object sender, EventArgs e)
     {
-        Shell.Current.Navigation.PushAsync(new EirikPage());
+        Shell.Current.Navigation.PushAsync(new ScrollTest());
 
     }
 

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/CollectionView.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/CollectionView.Properties.cs
@@ -40,17 +40,17 @@ public partial class CollectionView
     /// <summary>
     /// Determines the positioning of the header, if the <see cref="CollectionView.Header"/> property is set.
     /// </summary>
-    public CollectionViewHeaderPositioning HeaderPositioning
+    public HeaderPositioning HeaderPositioning
     {
-        get => (CollectionViewHeaderPositioning)GetValue(HeaderPositioningProperty);
+        get => (HeaderPositioning)GetValue(HeaderPositioningProperty);
         set => SetValue(HeaderPositioningProperty, value);
     }
 
     public static readonly BindableProperty HeaderPositioningProperty = BindableProperty.Create(
         nameof(HeaderPositioning),
-        typeof(CollectionViewHeaderPositioning),
+        typeof(HeaderPositioning),
         typeof(CollectionView),
-        defaultValue: CollectionViewHeaderPositioning.Normal);
+        defaultValue: HeaderPositioning.Normal);
     
     public static readonly BindableProperty HasAdditionalSizeAtTheEndProperty = BindableProperty.Create(
         nameof(HasAdditionalSpaceAtTheEnd),
@@ -75,7 +75,7 @@ public partial class CollectionView
     }
 }
 
-public enum CollectionViewHeaderPositioning
+public enum HeaderPositioning
 {
     /// <summary>
     ///     The header scrolls along with the <see cref="CollectionView"/>'s content.

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/CollectionView.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/CollectionView.Properties.cs
@@ -37,6 +37,21 @@ public partial class CollectionView
         set => SetValue(ShouldBounceProperty, value);
     }
     
+    /// <summary>
+    /// Determines the positioning of the header, if the <see cref="CollectionView.Header"/> property is set.
+    /// </summary>
+    public CollectionViewHeaderPositioning HeaderPositioning
+    {
+        get => (CollectionViewHeaderPositioning)GetValue(HeaderPositioningProperty);
+        set => SetValue(HeaderPositioningProperty, value);
+    }
+
+    public static readonly BindableProperty HeaderPositioningProperty = BindableProperty.Create(
+        nameof(HeaderPositioning),
+        typeof(CollectionViewHeaderPositioning),
+        typeof(CollectionView),
+        defaultValue: CollectionViewHeaderPositioning.Normal);
+    
     public static readonly BindableProperty HasAdditionalSizeAtTheEndProperty = BindableProperty.Create(
         nameof(HasAdditionalSpaceAtTheEnd),
         typeof(bool),
@@ -58,4 +73,21 @@ public partial class CollectionView
             handler.ReloadData(handler);
         }
     }
+}
+
+public enum CollectionViewHeaderPositioning
+{
+    /// <summary>
+    ///     The header scrolls along with the <see cref="CollectionView"/>'s content.
+    /// </summary>
+    Normal,
+    /// <summary>
+    ///     The header sticks to the top of the <see cref="CollectionView"/> and is always visible
+    /// </summary>
+    Sticky,
+    /// <summary>
+    ///     The header scrolls along with the <see cref="CollectionView"/>'s content, but will reappear and stick while
+    ///     scrolling upwards.
+    /// </summary>
+    PartialSticky
 }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/CollectionView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/CollectionView.cs
@@ -22,11 +22,11 @@ public partial class CollectionView : Microsoft.Maui.Controls.CollectionView
     
     private void OnScrolled(object? sender, ItemsViewScrolledEventArgs e)
     {
-        if (HeaderPositioning is CollectionViewHeaderPositioning.Normal || Header is not VisualElement view) return;
+        if (HeaderPositioning is HeaderPositioning.Normal || Header is not VisualElement view) return;
 
         view.TranslationY = Math.Max(TranslationY, e.VerticalOffset + m_headerOffset);
 
-        if (HeaderPositioning is not CollectionViewHeaderPositioning.PartialSticky) return;
+        if (HeaderPositioning is not HeaderPositioning.PartialSticky) return;
         
         if (this.AnimationIsRunning("PopBackIn")) return;
         

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/CollectionView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/CollectionView.cs
@@ -24,7 +24,7 @@ public partial class CollectionView : Microsoft.Maui.Controls.CollectionView
     {
         if (HeaderPositioning is HeaderPositioning.Normal || Header is not VisualElement view) return;
 
-        view.TranslationY = Math.Max(TranslationY, e.VerticalOffset + m_headerOffset);
+        view.TranslationY = TranslationY + Math.Max(0, e.VerticalOffset + m_headerOffset);
 
         if (HeaderPositioning is not HeaderPositioning.PartialSticky) return;
         

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/CollectionView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/CollectionView.cs
@@ -14,6 +14,36 @@ public partial class CollectionView : Microsoft.Maui.Controls.CollectionView
         m_extraSpaceBorder ??= new Border() {BackgroundColor = Microsoft.Maui.Graphics.Colors.Transparent};
         Footer = m_extraSpaceBorder;
         SelectionMode = SelectionMode.None;
+
+        Scrolled += OnScrolled;
+    }
+
+    private double m_headerOffset;
+    
+    private void OnScrolled(object? sender, ItemsViewScrolledEventArgs e)
+    {
+        if (HeaderPositioning is CollectionViewHeaderPositioning.Normal || Header is not VisualElement view) return;
+
+        view.TranslationY = Math.Max(TranslationY, e.VerticalOffset + m_headerOffset);
+
+        if (HeaderPositioning is not CollectionViewHeaderPositioning.PartialSticky) return;
+        
+        if (this.AnimationIsRunning("PopBackIn")) return;
+        
+        if (e.VerticalDelta > 0)
+        {
+            m_headerOffset = Math.Max(-view.Height, m_headerOffset - e.VerticalDelta);
+        }
+        if (e.VerticalDelta < 0 && m_headerOffset < 0)
+        {
+            PopBackIn(view);
+        }
+    }
+    
+    private void PopBackIn(VisualElement view)
+    {
+        var animation = new Animation(d => m_headerOffset = d, -view.Height, 0);
+        animation.Commit(this, "PopBackIn", 4, 250, Easing.Linear);
     }
 
     private void TrySetItemSpacing()


### PR DESCRIPTION
### Description of Change
- Added HeaderPositioning to dui:CollectionView
  - Normal: Header scrolls along with the collection view content
  - Sticky: Header sticks to the top of the collection view, over the content
  - PartialSticky: Header scrolls along with the collection view content, but will reappear and stick while scrolling upwards

### Todos
- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility