### PR TITLE
ContextMenuToolbarItem memory leak and modal bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [31.0.5]
+- [ContextMenuToolbarItem][Android] Made sure menu listeners are re-added when a modal page has been popped.
+- [ContextMenuToolbarItem][Android] Made sure it does not memoery leak.
+
 ## [31.0.4]
 - [ContextMenuToolbarItem] Bindings for Context Menu Items now works.
 

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -10,41 +10,31 @@
                  x:Class="Playground.HåvardSamples.HåvardPage"
                  ShouldHideFloatingNavigationMenuButton="True"
                  Padding="0">
-    <CarouselView Loop="False" x:Name="carouselView" BackgroundColor="Magenta">
-        <CarouselView.ItemTemplate>
-            <DataTemplate x:DataType="{x:Type håvardSamples:Item}">
-                <VerticalStackLayout
-                    Spacing="25"
-                    Padding="30,0"
-                    BackgroundColor="{Binding Color}"
-                    VerticalOptions="Fill">
-
-                    <Image
-                        Source="dotnet_bot.png"
-                        SemanticProperties.Description="Cute dot net bot waving hi to you!"
-                        HeightRequest="200"
-                        HorizontalOptions="Center" />
-
-                    <Label
-                        Text="Hello, World!"
-                        SemanticProperties.HeadingLevel="Level1"
-                        FontSize="32"
-                        HorizontalOptions="Center" />
-
-                    <Label
-                        Text="Welcome to .NET Multi-platform App UI"
-                        SemanticProperties.HeadingLevel="Level2"
-                        SemanticProperties.Description="Welcome to dot net Multi platform App U I"
-                        FontSize="18"
-                        HorizontalOptions="Center" />
-
-                    <Button
-                        Text="Don't touch me"
-                        SemanticProperties.Hint="Counts the number of times you click"
-                        HorizontalOptions="Center" />
-
-                </VerticalStackLayout>
-            </DataTemplate>
-        </CarouselView.ItemTemplate>
-        </CarouselView>
+    <dui:ContentPage.ToolbarItems>
+        <dui:ContextMenuToolbarItem IconImageSource="{dui:Icons alert_fill}">
+            <dui:ContextMenuToolbarItem.ContextMenu>
+                <dui:ContextMenu Title="Context menu">
+                    <dui:ContextMenuItem Title="Item 1"
+                                         IsCheckable="True"
+                                         DidClick="ContextMenuItem_OnDidClick" />
+                    <dui:ContextMenuItem Title="Item 2"
+                                         DidClick="ContextMenuItem_OnDidClick" />
+                </dui:ContextMenu>
+            </dui:ContextMenuToolbarItem.ContextMenu>
+        </dui:ContextMenuToolbarItem>
+        <dui:ContextMenuToolbarItem IconImageSource="{dui:Icons alert_fill}">
+            <dui:ContextMenuToolbarItem.ContextMenu>
+                <dui:ContextMenu Title="Context menu">
+                    <dui:ContextMenuItem Title="Item 1"
+                                         IsCheckable="True"
+                                         DidClick="ContextMenuItem_OnDidClick" />
+                    <dui:ContextMenuItem Title="Item 2"
+                                         DidClick="ContextMenuItem_OnDidClick" />
+                </dui:ContextMenu>
+            </dui:ContextMenuToolbarItem.ContextMenu>
+        </dui:ContextMenuToolbarItem>
+            
+    </dui:ContentPage.ToolbarItems>
+    <!-- <dui:Button Text="Open modal" -->
+    <!--             Clicked="Button_OnClicked" /> -->
 </dui:ContentPage>

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml.cs
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Input;
 using DIPS.Mobile.UI.API.Camera.BarcodeScanning;
+using DIPS.Mobile.UI.Components.Alerting.Dialog;
 using DIPS.Mobile.UI.Resources.Icons;
 using Image = DIPS.Mobile.UI.Components.Images.Image.Image;
 
@@ -10,48 +11,16 @@ public partial class HåvardPage
     public HåvardPage()
     {
         InitializeComponent();
-        m_barcodeScanner = new BarcodeScanner();
-        m_image = new Image() {Source = Icons.GetIcon(IconName.document_fill)};
         
-        carouselView.ItemsSource = new object[]
-        {
-            new Item { Color = Colors.Red },
-            new Item { Color = Colors.Green },
-            new Item { Color = Colors.Yellow },
-            new Item { Color = Colors.Blue },
-        };
+    }
+    
+    private void ContextMenuItem_OnDidClick(object sender, EventArgs e)
+    {
+        DialogService.ShowMessage("You tapped it", "yey!", "Ok");
     }
 
-    public ICommand NavigateCommand => new Command<string>(async s =>
+    private void Button_OnClicked(object sender, EventArgs e)
     {
-        App.Current.MainPage.Navigation.PushAsync(new HåvardPage());
-    });
-
-    protected override async void OnAppearing()
-    {
-        base.OnAppearing();
+        Shell.Current.Navigation.PushModalAsync(new HåvardPage3());
     }
-
-    public static readonly BindableProperty HideTextProperty = BindableProperty.Create(
-        nameof(HideText),
-        typeof(bool),
-        typeof(HåvardPage));
-
-    private readonly BarcodeScanner m_barcodeScanner;
-    private readonly Image m_image;
-
-    public bool HideText
-    {
-        get => (bool)GetValue(HideTextProperty);
-        set => SetValue(HideTextProperty, value);
-    }
-
-    // private void ShowTip(object sender, EventArgs e)
-    // {
-    //     TipService.Show("Testing tip", Label);
-    // }
-}
-public class Item
-{
-    public Color Color { get; set; }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Android/ShellRenderer.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Android/ShellRenderer.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Android.App;
 using Android.OS;
+using Android.Text.Method;
 using Android.Views;
 using Android.Widget;
 using AndroidX.DrawerLayout.Widget;
@@ -22,12 +23,6 @@ public partial class ShellRenderer : Microsoft.Maui.Controls.Handlers.Compatibil
 {
     protected override IShellToolbarAppearanceTracker CreateToolbarAppearanceTracker() => ToolbarApperanceTrancer = new CustomToolbarAppearanceTracker(this);
 
-    protected override IShellToolbarTracker CreateTrackerForToolbar(Toolbar toolbar)
-    {
-        return new CustomToolbarAppearanceTracker.CustomShellToolbarTracker(this, toolbar,
-            ((IShellContext)this).CurrentDrawerLayout);
-    }
-
     internal CustomToolbarAppearanceTracker ToolbarApperanceTrancer { get; set; }
 }
 
@@ -43,31 +38,35 @@ internal class CustomToolbarAppearanceTracker : ShellToolbarAppearanceTracker
         Toolbar = toolbar;
         m_appearance = appearance;
         
+        toolbar.LayoutChange -= ToolbarOnLayoutChange;
         toolbar.LayoutChange += ToolbarOnLayoutChange;  
-        
-        SetToolbarItemsTint();
     }
     
 
-    private void SetToolbarItemsTint()
-    {       
-        for (var i = 0; i < Toolbar?.Menu?.Size(); i++)
-        {
-            var toolbarItem = Toolbar.Menu.GetItem(i);
-            
-            toolbarItem!.SetIconTintList(m_appearance?.ForegroundColor.ToDefaultColorStateList());
-        }
-    }
 
     private void ToolbarOnLayoutChange(object? sender,View.LayoutChangeEventArgs layoutChangeEventArgs )
     {
-        SetToolbarItemsTint();
+        for (var i = 0; i < Toolbar.Menu?.Size(); i++)
+        {
+            var page = Microsoft.Maui.Controls.Shell.Current.CurrentPage;
+            
+            if (page.ToolbarItems.Count == 0) return;
+            var toolbarItem = page.ToolbarItems[i];
+            
+            var menuItem = Toolbar.Menu?.GetItem(i);
+            if (menuItem?.IconTintList == null) //Fixes toolbar item icon and text color bug.
+            {
+                menuItem!.SetIconTintList(m_appearance?.ForegroundColor.ToDefaultColorStateList());    
+            }
+
+            if(toolbarItem is not ContextMenuToolbarItem contextMenuToolbarItem)
+                continue;
+            menuItem?.SetOnMenuItemClickListener(new ToolbarMenuItemClickListener(contextMenuToolbarItem.ContextMenu, Toolbar));
+        }
+
     }
 
-    public CustomToolbarAppearanceTracker(IShellContext shellContext) : base(shellContext)
-    {
-        
-    }
+    public CustomToolbarAppearanceTracker(IShellContext shellContext) : base(shellContext) { }
     
     protected override void Dispose(bool disposing)
     {
@@ -76,53 +75,14 @@ internal class CustomToolbarAppearanceTracker : ShellToolbarAppearanceTracker
         if(Toolbar is null)
             return;
         
-        Toolbar.LayoutChange -= ToolbarOnLayoutChange;  
-    }
-
-    internal class CustomShellToolbarTracker : ShellToolbarTracker
-    {
-        private bool m_isChangingPage;
-
-        public CustomShellToolbarTracker(IShellContext shellContext, Toolbar toolbar, DrawerLayout drawerLayout) : base(shellContext, toolbar, drawerLayout)
+        Toolbar.LayoutChange -= ToolbarOnLayoutChange;
+        for (var i = 0; i < Toolbar.Menu?.Size(); i++)
         {
-        }
-
-        protected override void OnPageChanged(Page oldPage, Page newPage)
-        {
-            m_isChangingPage = true;
-            
-            base.OnPageChanged(oldPage, newPage);
-        }
-
-        protected async override void UpdateToolbarItems(Toolbar toolbar, Page page)
-        {
-            base.UpdateToolbarItems(toolbar, page);
-            
-            // Need to have a delay of 400ms here for some reason, otherwise the toolbar item changes will be overwritten.
-            // However, the time it takes to update the toolbar items will most likely be finished when animating to the page is done, so it's not a problem
-            await Task.Delay(400);
-
-            try
-            {
-                for (var i = 0; i < toolbar.Menu?.Size(); i++)
-                {
-                    var toolbarItem = page.ToolbarItems[i];
-                
-                    if(toolbarItem is not ContextMenuToolbarItem contextMenuToolbarItem)
-                        continue;
-                
-                    var menuItem = toolbar.Menu?.GetItem(i);
-                    menuItem?.SetShowAsAction(ShowAsAction.Always);
-                    menuItem?.SetOnMenuItemClickListener(new ToolbarMenuItemClickListener(contextMenuToolbarItem.ContextMenu, toolbar));
-                }
-            }
-            catch
-            {
-                // Exceptions can happen if toolbar is disposed after the delay
-            }
+            var menuItem = Toolbar.Menu?.GetItem(i);
+            menuItem?.SetOnMenuItemClickListener(null);
         }
     }
-    
+
     private class ToolbarMenuItemClickListener : Object, IMenuItemOnMenuItemClickListener, Application.IActivityLifecycleCallbacks, PopupMenu.IOnDismissListener, PopupMenu.IOnMenuItemClickListener
     {
         private readonly ContextMenu m_contextMenu;


### PR DESCRIPTION
### Description of Change

- [ContextMenuToolbarItem][Android] Made sure menu listeners are re-added when a modal page has been popped.
- [ContextMenuToolbarItem][Android] Made sure it does not memoery leak.



### Todos
- [X] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->