### PR TITLE
[MemoryLeak] Fixed an error where if you removed a page from the stack while in a modal context, all pages in the navigation stack would try to be resolved for memory leaks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [35.0.3]
-- [MemoryLeak] Fixed an error where if you removed a page from the stack while in a modal context, all pages in the navigation stack would try to be broke down by the automatic memory leak fix tooling.
+- [MemoryLeak] Fixed an error where if you removed a page from the stack while in a modal context, all pages in the navigation stack would try to be resolved for memory leaks.
 
 ## [35.0.2]
 - [Android][Chip] Fixed an issue where checkmark were sometimes not visible or the checkmark icon were tinted as black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [35.0.3]
 - [MemoryLeak] Fixed an error where if you removed a page from the stack while in a modal context, all pages in the navigation stack would try to be resolved for memory leaks.
+- Refactor `TryResolvePoppedPages` function.
 
 ## [35.0.2]
 - [Android][Chip] Fixed an issue where checkmark were sometimes not visible or the checkmark icon were tinted as black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [35.0.3]
-- [MemoryLeak] Fixed an error where if you removed a page from the stack while in a modal context, all pages would try to be broke down by automatic memory leak tooling.
+- [MemoryLeak] Fixed an error where if you removed a page from the stack while in a modal context, all pages in the navigation stack would try to be broke down by the automatic memory leak fix tooling.
 
 ## [35.0.2]
 - [Android][Chip] Fixed an issue where checkmark were sometimes not visible or the checkmark icon were tinted as black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [35.0.3]
+- [MemoryLeak] Fixed an error where if you removed a page from the stack while in a modal context, all pages would try to be broke down by automatic memory leak tooling.
+
 ## [35.0.2]
 - [Android][Chip] Fixed an issue where checkmark were sometimes not visible or the checkmark icon were tinted as black
 - [Android][ChipGroup] Fixed an issue where you could not de-toggle toggled chips when multi-selected `ChipGroup` were used.

--- a/src/app/Playground/MainPage.xaml.cs
+++ b/src/app/Playground/MainPage.xaml.cs
@@ -15,26 +15,7 @@ public partial class MainPage
 
     private void GoToVetle(object sender, EventArgs e)
     {
-        /*Shell.Current.Navigation.PushAsync(new VetlePage());*/
-        var tabBar = new TabBar {Route = "app"};
-
-        tabBar.Items.Add(new Tab
-        {
-            Title = "Test",
-            Icon = Icons.GetIcon(IconName.alert_fill),
-            Items =
-            {
-                new ShellContent
-                {
-                    ContentTemplate = new DataTemplate(() => new VetleTestPage1())
-                }
-            }
-        });
-
-        Shell.Current.Items.Clear();
-        Shell.Current.Items.Add(tabBar);
-
-        _ = Shell.Current.GoToAsync("//app");
+        Shell.Current.Navigation.PushAsync(new VetlePage());
     }
 
     private void GoToHåvard(object sender, EventArgs e)

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -9,15 +9,14 @@
                  x:Class="Playground.VetleSamples.VetlePage"
                  x:DataType="{x:Type vetleSamples:VetlePageViewModel}"
                  Padding="20"
-                 x:Name="This"
-                 HideSoftInputOnTapped="True">
+                 x:Name="This">
 
     <dui:ContentPage.BindingContext>
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
 
     
-     <dui:Button Clicked="Button_OnClicked"
+     <dui:Button Command="{Binding Navigate}"
                         Text="hello"></dui:Button>
     
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetleTestPage1.xaml
+++ b/src/app/Playground/VetleSamples/VetleTestPage1.xaml
@@ -13,6 +13,10 @@
                  IsSavingCompleted="{Binding IsSavingCompleted}"
                  SavingCompletedCommand="{Binding CompletedCommand}">
 
+    <dui:ContentPage.BindingContext>
+        <vetleSamples:VetleTestPage1ViewModel />
+    </dui:ContentPage.BindingContext>
+    
     <dui:ContentPage.ToolbarItems>
         <ToolbarItem IconImageSource="{dui:Icons bell_fill}" Command="{Binding Test}" />
         <ToolbarItem Text="Test" />
@@ -22,26 +26,8 @@
 
     
     
-    <dui:VerticalStackLayout BackgroundColor="Green"
-                             WidthRequest="100"
-                             HeightRequest="100"
-                             dui:Layout.CornerRadius="10, 10, 10, 10">
-        
-        
-        <dui:Button Clicked="Button_OnClicked" Text="error" Command="{Binding Navigate}" />
-      
-        <dui:Button Command="{Binding Test}" Text="success" />
-        
-        <dui:NavigationListItem Title="GoToAsync" 
-                                       Tapped="NavigationListItem_OnTapped"> </dui:NavigationListItem>
-        
-        <Grid WidthRequest="100"
-              HeightRequest="120"
-              BackgroundColor="Black"
-              dui:Touch.Command="{Binding Test}"
-              dui:Touch.LongPressCommand="{Binding Test}" />
-        
-    </dui:VerticalStackLayout>
+    <dui:Button Text="Hello"
+                Command="{Binding Navigate}"/>
 
 
 </dui:ContentSavePage>

--- a/src/app/Playground/VetleSamples/VetleTestPage2.xaml
+++ b/src/app/Playground/VetleSamples/VetleTestPage2.xaml
@@ -12,14 +12,6 @@
         <vetleSamples:VetleTestPage1ViewModel />
     </dui:ContentPage.BindingContext>
     
-    <dui:VerticalStackLayout>
-        <extensions:NavigationListItem Title="hei" 
-                                       Tapped="NavigationListItem_OnTapped"> </extensions:NavigationListItem>
-        
-        <Grid WidthRequest="100"
-                HeightRequest="120"
-                BackgroundColor="Black"
-                dui:Touch.Command="{Binding Test}"
-                dui:Touch.LongPressCommand="{Binding Test}" />
-    </dui:VerticalStackLayout>
+    <dui:Button Clicked="Button_OnClicked" />
+    
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetleTestPage2.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetleTestPage2.xaml.cs
@@ -18,4 +18,9 @@ public partial class VetleTestPage2
     {
         
     }
+
+    private void Button_OnClicked(object sender, EventArgs e)
+    {
+        Shell.Current.Navigation.PushModalAsync(new VetleTestPage3());
+    }
 }

--- a/src/app/Playground/VetleSamples/VetleTestPage3.xaml
+++ b/src/app/Playground/VetleSamples/VetleTestPage3.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:dui="http://dips.com/mobile.ui"
+             x:Class="Playground.VetleSamples.VetleTestPage3">
+
+    <dui:Button Text="Hello"
+                Clicked="Button_OnClicked"/>
+    
+</dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetleTestPage3.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetleTestPage3.xaml.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Playground.VetleSamples;
+
+public partial class VetleTestPage3
+{
+    public VetleTestPage3()
+    {
+        InitializeComponent();
+    }
+
+    private void Button_OnClicked(object sender, EventArgs e)
+    {
+        var page = Shell.Current.Navigation.NavigationStack.FirstOrDefault(page => page?.GetType() == typeof(VetleTestPage1));
+        Shell.Current.Navigation.RemovePage(page);
+        
+        _ = Shell.Current.Navigation.PopModalAsync();
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
@@ -96,7 +96,7 @@ namespace DIPS.Mobile.UI.Components.Shell
             while (pages.Count > 0)
             {
                 var page = pages[0];
-                if (page.Target is null)
+                if (page.Target is null || Current.Navigation.NavigationStack.Any(p => p == page.Target))
                 {
                     pages.RemoveAt(0);
                     continue;

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
@@ -92,23 +92,15 @@ namespace DIPS.Mobile.UI.Components.Shell
 
         private static async Task TryResolvePoppedPages(List<WeakReference> pages)
         {
-            var currentPage = Current.CurrentPage;
-            while (pages.Count > 0)
+            foreach (var page in pages)
             {
-                var page = pages[0];
-                if (page.Target is null || Current.Navigation.NavigationStack.Any(p => p == page.Target))
-                {
-                    pages.RemoveAt(0);
+                if(page.Target is null)
                     continue;
-                }
 
-                if (page.Target == currentPage)
-                {
-                    pages.Clear();
-                    break;
-                }
+                // Don't try to resolve memory leaks if the page is still in the NavigationStack
+                if (Current.Navigation.NavigationStack.Any(p => p == page.Target))
+                    continue;
                 
-                pages.RemoveAt(0);
                 await GCCollectionMonitor.Instance.CheckIfContentAliveOrAndTryResolveLeaks(
                     page.Target.ToCollectionContentTarget());
             }


### PR DESCRIPTION
### Description of Change

We now check if the page is contained in the NavigationStack, if it is, don't try to tear down the page for it to be GC'ed.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->