### PR TITLE
[NullableDatePicker] Fixed an issue where if dates were set as default, the pickers would still be null.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [29.1.1]
+- [NullableDatePicker] Fixed an issue where if dates were set as default, the pickers would still be null.
+
 ## [29.1.0]
 - [SegmentedControl] Added property `ShouldDeSelectOnSameItemTapped`.
 - [SegmentedControl] Fixed bug where `DidDeSelectItem` and `DidSelectItem` were fired when consumer tapped on the item that already was selected. 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/NullableDateAndTimePicker/NullableDateAndTimePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/NullableDateAndTimePicker/NullableDateAndTimePicker.cs
@@ -46,8 +46,9 @@ public partial class NullableDateAndTimePicker : BaseNullableDatePicker
 
     private void OnSelectedDateTimeChanged()
     {
-        if(m_dateAndTimePicker is not null)
+        if (m_dateAndTimePicker is not null)
             m_dateAndTimePicker.SelectedDateTime = SelectedDateTime ?? m_dateAndTimePicker.SelectedDateTime;
+        else return;
         
         DateEnabledSwitch.IsToggled = SelectedDateTime.HasValue;
         SelectedDateTimeCommand?.Execute(null);

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/NullableDatePicker/NullableDatePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/NullableDatePicker/NullableDatePicker.cs
@@ -49,8 +49,9 @@ public partial class NullableDatePicker : BaseNullableDatePicker
 
     private void OnSelectedDateChanged()
     {
-        if(m_datePicker is not null)
+        if (m_datePicker is not null)
             m_datePicker.SelectedDate = SelectedDate ?? m_datePicker.SelectedDate;
+        else return;
         
         DateEnabledSwitch.IsToggled = SelectedDate.HasValue;
         SelectedDateCommand?.Execute(null);

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/NullableTimePicker/NullableTimePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/NullableTimePicker/NullableTimePicker.cs
@@ -43,8 +43,9 @@ public partial class NullableTimePicker : BaseNullableDatePicker
 
     private void OnSelectedTimeChanged()
     {
-        if(m_timePicker is not null)
+        if (m_timePicker is not null)
             m_timePicker.SelectedTime = SelectedTime ?? m_timePicker.SelectedTime;
+        else return;
         
         DateEnabledSwitch.IsToggled = SelectedTime.HasValue;
         SelectedTimeCommand?.Execute(null);


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->