### PR TITLE
[MemoryLeak] Fixed crash of app when changing root page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [35.0.10]
+- [MemoryLeak] Fixed crash of app when changing root page.
+
 ## [35.0.9]
 - [MemoryLeak] Always wait for 9 GC collections before checking if there is any memory leaks.
 

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-android;</TargetFrameworks>
+        <TargetFrameworks>net8.0-ios;</TargetFrameworks>
 
         <OutputType>Exe</OutputType>
         <RootNamespace>Playground</RootNamespace>

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
@@ -124,7 +124,7 @@ namespace DIPS.Mobile.UI.Components.Shell
                 // We set a delay of 2 seconds to be sure that the animation is done, even though we could use a lower delay.
                 if (DUI.IsDebug)
                 {
-                    DUILogService.LogDebug<Shell>("Changed root page, will wait for 2 seconds before trying to resolve memory leaks");
+                    DUILogService.LogDebug<Shell>("Changed root page, will wait for 2 seconds before trying to resolve/monitor memory leaks");
                 }
                 await Task.Delay(2000);
             }

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
@@ -121,9 +121,9 @@ namespace DIPS.Mobile.UI.Components.Shell
             {
                 // We need a delay here, because it takes some time for Shell to animate to the new root page.
                 // Because we Disconnect the handler in the CollectionContentTarget, we need to wait for the animation to finish.
-                // We set a delay of 2 seconds to be sure that the animation is done, even though we could use a lower delay.
-                DUILogService.LogDebug<Shell>("Changed root page, will wait for 2 seconds before trying to resolve/monitor memory leaks");
-                await Task.Delay(2000);
+                // We set a delay of 5 seconds to be sure that the animation is done, even though we could use a lower delay.
+                DUILogService.LogDebug<Shell>("Changed root page, will wait for 5 seconds before trying to resolve/monitor memory leaks");
+                await Task.Delay(5000);
             }
             
             try

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using DIPS.Mobile.UI.Internal.Logging;
 using DIPS.Mobile.UI.MemoryManagement;
 
@@ -116,6 +115,15 @@ namespace DIPS.Mobile.UI.Components.Shell
         private async Task TryResolvePoppedPages(List<WeakReference> pages,
             ShellNavigationSource shellNavigatedEventArgs)
         {
+
+            if (shellNavigatedEventArgs is ShellNavigationSource.ShellItemChanged)
+            {
+                // We need a delay here, because it takes some time for Shell to animate to the new root page.
+                // Because we Disconnect the handler in the CollectionContentTarget, we need to wait for the animation to finish.
+                // We set a delay of 2 seconds to be sure that the animation is done, even though we could use a lower delay.
+                await Task.Delay(2000);
+            }
+            
             try
             {
                 foreach (var page in pages)
@@ -124,7 +132,7 @@ namespace DIPS.Mobile.UI.Components.Shell
                         continue;
 
                     if (shellNavigatedEventArgs != ShellNavigationSource.ShellItemChanged &&
-                        RootPage is {Target: Page rootPage}) //Check if we should gabarge collect when swappi
+                        RootPage is {Target: Page rootPage}) //Check if we should garbage collect when swapping
                     {
                         if (page.Target == rootPage)
                         {

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
@@ -122,10 +122,7 @@ namespace DIPS.Mobile.UI.Components.Shell
                 // We need a delay here, because it takes some time for Shell to animate to the new root page.
                 // Because we Disconnect the handler in the CollectionContentTarget, we need to wait for the animation to finish.
                 // We set a delay of 2 seconds to be sure that the animation is done, even though we could use a lower delay.
-                if (DUI.IsDebug)
-                {
-                    DUILogService.LogDebug<Shell>("Changed root page, will wait for 2 seconds before trying to resolve/monitor memory leaks");
-                }
+                DUILogService.LogDebug<Shell>("Changed root page, will wait for 2 seconds before trying to resolve/monitor memory leaks");
                 await Task.Delay(2000);
             }
             

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
@@ -1,3 +1,4 @@
+using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.Internal.Logging;
 using DIPS.Mobile.UI.MemoryManagement;
 
@@ -121,6 +122,10 @@ namespace DIPS.Mobile.UI.Components.Shell
                 // We need a delay here, because it takes some time for Shell to animate to the new root page.
                 // Because we Disconnect the handler in the CollectionContentTarget, we need to wait for the animation to finish.
                 // We set a delay of 2 seconds to be sure that the animation is done, even though we could use a lower delay.
+                if (DUI.IsDebug)
+                {
+                    DUILogService.LogDebug<Shell>("Changed root page, will wait for 2 seconds before trying to resolve memory leaks");
+                }
                 await Task.Delay(2000);
             }
             

--- a/src/library/DIPS.Mobile.UI/MemoryManagement/GarbageCollection.cs
+++ b/src/library/DIPS.Mobile.UI/MemoryManagement/GarbageCollection.cs
@@ -29,6 +29,9 @@ public static class GarbageCollection
         GC.WaitForPendingFinalizers();
     }
 
+    /// <summary>
+    /// Converts the object to an object that can be used in <see cref="GCCollectionMonitor"/> for memory management related things.
+    /// </summary>
     public static CollectionContentTarget ToCollectionContentTarget(this object target)
     {
         return new CollectionContentTarget(target);


### PR DESCRIPTION
### Description of Change

We added in some versions ago that when adding to the FlatVisualChildrenList in CollectionContentTarget, they would remove their parent and disconnect its handler. This was because we saw that the memory leak propagated upwards, so if a component had a leak way inside the visual tree, all its parent controls (grandparents etc) would also leak. So with the Disconnecting of handler and removal of parent, we could contain the memory leak. 

However, when we change root, the current page is still displayed, and an animation occurs to change visually to the new root page. So, we tried to disconnect the handler while the page is still being displayed, that's why the app crashed. There is now put a delay of 2 seconds, so we avoid disconnecting the handler of the visible page.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->