### PR TITLE
Fixed two bugs in Chip and ChipGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [35.0.2]
+- [Android][Chip] Fixed an issue where checkmark were sometimes not visible or the checkmark icon were tinted as black
+- [Android][ChipGroup] Fixed an issue where you could not de-toggle toggled chips when multi-selected `ChipGroup` were used.
+- [Android][Chip] Some refactor and code cleanup in its handler.
+
 ## [35.0.1]
 - Fixed an issue where the app could crash when navigating back and forth if the automatic memory resolving were activated.
 

--- a/src/app/Components/ComponentsSamples/Chips/ChipsSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Chips/ChipsSamples.xaml
@@ -36,7 +36,8 @@
         <dui:Chip Title="A toggleable chip"
                   HorizontalOptions="Start"
                   VerticalOptions="Start"
-                  IsToggleable="True"/>
+                  IsToggleable="True"
+                  IsToggled="True" />
         
         <dui:Label Text="Single selection chip-group"
                    Style="{dui:Styles Label=SectionHeader}" />
@@ -63,7 +64,6 @@
             
          
         </dui:ChipGroup>
-            <dui:Button Command="{Binding Test}" Text="test" />
     </dui:VerticalStackLayout>
 
 </dui:ContentPage>

--- a/src/app/Components/ComponentsSamples/Chips/ChipsSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Chips/ChipsSamples.xaml
@@ -36,8 +36,7 @@
         <dui:Chip Title="A toggleable chip"
                   HorizontalOptions="Start"
                   VerticalOptions="Start"
-                  IsToggleable="True"
-                  IsToggled="True" />
+                  IsToggleable="True" />
         
         <dui:Label Text="Single selection chip-group"
                    Style="{dui:Styles Label=SectionHeader}" />

--- a/src/app/Components/ComponentsSamples/Chips/ChipsSamplesViewModel.cs
+++ b/src/app/Components/ComponentsSamples/Chips/ChipsSamplesViewModel.cs
@@ -32,7 +32,12 @@ public class ChipsSamplesViewModel : ViewModel
         set => RaiseWhenSet(ref m_selectedItemsFootballers1, value);
     }
 
-    public List<Footballer> Footballers => new() { new Footballer(){Name = "Odegaard"},new Footballer(){Name = "Haaland"}, new Footballer(){Name = "Messi"}};
+    public List<Footballer> Footballers { get; } =
+    [
+        new Footballer() { Name = "Odegaard" }, new Footballer() { Name = "Haaland" },
+        new Footballer() { Name = "Messi" }
+    ];
+    
     public ICommand Test => new Command(Testeren);
     
     public ICommand FootballerChangedCommand { get; }

--- a/src/library/DIPS.Mobile.UI/Components/ChipGroup/ChipGroup.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ChipGroup/ChipGroup.cs
@@ -112,7 +112,8 @@ public partial class ChipGroup : ContentView
 
         if (chipGroupItem.Chip.IsToggled)
         {
-            m_selectedItems.Add(chipGroupItem);
+            if(m_selectedItems.FirstOrDefault(item => item.Chip.Title.Equals(chipGroupItem.Chip.Title)) is null)
+                m_selectedItems.Add(chipGroupItem);
         }
         else
         {

--- a/src/library/DIPS.Mobile.UI/Components/Chips/Android/ChipHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/Android/ChipHandler.cs
@@ -97,12 +97,12 @@ public partial class ChipHandler : ViewHandler<Chip, Google.Android.Material.Chi
         handler.PlatformView.SetTextColor(chip.TitleColor.ToPlatform());
     }
 
-    private static async partial void MapIsToggleable(ChipHandler handler, Chip chip)
+    private static partial void MapIsToggleable(ChipHandler handler, Chip chip)
     {
         if (chip.IsCloseable || !chip.IsToggleable)
             return;
 
-        await Task.Delay(1);
+        /*await Task.Delay(1);*/
         
         handler.PlatformView.Checkable = handler.PlatformView.CheckedIconVisible = true;
         handler.PlatformView.Checked = chip.IsToggled;

--- a/src/library/DIPS.Mobile.UI/Components/Chips/Android/ChipHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/Android/ChipHandler.cs
@@ -101,8 +101,6 @@ public partial class ChipHandler : ViewHandler<Chip, Google.Android.Material.Chi
     {
         if (chip.IsCloseable || !chip.IsToggleable)
             return;
-
-        /*await Task.Delay(1);*/
         
         handler.PlatformView.Checkable = handler.PlatformView.CheckedIconVisible = true;
         handler.PlatformView.Checked = chip.IsToggled;

--- a/src/library/DIPS.Mobile.UI/Components/Chips/Android/ChipHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/Android/ChipHandler.cs
@@ -1,10 +1,3 @@
-using Android.Content.Res;
-using Android.Runtime;
-using Android.Text;
-using DIPS.Mobile.UI.API.Library;
-using DIPS.Mobile.UI.Components.Chips.Android;
-using Java.Interop;
-using Android.Graphics.Fonts;
 using Android.Text;
 using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.Components.Chips.Android;
@@ -13,7 +6,6 @@ using DIPS.Mobile.UI.Resources.Styles.Label;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
-using Font = Microsoft.Maui.Graphics.Font;
 using TextAlignment = Android.Views.TextAlignment;
 
 
@@ -22,7 +14,7 @@ namespace DIPS.Mobile.UI.Components.Chips;
 
 public partial class ChipHandler : ViewHandler<Chip, Google.Android.Material.Chip.Chip>
 {
-    protected override Google.Android.Material.Chip.Chip CreatePlatformView() => new Google.Android.Material.Chip.Chip(Context);
+    protected override Google.Android.Material.Chip.Chip CreatePlatformView() => new(Context);
 
     protected override void ConnectHandler(Google.Android.Material.Chip.Chip platformView)
     {
@@ -41,14 +33,6 @@ public partial class ChipHandler : ViewHandler<Chip, Google.Android.Material.Chi
     private void OnChipTapped(object? sender, EventArgs e)
     {
         OnChipTapped();
-    }
-
-    protected override void DisconnectHandler(Google.Android.Material.Chip.Chip platformView)
-    {
-        base.DisconnectHandler(platformView);
-        platformView.SetOnCloseIconClickListener(null);
-        platformView.SetOnCheckedChangeListener(null);
-        platformView.Click -= OnChipTapped;
     }
 
     private static partial void MapTitle(ChipHandler handler, Chip chip)
@@ -80,37 +64,14 @@ public partial class ChipHandler : ViewHandler<Chip, Google.Android.Material.Chi
 
     private static partial void MapColor(ChipHandler handler, Chip chip)
     {
-        if (handler.VirtualView.Color == null) return;
-        handler.PlatformView.ChipBackgroundColor = new ColorStateList(CreateColorStates(handler.VirtualView.Color, out var colors), colors);
-    }
-
-    private static int[][] CreateColorStates(Color color, out int[] colors)
-    {
-        var states = new[]
-        {
-            new[] {global::Android.Resource.Attribute.StateEnabled}, // enabled
-            new[] {-global::Android.Resource.Attribute.StateEnabled}, // disabled
-            new[] {-global::Android.Resource.Attribute.StateChecked}, // unchecked
-            new[] {global::Android.Resource.Attribute.StateChecked}, // checked
-            new[] {global::Android.Resource.Attribute.StateChecked} // pressed
-        };
-
-        colors = new int[]
-        {
-            color.ToPlatform(),
-            color.ToPlatform(),
-            color.ToPlatform(),
-            color.ToPlatform(),
-            color.ToPlatform()
-        };
-        return states;
+        if (chip.Color == null) return;
+        handler.PlatformView.ChipBackgroundColor = chip.Color.ToDefaultColorStateList();
     }
 
     private static partial void MapCloseButtonColor(ChipHandler handler, Chip chip)
     {
-        if (handler.VirtualView.CloseButtonColor == null) return;
-        handler.PlatformView.CloseIcon?.SetTint(handler.VirtualView.CloseButtonColor.ToPlatform());
-
+        if (chip.CloseButtonColor == null) return;
+        handler.PlatformView.CloseIcon?.SetTint(chip.CloseButtonColor.ToPlatform());
     }
 
     private static partial void MapCornerRadius(ChipHandler handler, Chip chip)
@@ -122,8 +83,7 @@ public partial class ChipHandler : ViewHandler<Chip, Google.Android.Material.Chi
     {
         if (chip.BorderColor == null) return;
 
-        handler.PlatformView.ChipStrokeColor =
-            new ColorStateList(CreateColorStates(chip.BorderColor, out var colors), colors);
+        handler.PlatformView.ChipStrokeColor = chip.BorderColor.ToDefaultColorStateList();
     }
 
     private static partial void MapBorderWidth(ChipHandler handler, Chip chip)
@@ -135,21 +95,26 @@ public partial class ChipHandler : ViewHandler<Chip, Google.Android.Material.Chi
     {
         if (chip.TitleColor is null) return;
         handler.PlatformView.SetTextColor(chip.TitleColor.ToPlatform());
-        if (!handler.VirtualView.IsToggleable) return; //Do not change close icon color
-        handler.PlatformView.CheckedIconTint = new ColorStateList(CreateColorStates(handler.VirtualView.TitleColor, out var colors), colors);
     }
 
-    private static partial void MapIsToggleable(ChipHandler handler, Chip chip)
+    private static async partial void MapIsToggleable(ChipHandler handler, Chip chip)
     {
-        if (handler.VirtualView.IsCloseable || !handler.VirtualView.IsToggleable)
+        if (chip.IsCloseable || !chip.IsToggleable)
             return;
+
+        await Task.Delay(1);
         
         handler.PlatformView.Checkable = handler.PlatformView.CheckedIconVisible = true;
+        handler.PlatformView.Checked = chip.IsToggled;
+        
         DUI.TryGetResourceId(Icons.GetIconName(handler.ToggledIconName), out var id, defType:"drawable");
         if (id is not 0)
         {
+#pragma warning disable CA1422
             var drawable = Platform.AppContext.Resources?.GetDrawable(id);
+#pragma warning restore CA1422
             handler.PlatformView.CheckedIcon = drawable;
+            handler.PlatformView.CheckedIconTint = chip.TitleColor?.ToDefaultColorStateList();
         }
         handler.PlatformView.SetOnCheckedChangeListener(new OnToggledChangedListener(handler));
     }
@@ -157,9 +122,18 @@ public partial class ChipHandler : ViewHandler<Chip, Google.Android.Material.Chi
     private static partial void MapIsToggled(ChipHandler handler, Chip chip)
     {
         //Make sure not to mess with close button + check if chip actually is toggleable
-        if (handler.VirtualView.IsCloseable || !handler.VirtualView.IsToggleable)
+        if (chip.IsCloseable || !chip.IsToggleable)
             return;
-
-        handler.PlatformView.Checked = handler.VirtualView.IsToggled;
+        
+        handler.PlatformView.Checked = chip.IsToggled;
+    }
+    
+    protected override void DisconnectHandler(Google.Android.Material.Chip.Chip platformView)
+    {
+        base.DisconnectHandler(platformView);
+        
+        platformView.SetOnCloseIconClickListener(null);
+        platformView.SetOnCheckedChangeListener(null);
+        platformView.Click -= OnChipTapped;
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Chips/Android/OnToggledChangedListener.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/Android/OnToggledChangedListener.cs
@@ -1,4 +1,5 @@
 using Android.Widget;
+using Microsoft.Maui.Platform;
 
 namespace DIPS.Mobile.UI.Components.Chips;
 
@@ -10,8 +11,11 @@ internal class OnToggledChangedListener : Java.Lang.Object, CompoundButton.IOnCh
         m_handler = handler;
     }
     
-    public void OnCheckedChanged(CompoundButton? buttonView, bool isChecked)
+    public async void OnCheckedChanged(CompoundButton? buttonView, bool isChecked)
     {
         m_handler.VirtualView.IsToggled = isChecked;
+
+        await Task.Delay(1);
+        m_handler.PlatformView.CheckedIconTint = m_handler.VirtualView.TitleColor?.ToDefaultColorStateList();
     }
 }


### PR DESCRIPTION
### Description of Change

Sometimes the checkmark were not visible, or the checkmark were of black color. This was due to the TitleColor was set to black when the Chip was initialized, now we update the checkmark color when the Chip is toggled.

Furthermore, when ChipGroup was set to multiple mode, the chips were not able to be un-toggled. This was because we added duplicate objects to the SelectedItems. There is now an if-check in place to make sure this does not happen.

### Todos
- [X] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->