### PR TITLE
Made sure all public image sources has a image source converter so the component do not freeze up on Android when passing strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [30.0.1] 
+- Made sure all public image sources has a image source converter so the component do not freeze up on Android when passing strings.
+
 ## [30.0.0] 
 - [Icons] Changed icons from ImageSource to string to prevent memory leaks when using icons.
 

--- a/src/app/Components/ComponentsSamples/ListItems/ListItemsSamples.xaml.cs
+++ b/src/app/Components/ComponentsSamples/ListItems/ListItemsSamples.xaml.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DIPS.Mobile.UI.Components.ListItems;
+using DIPS.Mobile.UI.Resources.Icons;
 
 namespace Components.ComponentsSamples.ListItems;
 
@@ -11,5 +13,13 @@ public partial class ListItemsSamples
     public ListItemsSamples()
     {
         InitializeComponent();
+    }
+
+    private void VisualElement_OnLoaded(object? sender, EventArgs e)
+    {
+        if (sender is ListItem listItem)
+        {
+            listItem.Icon = Icons.GetIcon(IconName.image_fill);
+        }
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/SystemMessage/SystemMessageConfigurator.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/SystemMessage/SystemMessageConfigurator.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
 using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 
@@ -10,5 +11,6 @@ internal class SystemMessageConfigurator : ISystemMessageConfigurator
     public Color IconColor { get; set; } = Colors.GetColor(ColorName.color_system_white);
     public float Duration { get; set; } = 2500;
     public string Text { get; set; } = DUILocalizedStrings.YouHaveNotSetSomeText;
+    [TypeConverter(nameof(ImageSourceConverter))]
     public ImageSource? Icon { get; set; }
 }

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetHandler.cs
@@ -21,6 +21,7 @@ using Object = Java.Lang.Object;
 using RelativeLayout = Android.Widget.RelativeLayout;
 using ADrawableCompat = AndroidX.Core.Graphics.Drawable.DrawableCompat;
 using Paint = Android.Graphics.Paint;
+using System.ComponentModel;
 
 namespace DIPS.Mobile.UI.Components.BottomSheets;
 
@@ -385,6 +386,7 @@ class TextOrIconDrawable : DrawerArrowDrawable
     public Drawable? IconBitmap { get; set; }
     public string Text { get; set; }
     public Color TintColor { get; set; }
+    [TypeConverter(nameof(ImageSourceConverter))]
     public ImageSource IconBitmapSource { get; set; }
     float _defaultSize;
 

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.Properties.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Windows.Input;
 
 namespace DIPS.Mobile.UI.Components.ContextMenus;
@@ -139,6 +140,7 @@ public partial class ContextMenuItem
     /// <summary>
     /// The icon to be used as a image with the context menu item
     /// </summary>
+    [TypeConverter(nameof(ImageSourceConverter))]
     public ImageSource? Icon
     {
         get => (ImageSource)GetValue(IconProperty);

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
@@ -44,6 +44,7 @@ namespace DIPS.Mobile.UI.Components.ListItems
         /// <summary>
         /// Sets the Icon of the <see cref="ListItem"/>, which will be displayed to the left of <see cref="Title"/>
         /// </summary>
+        [TypeConverter(nameof(ImageSourceConverter))]
         public ImageSource Icon
         {
             get => (ImageSource)GetValue(IconProperty);

--- a/src/library/DIPS.Mobile.UI/Components/Loading/StateView/EmptyViewModel.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Loading/StateView/EmptyViewModel.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using DIPS.Mobile.UI.MVVM;
 using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
 
@@ -32,6 +33,7 @@ public class EmptyViewModel : ViewModel, IRefreshableViewModel
     /// Sets the icon
     /// </summary>
     /// <remarks>Optional</remarks>
+    [TypeConverter(nameof(ImageSourceConverter))]
     public ImageSource? Icon
     {
         get => m_icon;

--- a/src/library/DIPS.Mobile.UI/Components/Loading/StateView/ErrorViewModel.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Loading/StateView/ErrorViewModel.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Windows.Input;
 using DIPS.Mobile.UI.MVVM;
 using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
@@ -33,6 +34,7 @@ public class ErrorViewModel : ViewModel, IRefreshableViewModel
     /// Sets the icon
     /// </summary>
     /// <remarks>Optional</remarks>
+    [TypeConverter(nameof(ImageSourceConverter))]
     public ImageSource? Icon
     {
         get => m_icon;

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/ExtendedNavigationMenuButton/ExtendedNavigationMenuButton.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/ExtendedNavigationMenuButton/ExtendedNavigationMenuButton.Properties.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Windows.Input;
 using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 
@@ -18,6 +19,7 @@ internal partial class ExtendedNavigationMenuButton
     /// <summary>
     /// Sets the icon
     /// </summary>
+    [TypeConverter(nameof(ImageSourceConverter))]
     public ImageSource Icon
     {
         get => (ImageSource)GetValue(IconProperty);

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/NavigationMenuButton/NavigationMenuButton.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/NavigationMenuButton/NavigationMenuButton.Properties.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Windows.Input;
 using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 
@@ -8,6 +9,7 @@ internal partial class NavigationMenuButton
     /// <summary>
     /// Sets the icon
     /// </summary>
+    [TypeConverter(nameof(ImageSourceConverter))]
     public ImageSource Icon
     {
         get => (ImageSource)GetValue(IconProperty);

--- a/src/library/DIPS.Mobile.UI/Resources/Icons/Icons.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Icons/Icons.cs
@@ -16,6 +16,16 @@ public static partial class Icons
 
         return value;
     }
+    
+    /// <summary>
+    /// Get the icon value from a <see cref="IconName"/> as <see cref="ImageSource"/>
+    /// </summary>
+    /// <param name="iconName">The name of the color to get</param>
+    /// <returns></returns>
+    public static ImageSource GetIconAsImageSource(IconName iconName)
+    {
+        return ImageSource.FromFile(GetIcon(iconName));
+    }
 
     public static string GetIconName(IconName iconName) => iconName.ToString();
 }


### PR DESCRIPTION
### Description of Change

Made sure all public image sources has a image source converter so the component do not freeze up on Android when passing strings.


### Todos
- [X] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->