### PR TITLE
Changed Icons from ImageSource to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [29.5.1] 
+- [Icons] Changed icons from ImageSource to string to prevent memory leaks when using icons.
+
 ## [29.5.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [29.5.1] 
+## [30.0.0] 
 - [Icons] Changed icons from ImageSource to string to prevent memory leaks when using icons.
 
 ## [29.5.0] 

--- a/src/app/Components/App.xaml.cs
+++ b/src/app/Components/App.xaml.cs
@@ -13,7 +13,10 @@ public partial class App : Application
     {
         InitializeComponent();
 
-        var shell = new DIPS.Mobile.UI.Components.Shell.Shell();
+        var shell = new DIPS.Mobile.UI.Components.Shell.Shell()
+        {
+            ShouldGarbageCollectPreviousPage = true
+        };
         var tabBar = new TabBar();
         var tab = new Tab();
         

--- a/src/app/Components/ResourcesSamples/Icons/IconsSamples.xaml.cs
+++ b/src/app/Components/ResourcesSamples/Icons/IconsSamples.xaml.cs
@@ -7,8 +7,8 @@ namespace Components.ResourcesSamples.Icons
 {
     public partial class IconsSamples
     {
-        private Dictionary<string, ImageSource> m_icons;
-        private Dictionary<string, ImageSource> m_allIcons;
+        private Dictionary<string, string> m_icons;
+        private Dictionary<string, string> m_allIcons;
 
         public ICommand OpenIconCommand => new Command<string>(iconName =>
         {
@@ -29,7 +29,7 @@ namespace Components.ResourcesSamples.Icons
             m_allIcons = Icons;
         }
 
-        public Dictionary<string, ImageSource> Icons
+        public Dictionary<string, string> Icons
         {
             get => m_icons;
             private set

--- a/src/library/DIPS.Mobile.UI/Resources/Icons/IconResources.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Icons/IconResources.cs
@@ -6,7 +6,7 @@ this file is generated
         namespace DIPS.Mobile.UI.Resources.Icons;
         internal static class IconResources
         {
-            public static Dictionary<string, ImageSource> Icons { get; } = new()
+            public static Dictionary<string, string> Icons { get; } = new()
             {
                 ["none"] = "placeholdericon_fill.png",
                 ["arrows_outward_line"] = "arrows_outward_line.png",

--- a/src/library/DIPS.Mobile.UI/Resources/Icons/Icons.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Icons/Icons.cs
@@ -7,7 +7,7 @@ public static partial class Icons
     /// </summary>
     /// <param name="iconName">The name of the color to get</param>
     /// <returns><see cref="string"/></returns>
-    public static ImageSource GetIcon(IconName iconName)
+    public static string GetIcon(IconName iconName)
     {
         if (!IconResources.Icons.TryGetValue(iconName.ToString(), out var value))
         {


### PR DESCRIPTION
### Description of Change

To prevent memory leaks when using our Icons api, we've changed the return type from ImageSource to string.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->