### PR TITLE
[BottomSheet] Fixed an issue where app would crash if attempting to create a bottom bar in bottom sheet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [35.0.8]
+- [BottomSheet] Fixed an issue where app would crash if attempting to create a bottom bar in bottom sheet.
+
 ## [35.0.7]
 - [MemoryLeak] Improved GC helping and better output for developers to solve memory leaks.
 

--- a/src/app/Components/ComponentsSamples/BottomSheets/BottomSheetSamples.xaml
+++ b/src/app/Components/ComponentsSamples/BottomSheets/BottomSheetSamples.xaml
@@ -19,11 +19,15 @@
                                 Command="{dui:OpenBottomSheetCommand {x:Type sheets:BottomSheetWithToolbar}}"
                                 VerticalOptions="Start"
                                 HasBottomDivider="True"/>
+        
+        <dui:NavigationListItem Title="{x:Static localizedStrings:LocalizedStrings.BottomSheet_OpenWithBottomBar}"
+                                Command="{dui:OpenBottomSheetCommand {x:Type sheets:BottomSheetWithBottomBar}}"
+                                VerticalOptions="Start"
+                                HasBottomDivider="True"/>
 
         <dui:NavigationListItem Title="{x:Static localizedStrings:LocalizedStrings.BottomSheet}"
                                 Subtitle="{x:Static localizedStrings:LocalizedStrings.BottomSheet_OpenNotClosableInteracting}"
                                 Command="{dui:OpenBottomSheetCommand {x:Type sheets:BottomSheetNotClosableByInteracting}}"
-                                VerticalOptions="Start"
-                                HasBottomDivider="True"/>
+                                VerticalOptions="Start" />
     </dui:VerticalStackLayout>
 </dui:ContentPage>

--- a/src/app/Components/ComponentsSamples/BottomSheets/Sheets/BottomSheetWithBottomBar.xaml
+++ b/src/app/Components/ComponentsSamples/BottomSheets/Sheets/BottomSheetWithBottomBar.xaml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<dui:BottomSheet xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:dui="http://dips.com/mobile.ui"
+                 x:Class="Components.ComponentsSamples.BottomSheets.Sheets.BottomSheetWithBottomBar">
+
+    <dui:VerticalStackLayout Spacing="0">
+        <dui:Label Text="Bottom sheet with bottom bar"
+                   Style="{dui:Styles Label=SectionHeader}" />
+    </dui:VerticalStackLayout>
+
+    <dui:BottomSheet.BottombarButtons>
+        <dui:Button Text="Bottom bar" HorizontalOptions="Fill" />
+        
+    </dui:BottomSheet.BottombarButtons>
+
+</dui:BottomSheet>

--- a/src/app/Components/ComponentsSamples/BottomSheets/Sheets/BottomSheetWithBottomBar.xaml.cs
+++ b/src/app/Components/ComponentsSamples/BottomSheets/Sheets/BottomSheetWithBottomBar.xaml.cs
@@ -1,0 +1,9 @@
+namespace Components.ComponentsSamples.BottomSheets.Sheets;
+
+public partial class BottomSheetWithBottomBar
+{
+    public BottomSheetWithBottomBar()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/app/Components/Resources/LocalizedStrings/LocalizedStrings.Designer.cs
+++ b/src/app/Components/Resources/LocalizedStrings/LocalizedStrings.Designer.cs
@@ -656,5 +656,11 @@ namespace Components.Resources.LocalizedStrings {
                 return ResourceManager.GetString("Alert", resourceCulture);
             }
         }
+        
+        internal static string BottomSheet_OpenWithBottomBar {
+            get {
+                return ResourceManager.GetString("BottomSheet_OpenWithBottomBar", resourceCulture);
+            }
+        }
     }
 }

--- a/src/app/Components/Resources/LocalizedStrings/LocalizedStrings.en.resx
+++ b/src/app/Components/Resources/LocalizedStrings/LocalizedStrings.en.resx
@@ -324,4 +324,7 @@
     <data name="Alert" xml:space="preserve">
         <value>Alert</value>
     </data>
+    <data name="BottomSheet_OpenWithBottomBar" xml:space="preserve">
+        <value>Open bottom sheet that has bottom bar button</value>
+    </data>
 </root>

--- a/src/app/Components/Resources/LocalizedStrings/LocalizedStrings.resx
+++ b/src/app/Components/Resources/LocalizedStrings/LocalizedStrings.resx
@@ -329,4 +329,7 @@
     <data name="Alert" xml:space="preserve">
         <value>Alert</value>
     </data>
+    <data name="BottomSheet_OpenWithBottomBar" xml:space="preserve">
+        <value>Åpne bottom sheet som har knapper i bunn</value>
+    </data>
 </root>

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/BottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/BottomSheet.cs
@@ -101,8 +101,8 @@ namespace DIPS.Mobile.UI.Components.BottomSheets
        
             foreach (var button in BottombarButtons)
             {
-                var index = grid.ColumnDefinitions.Count - 1;
                 grid.AddColumnDefinition(new ColumnDefinition(GridLength.Star));
+                var index = grid.ColumnDefinitions.Count - 1;
                 grid.Add(button, index);
                 button.AutomationId = $"BottomBarButton{index}".ToDUIAutomationId<BottomSheet>();
             }


### PR DESCRIPTION
### Description of Change

It seems that MAUI has updated where Grid does not start with Grid.ColumnDefinitions 1, but with 0. Idk

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->