### PR TITLE
Fixed an issue where `MultiItemsPicker.DidSelectItem` was not triggered when selecting first item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [29.3.2]
+- [MultiItemsPicker] Fixed an issue where `MultiItemsPicker.DidSelectItem` was not triggered when first item was selected
+
 ## [29.3.1]
 - [iOS][ContextMenuToolbarItem] Fixed an issue where `IsCheckable` did not work.
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPicker.cs
@@ -118,14 +118,17 @@ public partial class MultiItemsPicker : ContentView
             if (!selectedItems.Any())
             {
                 SelectedItems = new List<object> {item};
+            }
+            else if (selectedItems.Contains(item))
+            {
                 return;
             }
-
-            if (selectedItems.Contains(item)) return;
-
-            var tempList = selectedItems.ToList();
-            tempList.Add(item);
-            SelectedItems = tempList;
+            else
+            {
+                var tempList = selectedItems.ToList();
+                tempList.Add(item);
+                SelectedItems = tempList;
+            }
         }
 
         SelectedItemsCommand?.Execute(SelectedItems);


### PR DESCRIPTION
### Description of Change

Changed control flow of item selection, so that the operation does not immediately return if the list of selected items is empty.

### Todos
- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility