### PR TITLE
Fixed an issue where the app could crash when navigating back and forth if the automatic memory resolving were activated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [35.0.1]
+- Fixed an issue where the app could crash when navigating back and forth if the automatic memory resolving were activated.
+
 ## [35.0.0]
 - Updated .NET MAUI from 8.0.60 to 8.0.70.
 

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
@@ -90,8 +90,9 @@ namespace DIPS.Mobile.UI.Components.Shell
         public static ColorName ToolbarBackgroundColorName => ColorName.color_primary_90;
         public static ColorName ToolbarTitleTextColorName => ColorName.color_system_white;
 
-        private async Task TryResolvePoppedPages(List<WeakReference> pages)
+        private static async Task TryResolvePoppedPages(List<WeakReference> pages)
         {
+            var currentPage = Current.CurrentPage;
             while (pages.Count > 0)
             {
                 var page = pages[0];
@@ -101,7 +102,7 @@ namespace DIPS.Mobile.UI.Components.Shell
                     continue;
                 }
 
-                if (page.Target == Current.CurrentPage)
+                if (page.Target == currentPage)
                 {
                     pages.Clear();
                     break;


### PR DESCRIPTION
### Description of Change

This could happen if you navigate back and forth, because the call to resolve is awaited, the current page can be changed while the app is in the while loop. With this fix, the "current page" will stay the same

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->