### PR TITLE
Task/sani shell crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [31.0.5]
+## [31.0.6]
 - [ShellRenderer][Android] Null check on `CurrentPage`.
 
 ## [31.0.5]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [31.0.5]
+- [ShellRenderer][Android] Null check on `CurrentPage`.
+
+## [31.0.5]
 - [ContextMenuToolbarItem][Android] Made sure menu listeners are re-added when a modal page has been popped.
 - [ContextMenuToolbarItem][Android] Made sure it does not memoery leak.
 

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Android/ShellRenderer.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Android/ShellRenderer.cs
@@ -49,6 +49,8 @@ internal class CustomToolbarAppearanceTracker : ShellToolbarAppearanceTracker
         for (var i = 0; i < Toolbar.Menu?.Size(); i++)
         {
             var page = Microsoft.Maui.Controls.Shell.Current.CurrentPage;
+            if (page is null)
+                return;
             
             if (page.ToolbarItems.Count == 0) return;
             var toolbarItem = page.ToolbarItems[i];


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

Ser ut som at når man i Arena Mobil kaller `INavigationService.SwapRootTo()` at `Microsoft.Maui.Controls.Shell.Current.CurrentPage` kan være null når `ShellRenderer.ToolbarOnLayoutChange()` kjører. Returnerer derfor bare dersom dette er tilfellet

### Todos
- [x] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->