### PR TITLE
Changed build script

### DIFF
--- a/build/BuildSystem/Git.csx
+++ b/build/BuildSystem/Git.csx
@@ -32,6 +32,12 @@ public static class Git{
         return await GetCurrentBranch(workingDirectory) == "main";
     }
 
+    public static async Task<bool> CurrentBranchIsPatch(string workingDirectory = null)
+    {
+        var branch = await GetCurrentBranch(workingDirectory);
+        return branch.StartsWith("patch");
+    }
+
     private static Task<CommandResult> ExecuteGitCommand(string arguments, string workingDirectory){
         return Command.CaptureAsync("git", arguments, workingDirectory);
     }

--- a/build/build.csx
+++ b/build/build.csx
@@ -237,8 +237,8 @@ async Task<FileInfo> PackLibrary(string outputdir = null)
 {
     outputdir ??= OutputDir;
     var version = VersionUtil.GetLatestVersionFromChangelog(ChangeLogPath);
-    if (!await Git.CurrentBranchIsMain())
-    {
+    if (!await Git.CurrentBranchIsMain() && !await Git.CurrentBranchIsPatch())
+     {
         var buildNumber = AzureDevops.GetEnvironmentVariable("Build.BuildNumber");
         version += $"-pre{buildNumber}";
     }


### PR DESCRIPTION
### Description of Change
Changed buildscript so that nuget packages does not get published as pre-release package when suffix of branch starts with "patch".

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->