### PR TITLE
[MemoryLeak] Always wait for 9 GC collections before checking if there is any memory leaks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [35.0.8]
+- [MemoryLeak] Always wait for 9 GC collections before checking if there is any memory leaks.
+
 ## [35.0.7]
 - [MemoryLeak] Improved GC helping and better output for developers to solve memory leaks.
 

--- a/src/library/DIPS.Mobile.UI/MemoryManagement/GCCollectionMonitor.cs
+++ b/src/library/DIPS.Mobile.UI/MemoryManagement/GCCollectionMonitor.cs
@@ -105,13 +105,7 @@ public class GCCollectionMonitor
         for (; currentCollection < MaxCollections; currentCollection++)
         {
             GarbageCollection.CollectAndWaitForPendingFinalizers();
-            if (collectionContentTarget.Content.IsAlive)
-            {
-                await Task.Delay(MsBetweenCollections);
-                continue;
-            }
-
-            break;
+            await Task.Delay(MsBetweenCollections);
         }
 
         var allVisualChildrenThatLives =
@@ -124,7 +118,6 @@ public class GCCollectionMonitor
         {
             GarbageCollection.Print($"Number of leaks: {totalNumberOfLeaks}");
         }
-
 
         if (allVisualChildrenThatLives.Count > 0)
         {


### PR DESCRIPTION
### Description of Change

Even though the page does not have memory leak, does not mean we should cancel the GC collection. I found that in some pages the viewmodel needed more collections to be GC'ed.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->