### PR TITLE
[ScrollPicker][BreakingChange] Added `OnDataInvalidated`, to force the UI to update itself. Added a BaseScrollPickerComponent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [28.0.0]
-- [ScrollPicker][BreakingChange] Added `OnDataInvalidated`, so that consumer can update the selected item without actually tapping. Added a BaseScrollPickerComponent.
+- [ScrollPicker][BreakingChange] Added `OnDataInvalidated`, to force the UI to update itself. Added a BaseScrollPickerComponent.
 
 ## [27.5.0]
 - [ChipGroup] Added the ability to set the selected items to an empty list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [28.0.0]
+- [ScrollPicker][BreakingChange] Added `OnDataInvalidated`, so that consumer can update the selected item without actually tapping. Added a BaseScrollPickerComponent.
+
 ## [27.4.0]
 - Added 'FormattedText' to Subtitle in `ListItem`.
 

--- a/src/app/Components/ComponentsSamples/Pickers/ScrollPickerComponents/DayScrollPickerComponent.cs
+++ b/src/app/Components/ComponentsSamples/Pickers/ScrollPickerComponents/DayScrollPickerComponent.cs
@@ -4,7 +4,7 @@ namespace Components.ComponentsSamples.Pickers.ScrollPickerComponents;
 
 public class DayScrollPickerComponent : BaseScrollPickerComponent
 {
-    public override void SetSelectedItem(int index)
+    public override void SetSelectedItem(int index, IScrollPickerComponent.SetSelectedItemMode setSelectedItemMode = IScrollPickerComponent.SetSelectedItemMode.Programmatic)
     {
         SelectedItem = index + 1;
     }

--- a/src/app/Components/ComponentsSamples/Pickers/ScrollPickerComponents/DayScrollPickerComponent.cs
+++ b/src/app/Components/ComponentsSamples/Pickers/ScrollPickerComponents/DayScrollPickerComponent.cs
@@ -2,24 +2,24 @@ using DIPS.Mobile.UI.Components.Pickers.ScrollPicker;
 
 namespace Components.ComponentsSamples.Pickers.ScrollPickerComponents;
 
-public class DayScrollPickerComponent : IScrollPickerComponent
+public class DayScrollPickerComponent : BaseScrollPickerComponent
 {
-    public void SetSelectedItem(int index)
+    public override void SetSelectedItem(int index)
     {
         SelectedItem = index + 1;
     }
 
-    public int GetItemsCount()
+    public override int GetItemsCount()
     {
         return 31;
     }
 
-    public int GetSelectedItemIndex()
+    public override int GetSelectedItemIndex()
     {
         return SelectedItem - 1;
     }
 
-    public string GetItemText(int index)
+    public override string GetItemText(int index)
     {
         return (index + 1).ToString();
     }

--- a/src/app/Components/ComponentsSamples/Pickers/ScrollPickerComponents/MonthScrollPickerComponent.cs
+++ b/src/app/Components/ComponentsSamples/Pickers/ScrollPickerComponents/MonthScrollPickerComponent.cs
@@ -11,7 +11,7 @@ public class MonthScrollPickerComponent : BaseScrollPickerComponent
         m_monthNames = System.Globalization.CultureInfo.CurrentCulture.DateTimeFormat.MonthNames;
     }
     
-    public override void SetSelectedItem(int index)
+    public override void SetSelectedItem(int index, IScrollPickerComponent.SetSelectedItemMode setSelectedItemMode = IScrollPickerComponent.SetSelectedItemMode.Programmatic)
     {
         SelectedItem = index;
     }

--- a/src/app/Components/ComponentsSamples/Pickers/ScrollPickerComponents/MonthScrollPickerComponent.cs
+++ b/src/app/Components/ComponentsSamples/Pickers/ScrollPickerComponents/MonthScrollPickerComponent.cs
@@ -2,7 +2,7 @@ using DIPS.Mobile.UI.Components.Pickers.ScrollPicker;
 
 namespace Components.ComponentsSamples.Pickers.ScrollPickerComponents;
 
-public class MonthScrollPickerComponent : IScrollPickerComponent
+public class MonthScrollPickerComponent : BaseScrollPickerComponent
 {
     private readonly string[] m_monthNames;
 
@@ -11,22 +11,22 @@ public class MonthScrollPickerComponent : IScrollPickerComponent
         m_monthNames = System.Globalization.CultureInfo.CurrentCulture.DateTimeFormat.MonthNames;
     }
     
-    public void SetSelectedItem(int index)
+    public override void SetSelectedItem(int index)
     {
         SelectedItem = index;
     }
 
-    public int GetItemsCount()
+    public override int GetItemsCount()
     {
         return m_monthNames.Length - 1;
     }
 
-    public int GetSelectedItemIndex()
+    public override int GetSelectedItemIndex()
     {
         return SelectedItem;
     }
 
-    public string GetItemText(int index)
+    public override string GetItemText(int index)
     {
         return m_monthNames[index];
     }

--- a/src/app/Components/ComponentsSamples/Pickers/ScrollPickerComponents/YearScrollPickerComponent.cs
+++ b/src/app/Components/ComponentsSamples/Pickers/ScrollPickerComponents/YearScrollPickerComponent.cs
@@ -7,7 +7,7 @@ public class YearScrollPickerComponent : BaseScrollPickerComponent
     private const int StartYear = 0;
     private const int EndYear = 9999;
 
-    public override void SetSelectedItem(int index)
+    public override void SetSelectedItem(int index, IScrollPickerComponent.SetSelectedItemMode setSelectedItemMode = IScrollPickerComponent.SetSelectedItemMode.Programmatic)
     {
         SelectedItem = index;
     }

--- a/src/app/Components/ComponentsSamples/Pickers/ScrollPickerComponents/YearScrollPickerComponent.cs
+++ b/src/app/Components/ComponentsSamples/Pickers/ScrollPickerComponents/YearScrollPickerComponent.cs
@@ -2,27 +2,27 @@ using DIPS.Mobile.UI.Components.Pickers.ScrollPicker;
 
 namespace Components.ComponentsSamples.Pickers.ScrollPickerComponents;
 
-public class YearScrollPickerComponent : IScrollPickerComponent
+public class YearScrollPickerComponent : BaseScrollPickerComponent
 {
     private const int StartYear = 0;
     private const int EndYear = 9999;
 
-    public void SetSelectedItem(int index)
+    public override void SetSelectedItem(int index)
     {
         SelectedItem = index;
     }
 
-    public int GetItemsCount()
+    public override int GetItemsCount()
     {
         return EndYear - StartYear + 1;
     }
 
-    public int GetSelectedItemIndex()
+    public override int GetSelectedItemIndex()
     {
         return SelectedItem - StartYear;
     }
 
-    public string GetItemText(int index)
+    public override string GetItemText(int index)
     {
         return (StartYear + index).ToString();
     }

--- a/src/app/Components/ComponentsSamples/Pickers/ScrollPickerSamplesViewModel.cs
+++ b/src/app/Components/ComponentsSamples/Pickers/ScrollPickerSamplesViewModel.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Windows.Input;
 using Components.ComponentsSamples.Pickers.ScrollPickerComponents;
 using DIPS.Mobile.UI.Components.Alerting.SystemMessage;
 using DIPS.Mobile.UI.Components.Pickers.ScrollPicker;
@@ -44,6 +45,4 @@ public class ScrollPickerSamplesViewModel
     public List<IScrollPickerComponent> DateComponents { get; }
     public List<IScrollPickerComponent> FootballersComponents { get; }
     public List<IScrollPickerComponent> ItemComponents { get; set; }
-
-
 }

--- a/src/app/Components/ComponentsSamples/Pickers/ScrollPickerSamplesViewModel.cs
+++ b/src/app/Components/ComponentsSamples/Pickers/ScrollPickerSamplesViewModel.cs
@@ -26,12 +26,11 @@ public class ScrollPickerSamplesViewModel
         DateComponents = [yearsScrollPickerItemsSource, weekScrollPickerItemsSource, daysScrollPickerItemsSource];
     }
 
-    private static void OnSelectedItemChanged(int obj)
+    private async void OnSelectedItemChanged(int obj)
     {
-        SystemMessageService.Display(config =>
-        {
-            config.Text = obj.ToString();
-        });
+        await Task.Delay(2500);
+        DateComponents[1].SetSelectedItem(0, IScrollPickerComponent.SetSelectedItemMode.Programmatic);
+        DateComponents[1].InvalidateData();
     }
 
     private List<int> GetWeeksInYear(int year)

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/Android/MaterialScrollPickerFragment.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/Android/MaterialScrollPickerFragment.cs
@@ -9,6 +9,7 @@ using DIPS.Mobile.UI.Resources.Styles;
 using DIPS.Mobile.UI.Resources.Styles.Button;
 using DIPS.Mobile.UI.Resources.Styles.Label;
 using Google.Android.Material.Shape;
+using Microsoft.Maui.Controls.Compatibility.Platform.Android;
 using Microsoft.Maui.Platform;
 using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 using DialogFragment = AndroidX.Fragment.App.DialogFragment;

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/Android/ScrollPickerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/Android/ScrollPickerHandler.cs
@@ -28,6 +28,7 @@ public partial class ScrollPickerHandler : ViewHandler<ScrollPicker, Chip>
             throw new Exception("The components of ScrollPicker must be set!");
 
         m_scrollPickerViewModel = new ScrollPickerViewModel(VirtualView.Components);
+        m_scrollPickerViewModel.OnAnyComponentsDataInvalidated += SetChipTitle;
         
         platformView.Click += PlatformViewOnClick;
         
@@ -60,6 +61,7 @@ public partial class ScrollPickerHandler : ViewHandler<ScrollPicker, Chip>
         base.DisconnectHandler(platformView);
         
         platformView.Click -= PlatformViewOnClick;
+        m_scrollPickerViewModel.OnAnyComponentsDataInvalidated -= SetChipTitle;
     }
 }
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/IScrollPickerViewModel.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/IScrollPickerViewModel.cs
@@ -1,6 +1,6 @@
 namespace DIPS.Mobile.UI.Components.Pickers.ScrollPicker;
 
-internal interface IScrollPickerViewModel
+internal interface IScrollPickerViewModel : IDisposable
 {
    /// <summary>
     /// The number of components (scroll pickers) in the scroll picker

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/IScrollPickerViewModel.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/IScrollPickerViewModel.cs
@@ -26,6 +26,9 @@ internal interface IScrollPickerViewModel : IDisposable
     /// The selected index in the specified component
     /// </summary>
     int SelectedIndexForComponent(int component);
+    
+    void SendSelectedIndexesChanged();
 
     event Action OnAnySelectedIndexesChanged;
+    event Action OnAnyComponentsDataInvalidated;
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/ScrollPickerViewModel.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/ScrollPickerViewModel.cs
@@ -1,48 +1,81 @@
 namespace DIPS.Mobile.UI.Components.Pickers.ScrollPicker;
 
-internal class ScrollPickerViewModel(IReadOnlyList<IScrollPickerComponent>? components) : IScrollPickerViewModel
+internal class ScrollPickerViewModel : IScrollPickerViewModel
 {
+    private readonly IReadOnlyList<IScrollPickerComponent>? m_components;
+
+    public ScrollPickerViewModel(IReadOnlyList<IScrollPickerComponent>? components)
+    {
+        m_components = components;
+
+        if (m_components is null)
+            return;
+        
+        foreach (var scrollPickerComponent in m_components)
+        {
+            scrollPickerComponent.OnDataInvalidated += DataInvalidated;
+        }
+    }
+
+    private void DataInvalidated()
+    {
+        OnAnySelectedIndexesChanged?.Invoke();
+    }
+
     public int GetComponentCount()
     {
-        return components?.Count ?? 0;
+        return m_components?.Count ?? 0;
     }
 
     public int GetRowsInComponent(int component)
     {
-        return components is null ? 0 : components[component].GetItemsCount();
+        return m_components is null ? 0 : m_components[component].GetItemsCount();
     }
 
     public string GetTextForRowInComponent(int row, int component)
     {
-        return components is null ? string.Empty : components[component].GetItemText(row);
+        return m_components is null ? string.Empty : m_components[component].GetItemText(row);
     }
 
     public void SelectedRowInComponent(int row, int component)
     {
-        if(components is null)
+        if(m_components is null)
             return;
         
         if(SelectedIndexForComponent(component) == row)
             return;
         
-        components[component].SetSelectedItem(row);
+        m_components[component].SetSelectedItem(row);
         OnAnySelectedIndexesChanged?.Invoke();
     }
 
     public int SelectedIndexForComponent(int component)
     {
-        return components is null ? 0 : components[component].GetSelectedItemIndex();
+        return m_components is null ? 0 : m_components[component].GetSelectedItemIndex();
     }
 
     public event Action? OnAnySelectedIndexesChanged;
+
+    public void Dispose()
+    {
+        if (m_components is null)
+            return;
+        
+        foreach (var scrollPickerComponent in m_components)
+        {
+            scrollPickerComponent.OnDataInvalidated -= DataInvalidated;
+        }
+    }
 }
 
-public class StandardScrollPickerComponent<TModel> : List<TModel>, IScrollPickerComponent
+public class StandardScrollPickerComponent<TModel> : BaseScrollPickerComponent
 {
+    private readonly IList<TModel> m_items;
     private readonly Action<TModel>? m_onSelectedItemChanged;
 
-    public StandardScrollPickerComponent(IReadOnlyList<TModel> items, TModel? selectedItem = default, Action<TModel>? onSelectedItemChanged = null) : base(items)
+    public StandardScrollPickerComponent(IList<TModel> items, TModel? selectedItem = default, Action<TModel>? onSelectedItemChanged = null)
     {
+        m_items = items;
         m_onSelectedItemChanged = onSelectedItemChanged;
 
         if (selectedItem is null)
@@ -54,29 +87,42 @@ public class StandardScrollPickerComponent<TModel> : List<TModel>, IScrollPicker
         SelectedItem = selectedItem.Equals(default(TModel)) ? items[0] : selectedItem;
     }
     
-    public void SetSelectedItem(int index)
+    public override void SetSelectedItem(int index)
     {
-        SelectedItem = base[index];
+        SelectedItem = m_items[index];
         
         m_onSelectedItemChanged?.Invoke(SelectedItem);
     }
 
-    public int GetItemsCount()
+    public override  int GetItemsCount()
     {
-        return Count;
+        return m_items.Count;
     }
 
-    public int GetSelectedItemIndex()
+    public override int GetSelectedItemIndex()
     {
-        return SelectedItem is not null ? base.IndexOf(SelectedItem) : 0;
+        return SelectedItem is not null ? m_items.IndexOf(SelectedItem) : 0;
     }
 
-    public string GetItemText(int index)
+    public override string GetItemText(int index)
     {
-        return base[index]?.ToString() ?? string.Empty;
+        return m_items[index]?.ToString() ?? string.Empty;
     }
 
     public TModel SelectedItem { get; private set; }
+}
+
+public abstract class BaseScrollPickerComponent : IScrollPickerComponent
+{
+    public abstract void SetSelectedItem(int index);
+    public abstract int GetItemsCount();
+    public abstract int GetSelectedItemIndex();
+    public abstract string GetItemText(int index);
+    public event Action? OnDataInvalidated;
+    public void InvalidateData()
+    {
+        OnDataInvalidated?.Invoke();
+    }
 }
 
 public interface IScrollPickerComponent
@@ -100,4 +146,14 @@ public interface IScrollPickerComponent
     /// Gets the text for the specified item
     /// </summary>
     string GetItemText(int index);
+    
+    /// <summary>
+    /// Invoked when the selected item is changed
+    /// </summary>
+    event Action? OnDataInvalidated;
+    
+    /// <summary>
+    /// Call this when you have changed the selected item
+    /// </summary>
+    void InvalidateData();
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/ScrollPickerViewModel.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/ScrollPickerViewModel.cs
@@ -19,7 +19,7 @@ internal class ScrollPickerViewModel : IScrollPickerViewModel
 
     private void DataInvalidated()
     {
-        OnAnySelectedIndexesChanged?.Invoke();
+        OnAnyComponentsDataInvalidated?.Invoke();
     }
 
     public int GetComponentCount()
@@ -45,7 +45,7 @@ internal class ScrollPickerViewModel : IScrollPickerViewModel
         if(SelectedIndexForComponent(component) == row)
             return;
         
-        m_components[component].SetSelectedItem(row);
+        m_components[component].SetSelectedItem(row, IScrollPickerComponent.SetSelectedItemMode.Tapped);
         OnAnySelectedIndexesChanged?.Invoke();
     }
 
@@ -54,7 +54,13 @@ internal class ScrollPickerViewModel : IScrollPickerViewModel
         return m_components is null ? 0 : m_components[component].GetSelectedItemIndex();
     }
 
+    public void SendSelectedIndexesChanged()
+    {
+        OnAnySelectedIndexesChanged?.Invoke();
+    }
+
     public event Action? OnAnySelectedIndexesChanged;
+    public event Action? OnAnyComponentsDataInvalidated;
 
     public void Dispose()
     {
@@ -87,11 +93,12 @@ public class StandardScrollPickerComponent<TModel> : BaseScrollPickerComponent
         SelectedItem = selectedItem.Equals(default(TModel)) ? items[0] : selectedItem;
     }
     
-    public override void SetSelectedItem(int index)
+    public override void SetSelectedItem(int index, IScrollPickerComponent.SetSelectedItemMode setSelectedItemMode = IScrollPickerComponent.SetSelectedItemMode.Programmatic)
     {
         SelectedItem = m_items[index];
         
-        m_onSelectedItemChanged?.Invoke(SelectedItem);
+        if(setSelectedItemMode == IScrollPickerComponent.SetSelectedItemMode.Tapped)
+            m_onSelectedItemChanged?.Invoke(SelectedItem);
     }
 
     public override  int GetItemsCount()
@@ -114,7 +121,7 @@ public class StandardScrollPickerComponent<TModel> : BaseScrollPickerComponent
 
 public abstract class BaseScrollPickerComponent : IScrollPickerComponent
 {
-    public abstract void SetSelectedItem(int index);
+    public abstract void SetSelectedItem(int index, IScrollPickerComponent.SetSelectedItemMode setSelectedItemMode = IScrollPickerComponent.SetSelectedItemMode.Programmatic);
     public abstract int GetItemsCount();
     public abstract int GetSelectedItemIndex();
     public abstract string GetItemText(int index);
@@ -130,7 +137,7 @@ public interface IScrollPickerComponent
     /// <summary>
     /// Sets the selected item
     /// </summary>
-    void SetSelectedItem(int index);
+    void SetSelectedItem(int index, SetSelectedItemMode setSelectedItemMode = SetSelectedItemMode.Programmatic);
     
     /// <summary>
     /// Gets the number of items in the component
@@ -156,4 +163,16 @@ public interface IScrollPickerComponent
     /// Call this when you have changed the selected item
     /// </summary>
     void InvalidateData();
+    
+    public enum SetSelectedItemMode
+    {
+        /// <summary>
+        /// If the user has tapped/scrolled in the ScrollPicker to set the selected item
+        /// </summary>
+        Tapped,
+        /// <summary>
+        /// If the selected item is set programmatically
+        /// </summary>
+        Programmatic
+    }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/iOS/ScrollPickerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/iOS/ScrollPickerHandler.cs
@@ -151,7 +151,7 @@ internal class ScrollPickerViewController : UIViewController
 
     public async void OnChipTitleChanged()
     {
-        if (PopoverPresentationController is null)
+        if (PopoverPresentationController is null || m_uiButton is null)
             return;
 
         await Task.Delay(1);

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/iOS/ScrollPickerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/iOS/ScrollPickerHandler.cs
@@ -70,6 +70,7 @@ public partial class ScrollPickerHandler : ViewHandler<ScrollPicker, UIButton>
     {
         base.DisconnectHandler(platformView);
 
+        m_scrollPickerViewModel.Dispose();
         m_scrollPickerViewModel = null!;
         m_chip.Command = null;
         m_scrollPickerViewController = null;

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/iOS/ScrollPickerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/iOS/ScrollPickerHandler.cs
@@ -33,6 +33,7 @@ public partial class ScrollPickerHandler : ViewHandler<ScrollPicker, UIButton>
 
         m_scrollPickerViewModel = new ScrollPickerViewModel(VirtualView.Components);
         m_scrollPickerViewModel.OnAnySelectedIndexesChanged += SetChipTitle;
+        
         SetChipTitle();
     }
 
@@ -118,6 +119,8 @@ internal class ScrollPickerViewController : UIViewController
     {
         m_scrollPickerViewModel = scrollPickerViewModel;
         
+        m_scrollPickerViewModel.OnAnyComponentsDataInvalidated += OnAnyComponentsDataInvalidated;
+        
         m_uiPicker = new UIPickerView();
         var vm = new DUIPickerViewModel { ScrollPickerViewModel = m_scrollPickerViewModel };
         m_uiPicker.Model = vm;
@@ -148,6 +151,20 @@ internal class ScrollPickerViewController : UIViewController
         {
             PopoverPresentationController.SourceItem = m_uiButton;
         }
+    }
+
+    private void OnAnyComponentsDataInvalidated()
+    {
+        for (var i = 0; i < m_scrollPickerViewModel.GetComponentCount(); i++)
+        {
+            var initialSelectedIndexForComponent = m_scrollPickerViewModel.SelectedIndexForComponent(i);
+            if (initialSelectedIndexForComponent == -1)
+                continue;
+
+            m_uiPicker.Select(initialSelectedIndexForComponent, i, true);
+        }
+        
+        m_scrollPickerViewModel.SendSelectedIndexesChanged();
     }
 
     public async void OnChipTitleChanged()
@@ -212,6 +229,8 @@ internal class ScrollPickerViewController : UIViewController
     public override void ViewWillDisappear(bool animated)
     {
         base.ViewWillDisappear(animated);
+        
+        m_scrollPickerViewModel.OnAnyComponentsDataInvalidated -= OnAnyComponentsDataInvalidated;
         
         m_uiPicker = null!;
         m_uiButton = null!;


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->