### PR TITLE
More ListItem and VirtualListView bugfixes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [ListItem] Now there is no need to set `Title` or `Subtitle` on `ListItem` in order to use the `FormattedText` in their options.
 - [ListItem][Android] Fixed an issue where a blank `Subtitle` would take up space.
 - [ListItem] Fixed a bug where a `ListItem` in a `CollectionView` sometimes don't give `Title` it's required space. 
+- [VirtualListView][Android] The `OnScrolled` event will never be invoked now unless user has scrolled.
 
 ## [29.1.2]
 - [VirtualListView][Android] When the list is rendered the first time, it won't invoke `OnScrolled` event.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [29.1.3]
+- [ListItem] Now there is no need to set `Title` or `Subtitle` on `ListItem` in order to use the `FormattedText` in their options.
+- [ListItem][Android] Fixed an issue where a blank `Subtitle` would take up space.
+- [ListItem] Fixed a bug where a `ListItem` in a `CollectionView` sometimes don't give `Title` it's required space. 
+
 ## [29.1.2]
 - [VirtualListView][Android] When the list is rendered the first time, it won't invoke `OnScrolled` event.
 - [ListItem] `Title`, `Subtitle` and `InlineContent` will now always be centered no matter the height of the `ListItem` (If underlying content has not been set).

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -14,41 +14,53 @@
     <dui:ContentPage.BindingContext>
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
-    
+
     <dui:ContentPage.ToolbarItems>
         <ToolbarItem Text="hei" />
     </dui:ContentPage.ToolbarItems>
 
     <Grid RowDefinitions="Auto, *">
-    <dui:SearchBar x:Name="SearchBar" />
-    
-    <!--<dui:NavigationListItem Title="Components"></dui:NavigationListItem>-->
-    
-    <dui:CollectionView ItemsSource="{Binding TestStrings}"
-                         Grid.Row="1"
-                         BackgroundColor="Transparent">
-        <dui:CollectionView.ItemTemplate>
-            <DataTemplate x:DataType="{x:Type vetleSamples:TestObject2}">
-                
-                <dui:ListItem Margin="{dui:Thickness Left=size_2, Right=size_2, Top=size_4, Bottom=size_4}" 
-                              Icon="{dui:Icons test_tube_line}"
-                              Title="hei">
-                    
-                    <dui:ListItem.InLineContentOptions>
-                      <dui:InLineContentOptions Width="Auto"  />
+        <dui:SearchBar x:Name="SearchBar" />
+
+        <!--<dui:NavigationListItem Title="Components"></dui:NavigationListItem>-->
+
+      
+
+                    <dui:ListItem 
+                                  Title="asd"
+                                  >
+
+                        <dui:ListItem.SubtitleOptions>
+                            <dui:SubtitleOptions>
+                                <dui:SubtitleOptions.FormattedText>
+                                    
+                                <FormattedString>
+                                    <Span Text="Lol" />
+                                </FormattedString>
+                                </dui:SubtitleOptions.FormattedText>
+                            </dui:SubtitleOptions>
+                        </dui:ListItem.SubtitleOptions>
                         
-                    </dui:ListItem.InLineContentOptions>
-                    
-                    <dui:ListItem.TitleOptions>
-                        <dui:TitleOptions HorizontalTextAlignment="End"></dui:TitleOptions>
-                    </dui:ListItem.TitleOptions>
-                    
-                  </dui:ListItem>
-            </DataTemplate>
-        </dui:CollectionView.ItemTemplate>
-    </dui:CollectionView>
- 
+                       
+                        
+                        <Switch />
+                        
+                        <!--<dui:ListItem.SubtitleOptions>
+                            <dui:SubtitleOptions LineBreakMode="TailTruncation"
+                                                 MaxLines="1">
+                                <dui:SubtitleOptions.FormattedText>
+                                    <FormattedString>
+                                        <Span Text="asdasdsadsadsadasdasdsadsadsasdasdasdasdsadasdsadasdsadsa" />
+                                    </FormattedString>
+                                </dui:SubtitleOptions.FormattedText>
+                            </dui:SubtitleOptions>
+                        </dui:ListItem.SubtitleOptions>-->
+
+                     
+
+                    </dui:ListItem>
+
     </Grid>
-    
-        
+
+
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -22,43 +22,31 @@
     <Grid RowDefinitions="Auto, *">
         <dui:SearchBar x:Name="SearchBar" />
 
-        <!--<dui:NavigationListItem Title="Components"></dui:NavigationListItem>-->
-
-      
-
-                    <dui:ListItem 
-                                  Title="asd"
-                                  >
-
-                        <dui:ListItem.SubtitleOptions>
-                            <dui:SubtitleOptions>
-                                <dui:SubtitleOptions.FormattedText>
-                                    
-                                <FormattedString>
-                                    <Span Text="Lol" />
-                                </FormattedString>
-                                </dui:SubtitleOptions.FormattedText>
-                            </dui:SubtitleOptions>
-                        </dui:ListItem.SubtitleOptions>
-                        
-                       
-                        
-                        <Switch />
-                        
-                        <!--<dui:ListItem.SubtitleOptions>
-                            <dui:SubtitleOptions LineBreakMode="TailTruncation"
-                                                 MaxLines="1">
-                                <dui:SubtitleOptions.FormattedText>
-                                    <FormattedString>
-                                        <Span Text="asdasdsadsadsadasdasdsadsadsasdasdasdasdsadasdsadasdsadsa" />
-                                    </FormattedString>
-                                </dui:SubtitleOptions.FormattedText>
-                            </dui:SubtitleOptions>
-                        </dui:ListItem.SubtitleOptions>-->
-
-                     
-
-                    </dui:ListItem>
+        <dui:VirtualListView Adapter="{Binding Adapter}"
+                             Grid.Row="1"
+                             ViewToUnfocusOnScrolled="{x:Reference SearchBar}">
+            <dui:VirtualListView.GlobalHeader>
+                <Label Text="hehe"></Label>
+            </dui:VirtualListView.GlobalHeader>
+            
+            <dui:VirtualListView.ItemTemplate>
+                <DataTemplate>
+                    <dui:ListItem Title="Hei!" />
+                </DataTemplate>
+            </dui:VirtualListView.ItemTemplate>
+            
+            <dui:VirtualListView.EmptyView>
+                <dui:ActivityIndicator />
+            </dui:VirtualListView.EmptyView>
+            
+            <dui:VirtualListView.GlobalFooter>
+                <Grid>
+                <BoxView HeightRequest="1000"
+                         BackgroundColor="Red"/>
+                </Grid>
+            </dui:VirtualListView.GlobalFooter>
+            
+        </dui:VirtualListView>
 
     </Grid>
 

--- a/src/app/Playground/VetleSamples/VetlePageViewModel.cs
+++ b/src/app/Playground/VetleSamples/VetlePageViewModel.cs
@@ -68,7 +68,7 @@ public class VetlePageViewModel : ViewModel
 
     }
 
-    public IVirtualListViewAdapter Adapter => new VirtualListViewAdapter<TestObject2>([new TestObject2("Lokalisasjon påkrevd - Kodeverk og egendefinert"), new TestObject2("Test2"), new TestObject2("Lokalisasjon - Fritekst")]);
+    public TestAdapter Adapter { get; } = new TestAdapter();
 
     private void Disable()
     {
@@ -127,7 +127,7 @@ public class VetlePageViewModel : ViewModel
     private async Task DelayFunction()
     {
         await Task.Delay(2000);
-        
+        Adapter.SetData([new TestObject2("Lokalisasjon påkrevd - Kodeverk og egendefinert"), new TestObject2("Test2"), new TestObject2("Lokalisasjon - Fritekst")]);
     }
 
 
@@ -332,4 +332,27 @@ public class TestObject2
    public string Name { get; set; }
 
    public string SearchTerm { get; } = "Test";
+}
+
+public class TestAdapter : VirtualListViewAdapterBase<object, TestObject2>, IVirtualListViewAdapter
+{
+    private List<TestObject2> m_testObjects;
+
+    public override TestObject2 GetItem(int sectionIndex, int itemIndex)
+    {
+        return m_testObjects?[itemIndex] ?? new TestObject2("l");
+    }
+
+    public override int GetNumberOfItemsInSection(int sectionIndex)
+    {
+        return m_testObjects?.Count ?? 0;
+    }
+
+    public void SetData(List<TestObject2> testObjects)
+    {
+        m_testObjects = testObjects;
+        
+        InvalidateData();
+    }
+    
 }

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
@@ -294,14 +294,12 @@ namespace DIPS.Mobile.UI.Components.ListItems
         public static readonly BindableProperty TitleProperty = BindableProperty.Create(
             nameof(Title),
             typeof(string),
-            typeof(ListItem), 
-            propertyChanged: (bindable, _, _) => ((ListItem)bindable).AddTitle());
+            typeof(ListItem));
     
         public static readonly BindableProperty SubtitleProperty = BindableProperty.Create(
             nameof(Subtitle),
             typeof(string),
-            typeof(ListItem), 
-            propertyChanged: (bindable, _, _) => ((ListItem)bindable).AddSubtitle());
+            typeof(ListItem));
 
         public static readonly BindableProperty IconProperty = BindableProperty.Create(
             nameof(Icon),

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
@@ -1,5 +1,6 @@
 using DIPS.Mobile.UI.Components.ContextMenus;
 using DIPS.Mobile.UI.Components.Dividers;
+using DIPS.Mobile.UI.Components.Labels;
 using DIPS.Mobile.UI.Components.ListItems.Options;
 using DIPS.Mobile.UI.Effects.Touch;
 using Microsoft.Maui.Controls.Shapes;
@@ -48,7 +49,7 @@ public partial class ListItem : ContentView
     internal Border Border { get; } = new();
     internal Image? ImageIcon { get; private set; }
     internal Label TitleLabel { get; private set; } = new();
-    internal Label? SubtitleLabel { get; private set; }
+    internal Label SubtitleLabel { get; private set; } = new() { IsVisible = false };
     
     private IView m_oldInLineContent;
     private IView? m_oldUnderlyingContent;
@@ -75,16 +76,7 @@ public partial class ListItem : ContentView
         ContainerGrid.Add(TitleAndLabelGrid, 1);
         RootGrid.Add(Border);
         
-        TitleLabel.SizeChanged += TitleLabelOnSizeChanged;
-        TitleAndLabelGrid.SetRowSpan(TitleLabel, 2);
-        TitleAndLabelGrid.Add(TitleLabel);
-        
         this.Content = RootGrid;
-    }
-
-    private void TitleLabelOnSizeChanged(object? sender, EventArgs e)
-    {
-        UpdateTitleSubtitleLogic();
     }
 
     private void BindBorder()
@@ -112,29 +104,17 @@ public partial class ListItem : ContentView
         Border.StrokeThickness = 0;
 #endif
         
+        AddTitle();
+        AddSubtitle();
+        
         AddTouch();
     }
-
-    private bool TitleHasText => !string.IsNullOrEmpty(Title) || !string.IsNullOrEmpty(TitleLabel.FormattedText?.ToString());
-    private bool SubtitleHasText => !string.IsNullOrEmpty(Subtitle) || !string.IsNullOrEmpty(SubtitleLabel?.FormattedText?.ToString());
     
     private void AddTitle()
     {
-        if (TitleAndLabelGrid.Contains(TitleLabel))
-        {
-            TitleAndLabelGrid.Remove(TitleLabel);
-        }
-        
-        TitleLabel = new Label
-        {
-            Text = Title
-        };
-        
-        BindToOptions(TitleOptions);
-        
-        UpdateTitleSubtitleLogic();
-
         TitleAndLabelGrid.Insert(0, TitleLabel);
+
+        BindToOptions(TitleOptions);
         
         if(IsDebugMode)
             BindToOptions(DebuggingOptions);
@@ -142,41 +122,14 @@ public partial class ListItem : ContentView
 
     private void AddSubtitle()
     {
-        if (TitleAndLabelGrid.Contains(SubtitleLabel))
-        {
-            TitleAndLabelGrid.Remove(SubtitleLabel);
-        }
-
-        SubtitleLabel = new Label
-        {
-            Text = Subtitle
-        };
+        TitleAndLabelGrid.Add(SubtitleLabel, 0, 1);
         
         BindToOptions(SubtitleOptions);
-
-        UpdateTitleSubtitleLogic();
-        
-        TitleAndLabelGrid.Add(SubtitleLabel, 0, 1);
         
         if(IsDebugMode)
             BindToOptions(DebuggingOptions);
     }
 
-    private void UpdateTitleSubtitleLogic()
-    {
-        switch (TitleHasText)
-        {
-            case true when SubtitleHasText:
-                TitleOptions.VerticalTextAlignment = TextAlignment.End;
-                TitleAndLabelGrid.SetRowSpan(TitleLabel, 1);
-                break;
-            case false when !SubtitleHasText:
-                TitleOptions.VerticalTextAlignment = TextAlignment.Center;
-                TitleAndLabelGrid.SetRowSpan(TitleLabel, 2);
-                break;
-        }
-    }
-    
     private void AddIcon()
     {
         if (ContainerGrid.Contains(ImageIcon))
@@ -376,7 +329,5 @@ public partial class ListItem : ContentView
         
         if(m_verticalStackLayout is not null)
             m_verticalStackLayout.SizeChanged -= OnVerticalStackLayoutSizeChanged;
-
-        TitleLabel.SizeChanged -= TitleLabelOnSizeChanged;
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Subtitle/SubtitleOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Subtitle/SubtitleOptions.cs
@@ -11,6 +11,7 @@ public partial class SubtitleOptions : ListItemOptions
         if(listItem.SubtitleLabel is null)
             return;            
         
+        listItem.SubtitleLabel.SetBinding(Label.TextProperty, new Binding(nameof(ListItem.Subtitle), source: listItem));
         listItem.SubtitleLabel.SetBinding(Label.FontAttributesProperty, new Binding(nameof(FontAttributes), source: this));
         listItem.SubtitleLabel.SetBinding(Label.HorizontalTextAlignmentProperty, new Binding(nameof(HorizontalTextAlignment), source: this));
         listItem.SubtitleLabel.SetBinding(Label.VerticalTextAlignmentProperty, new Binding(nameof(VerticalTextAlignment), source: this));
@@ -19,9 +20,21 @@ public partial class SubtitleOptions : ListItemOptions
         listItem.SubtitleLabel.SetBinding(Label.LineBreakModeProperty, new Binding(nameof(LineBreakMode), source: this));
         listItem.SubtitleLabel.SetBinding(Label.FormattedTextProperty, new Binding(nameof(FormattedText), source: this));
 
+        listItem.SubtitleLabel.IsVisible = !IsSubtitleEmptyOrNull(listItem);
+        
         if (MaxLines > -1) //We can not trigger property changed for this if its -1 because it causes bugs on Android.
         {
             listItem.SubtitleLabel.MaxLines = MaxLines;
         }
+    }
+
+    private bool IsSubtitleEmptyOrNull(ListItem listItem)
+    {
+        if (FormattedText is not null)
+        {
+            return string.IsNullOrEmpty(FormattedText.ToString());
+        }
+
+        return string.IsNullOrEmpty(listItem.Subtitle);
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Title/TitleOptions.cs
@@ -9,6 +9,7 @@ public partial class TitleOptions : ListItemOptions
         if(listItem.TitleLabel is null)
             return;
 
+        listItem.TitleLabel.SetBinding(Label.TextProperty, new Binding(nameof(ListItem.Title), source: listItem));
         listItem.TitleLabel.SetBinding(Label.FontAttributesProperty, new Binding(nameof(FontAttributes), source: this));
         listItem.TitleLabel.SetBinding(VisualElement.StyleProperty, new Binding(nameof(Style), source: this));
         listItem.TitleLabel.SetBinding(Label.TextColorProperty, new Binding(nameof(TextColor), source: this));
@@ -17,7 +18,7 @@ public partial class TitleOptions : ListItemOptions
         listItem.TitleLabel.SetBinding(Label.LineBreakModeProperty, new Binding(nameof(LineBreakMode), source: this));
         listItem.TitleLabel.SetBinding(View.MarginProperty, new Binding(nameof(Margin), source: this));
         listItem.TitleLabel.SetBinding(Label.FormattedTextProperty, new Binding(nameof(FormattedText), source: this));
-        listItem.TitleLabel.SetBinding(Label.MaximumWidthRequestProperty, new Binding(nameof(MaxWidth), source: this));
+        listItem.TitleLabel.SetBinding(VisualElement.MaximumWidthRequestProperty, new Binding(nameof(MaxWidth), source: this));
         
         if (MaxLines > -1) //We can not trigger property changed for this if its -1 because it causes bugs on Android.
         {

--- a/src/library/DIPS.Mobile.UI/Components/VirtualListView/Android/RvScrollListener.cs
+++ b/src/library/DIPS.Mobile.UI/Components/VirtualListView/Android/RvScrollListener.cs
@@ -6,7 +6,7 @@ public partial class VirtualListViewHandler
 {
     class RvScrollListener : RecyclerView.OnScrollListener
     {
-        private bool m_firstScroll = true;
+        private bool m_haveScrolled;
         
         public RvScrollListener(Action<RecyclerView, int, int> scrollHandler)
         {
@@ -19,14 +19,14 @@ public partial class VirtualListViewHandler
         {
             base.OnScrolled(recyclerView, dx, dy);
 
-            // This is a workaround for the first scroll event that is triggered when the view is created
-            if(m_firstScroll)
+            // This function gets called when GlobalHeader, ItemTemplate etc. is drawn, so we have to check here if the user has scrolled, if not, never invoke the ScrollHandler
+            if (dx != 0 || dy != 0)
             {
-                m_firstScroll = false;
-                return;
+                m_haveScrolled = true;
             }
             
-            ScrollHandler?.Invoke(recyclerView, dx, dy);
+            if(m_haveScrolled)
+                ScrollHandler?.Invoke(recyclerView, dx, dy);
         }
     }
 }


### PR DESCRIPTION
### Description of Change

Noticed that setting FormattedText on Title and Subtitle did not work unless you set something on Title and Subtitle. Now, you don't have do to that. There was also an issue where setting an empty Subtitle would take up space on Android.

For VirtualListView, I noticed that the OnScrolled event were invoked every time something is drawn on it. For example, GlobalHeader, footer etc. So now I do a check where it will only call it if the user has previously scrolled.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->