### PR TITLE
[Android] Made sure the CloseAll-task is completed after the stack has been modified and not before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [27.2.1]
+- [Android] Ensure `TaskCompletionSource.Result` for `BottomSheetFragment` is set after fragment is removed from stack.
+
 ## [27.2.0]
 - Handle `IScrollPickerComponent` being `null`.
 

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetFragment.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetFragment.cs
@@ -121,7 +121,6 @@ namespace DIPS.Mobile.UI.Components.BottomSheets.Android
         public override void OnDestroy()
         {
             base.OnDestroy();
-            m_dismissTaskCompletionSource.SetResult(true);
             m_bottomSheet.SendClose();
             BottomSheetService.RemoveFromStack(m_bottomSheet);
             m_bottomSheet.Handler?.DisconnectHandler();
@@ -131,6 +130,7 @@ namespace DIPS.Mobile.UI.Components.BottomSheets.Android
                 inputView.Focused -= OnInputViewFocused;
             }
 
+            m_dismissTaskCompletionSource.SetResult(true);
             m_bottomSheet.OnPositioningChanged -= OnBottomSheetPositioningChanged;
         }
 


### PR DESCRIPTION
TaskCompletionSource was being set before bottom sheet was removed from stack, causing it not to be "as async as intended"


### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [x] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->