### PR TITLE
[DatePicker][iOS] We now avoid setting static width on date pickers (DatePicker, DateAndTimePicker, TimePicker), and rather set the width based on their actual width.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [28.3.2] 
+- [DatePicker][iOS] We now avoid setting static width on date pickers (DatePicker, DateAndTimePicker, TimePicker), and rather set the width based on their actual width.
+
 ## [28.3.1] 
 - [ItemPicker] Fixed an issue where the context menu did not reflect correctly what item was selected when setting selected item programatically.
 

--- a/src/app/Components/ComponentsSamples/Pickers/DateTimePickersSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Pickers/DateTimePickersSamples.xaml
@@ -33,10 +33,12 @@
 
         <dui:Label Text="DatePicker (With maximum date)"
                    Margin="5" />
+        <HorizontalStackLayout>
         <dui:DatePicker VerticalOptions="End"
                         SelectedDate="{Binding Test}"
                         HorizontalOptions="Start"
                         MaximumDate="{Binding MaximumDate}" />
+        </HorizontalStackLayout>
 
         <dui:Label Text="DatePicker (With minimum date)"
                    Margin="5" />

--- a/src/app/Components/ComponentsSamples/Pickers/DateTimePickersSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Pickers/DateTimePickersSamples.xaml
@@ -33,12 +33,10 @@
 
         <dui:Label Text="DatePicker (With maximum date)"
                    Margin="5" />
-        <HorizontalStackLayout>
         <dui:DatePicker VerticalOptions="End"
                         SelectedDate="{Binding Test}"
                         HorizontalOptions="Start"
                         MaximumDate="{Binding MaximumDate}" />
-        </HorizontalStackLayout>
 
         <dui:Label Text="DatePicker (With minimum date)"
                    Margin="5" />

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -20,8 +20,7 @@
     </dui:ContentPage.ToolbarItems>
    
  
-    <dui:Button Text="Open"
-                Command="{dui:OpenBottomSheetCommand {x:Type vetleSamples:BottomSheetWithToolbar}}" />
+    
     
         
 </dui:ContentPage>

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DateAndTimePicker/DateAndTimePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DateAndTimePicker/DateAndTimePicker.cs
@@ -8,11 +8,6 @@ public partial class DateAndTimePicker : View, IDateTimePicker
     {
         base.OnHandlerChanged();
         
-#if __IOS__
-        // DatePickers on iOS takes up invisible space
-        WidthRequest = 200;
-#endif
-            
         // SelectedDate should not be above maximum date
         if (MaximumDate != null && SelectedDateTime > MaximumDate)
         {

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DateAndTimePicker/iOS/DateAndTimePickerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DateAndTimePicker/iOS/DateAndTimePickerHandler.cs
@@ -18,7 +18,7 @@ public partial class DateAndTimePickerHandler : ViewHandler<DateAndTimePicker, D
     {
         return new DUIDatePicker
         {
-            Mode = UIDatePickerMode.DateAndTime, PreferredDatePickerStyle = UIDatePickerStyle.Compact
+            Mode = UIDatePickerMode.DateAndTime, PreferredDatePickerStyle = UIDatePickerStyle.Compact, VirtualView = VirtualView
         };
     }
     

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/DatePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/DatePicker.cs
@@ -10,11 +10,6 @@ namespace DIPS.Mobile.UI.Components.Pickers.DatePicker
         public DatePicker()
         {
             BackgroundColor = Colors.GetColor(ColorName.color_secondary_30);
-            
-#if __IOS__
-            // DatePickers on iOS takes up invisible space
-            WidthRequest = 100;
-#endif
         }
 
         protected override void OnHandlerChanged()

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/iOS/DUIDatePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/iOS/DUIDatePicker.cs
@@ -11,11 +11,44 @@ namespace DIPS.Mobile.UI.Components.Pickers.DatePicker.iOS;
 
 public class DUIDatePicker : UIDatePicker
 {
+    public View VirtualView { get; set; }
+    
     public override void Draw(CGRect rect)
     {
         base.Draw(rect);
         UpdateInLineLayerAttributes(); //Update attributes when its first drawn
         ValueChanged += UpdateInLineLayerAttributes;
+
+        switch (Mode)
+        {
+            case UIDatePickerMode.Date:
+            case UIDatePickerMode.Time:
+                {
+                    var subView = Subviews.FirstOrDefault()?.Subviews.FirstOrDefault();
+                    if (subView is not null)
+                    {
+                        VirtualView.WidthRequest = subView.Frame.Width;
+                    }
+
+                    break;
+                }
+            case UIDatePickerMode.DateAndTime:
+                {
+                    var dateFrame = Subviews.FirstOrDefault()?.Subviews.FirstOrDefault()?.Frame;
+                    var timeFrame = Subviews.FirstOrDefault()?.Subviews.LastOrDefault()?.Frame;
+                    
+                    if(dateFrame.HasValue && timeFrame.HasValue)
+                    {
+                        //Set the width of the date picker to the width of the date and time picker plus their spacing
+                        VirtualView.WidthRequest = dateFrame.Value.Width + timeFrame.Value.Width + (timeFrame.Value.X - dateFrame.Value.Width);
+                    }
+                }
+                break;
+            case UIDatePickerMode.CountDownTimer:
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
     }
 
     private void UpdateInLineLayerAttributes()

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/iOS/DatePickerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/iOS/DatePickerHandler.cs
@@ -4,6 +4,7 @@ using DIPS.Mobile.UI.Components.Pickers.Platforms.iOS;
 using DIPS.Mobile.UI.Platforms.iOS;
 using Foundation;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
 using UIKit;
 
 // ReSharper disable once CheckNamespace
@@ -15,7 +16,7 @@ public partial class DatePickerHandler : ViewHandler<DatePicker, DUIDatePicker>
 
     protected override DUIDatePicker CreatePlatformView()
     {
-        return new DUIDatePicker {PreferredDatePickerStyle = UIDatePickerStyle.Compact, Mode = UIDatePickerMode.Date};
+        return new DUIDatePicker {PreferredDatePickerStyle = UIDatePickerStyle.Compact, Mode = UIDatePickerMode.Date, VirtualView = VirtualView};
     }
     
     protected override void ConnectHandler(DUIDatePicker platformView)
@@ -28,7 +29,7 @@ public partial class DatePickerHandler : ViewHandler<DatePicker, DUIDatePicker>
         platformView.EditingDidEnd += OnClose;
         DUI.OnRemoveViewsLocatedOnTopOfPage += TryClose;
     }
-
+    
    
 
     private void OnOpen(object? sender, EventArgs e)

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/TimePicker/TimePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/TimePicker/TimePicker.cs
@@ -9,10 +9,5 @@ public partial class TimePicker : View, IDateTimePicker
     public TimePicker()
     {
         BackgroundColor = Colors.GetColor(ColorName.color_secondary_30);
-        
-#if __IOS__
-        // DatePickers on iOS takes up invisible space
-        WidthRequest = 100;
-#endif
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/TimePicker/iOS/TimePickerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/TimePicker/iOS/TimePickerHandler.cs
@@ -10,7 +10,7 @@ namespace DIPS.Mobile.UI.Components.Pickers.TimePicker;
 
 public partial class TimePickerHandler : ViewHandler<TimePicker, DUIDatePicker>
 {
-    protected override DUIDatePicker CreatePlatformView() => new() { Mode = UIDatePickerMode.Time, PreferredDatePickerStyle = UIDatePickerStyle.Compact };
+    protected override DUIDatePicker CreatePlatformView() => new() { Mode = UIDatePickerMode.Time, PreferredDatePickerStyle = UIDatePickerStyle.Compact, VirtualView = VirtualView };
 
     private bool m_isOpen;
     


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

We set static width request on every type of date picker. This had the implication that they did not correctly reflect their actual width from their native frame, this would also stop native accessibility when users resizes their font-size on their iOS phone.