### PR TITLE
[MemoryLeak] Will now try to resolve memory leaks before checking if there are any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 ## [35.0.11]
-- [MemoryLeak] Reverted trying to contain the memory leak in `CollectionContentTarget`.
 - [MemoryLeak] Will now try to resolve memory leaks before checking if there are any.
 - [MemoryLeak] Fixed duplicate checking of memory leaks in `BindingContext` of BottomSheets.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [35.0.11]
+- [MemoryLeak] Reverted trying to contain the memory leak in `CollectionContentTarget`.
+- [MemoryLeak] Will now try to resolve memory leaks before checking if there are any.
+- [MemoryLeak] Fixed duplicate checking of memory leaks in `BindingContext` of BottomSheets.
+
 ## [35.0.10]
 - [MemoryLeak] Fixed crash of app when changing root page.
 

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetFragment.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetFragment.cs
@@ -123,7 +123,7 @@ namespace DIPS.Mobile.UI.Components.BottomSheets.Android
         {
             base.OnDestroy();
             
-            TryMemoryCleanUp();            
+            _ = GCCollectionMonitor.Instance.CheckIfObjectIsAliveAndTryResolveLeaks(m_bottomSheet.ToCollectionContentTarget());
             
             m_bottomSheet.SendClose();
             BottomSheetService.RemoveFromStack(m_bottomSheet);
@@ -136,12 +136,6 @@ namespace DIPS.Mobile.UI.Components.BottomSheets.Android
 
             m_dismissTaskCompletionSource.SetResult(true);
             m_bottomSheet.OnPositioningChanged -= OnBottomSheetPositioningChanged;
-        }
-        
-        private async void TryMemoryCleanUp()
-        {
-            await GCCollectionMonitor.Instance.CheckIfObjectIsAliveAndTryResolveLeaks(m_bottomSheet.BindingContext?.ToCollectionContentTarget());
-            await GCCollectionMonitor.Instance.CheckIfObjectIsAliveAndTryResolveLeaks(m_bottomSheet.ToCollectionContentTarget());
         }
 
         public Task Close(bool animated)

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/iOS/BottomSheetViewController.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/iOS/BottomSheetViewController.cs
@@ -133,13 +133,7 @@ public class BottomSheetViewController : UIViewController
         
         BottomSheet.Handler?.DisconnectHandler();
 
-        TryMemoryCleanUp();
-    }
-
-    private async void TryMemoryCleanUp()
-    {
-        await GCCollectionMonitor.Instance.CheckIfObjectIsAliveAndTryResolveLeaks(BottomSheet.BindingContext?.ToCollectionContentTarget());
-        await GCCollectionMonitor.Instance.CheckIfObjectIsAliveAndTryResolveLeaks(BottomSheet.ToCollectionContentTarget());
+        _ = GCCollectionMonitor.Instance.CheckIfObjectIsAliveAndTryResolveLeaks(BottomSheet.ToCollectionContentTarget());
     }
 
     public void SetBackButtonVisibility()

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
@@ -120,8 +120,8 @@ namespace DIPS.Mobile.UI.Components.Shell
             if (shellNavigatedEventArgs is ShellNavigationSource.ShellItemChanged)
             {
                 // We need a delay here, because it takes some time for Shell to animate to the new root page.
-                // Because we Disconnect the handler in the CollectionContentTarget, we need to wait for the animation to finish.
-                // We set a delay of 5 seconds to be sure that the animation is done, even though we could use a lower delay.
+                // Causing it to be still visible, disconnecting the handler while the page is visible, will cause a crash.
+                // We set a delay of 5 seconds to be 100% sure that the animation is done, even though we could use a lower delay.
                 DUILogService.LogDebug<Shell>("Changed root page, will wait for 5 seconds before trying to resolve/monitor memory leaks");
                 await Task.Delay(5000);
             }

--- a/src/library/DIPS.Mobile.UI/MemoryManagement/CollectionContentTarget.cs
+++ b/src/library/DIPS.Mobile.UI/MemoryManagement/CollectionContentTarget.cs
@@ -37,8 +37,6 @@ public class CollectionContentTarget
 
         if (visualTreeElement is Element element)
         {
-            element.Parent = null;
-            element.Handler?.DisconnectHandler();
             name = element.ToString();
             if (!string.IsNullOrEmpty(element.AutomationId))
             {

--- a/src/library/DIPS.Mobile.UI/MemoryManagement/GCCollectionMonitor.cs
+++ b/src/library/DIPS.Mobile.UI/MemoryManagement/GCCollectionMonitor.cs
@@ -89,7 +89,7 @@ public class GCCollectionMonitor
     }
 
     public async Task<bool> CheckIfCollectionTargetIsAlive(CollectionContentTarget collectionContentTarget,
-        List<CollectionContentTarget>? references = null, bool shouldPrintTotalMemory = false, bool shouldPrintAllLeaks = true)
+        List<CollectionContentTarget>? references = null, bool shouldPrintTotalMemory = false)
     {
         GarbageCollection.Print($"Checking if {collectionContentTarget.Name} has memory leaks...");
         var totalMemoryBefore = 0L;
@@ -119,35 +119,29 @@ public class GCCollectionMonitor
             GarbageCollection.Print($"Number of leaks: {totalNumberOfLeaks}");
         }
 
-        if (allVisualChildrenThatLives.Count > 0 && shouldPrintAllLeaks)
+        if (allVisualChildrenThatLives.Count > 0)
         {
             GarbageCollection.Print($"---- Visual children zombies of {collectionContentTarget.Name}: ----");
         }
 
-        if (shouldPrintAllLeaks)
+        foreach (var child in allVisualChildrenThatLives)
         {
-            foreach (var child in allVisualChildrenThatLives)
+            if (child.Target.TryGetTarget(out var target))
             {
-                if (child.Target.TryGetTarget(out var target))
-                {
-                    GarbageCollection.Print($@"- 🧟 {child.Name} is a zombie!");
-                }
+                GarbageCollection.Print($@"- 🧟 {child.Name} is a zombie!");
             }
         }
 
-        if (allBindingContextsThatLives.Count > 0 && shouldPrintAllLeaks)
+        if (allBindingContextsThatLives.Count > 0)
         {
             GarbageCollection.Print($"---- Binding Context zombies of {collectionContentTarget.Name}: ----");
         }
 
-        if (shouldPrintAllLeaks)
+        foreach (var child in allBindingContextsThatLives)
         {
-            foreach (var child in allBindingContextsThatLives)
+            if (child.Target.TryGetTarget(out var target))
             {
-                if (child.Target.TryGetTarget(out var target))
-                {
-                    GarbageCollection.Print($@"- 🧟 {child.Name} is a zombie!");
-                }
+                GarbageCollection.Print($@"- 🧟 {child.Name} is a zombie!");
             }
         }
 
@@ -195,7 +189,7 @@ public class GCCollectionMonitor
             }
             else
             {
-                if (!(await CheckIfCollectionTargetIsAlive(target, shouldPrintTotalMemory: true, shouldPrintAllLeaks: false)))
+                if (!(await CheckIfCollectionTargetIsAlive(target, shouldPrintTotalMemory: true)))
                 {
                     GarbageCollection.Print($"✅ No memory leaks when checking {target.Name}");
                 }    

--- a/src/library/DIPS.Mobile.UI/MemoryManagement/VisualTreeMemoryResolver.cs
+++ b/src/library/DIPS.Mobile.UI/MemoryManagement/VisualTreeMemoryResolver.cs
@@ -25,11 +25,14 @@ internal class VisualTreeMemoryResolver
                             case CollectionView collectionView:
                                 collectionView.ItemsSource = null;
                                 collectionView.ItemTemplate = null;
-                                collectionView.FooterTemplate = null;
-                                collectionView.HeaderTemplate = null;
-                                collectionView.Footer = null;
-                                collectionView.Header = null;
-                                collectionView.EmptyView = null;
+                                if (!collectionView.IsGrouped)
+                                {
+                                    collectionView.FooterTemplate = null;
+                                    collectionView.HeaderTemplate = null;
+                                    collectionView.Footer = null;
+                                    collectionView.Header = null;
+                                    collectionView.EmptyView = null;
+                                }
                                 break;
                             case Border border:
                                 border.Content = null;


### PR DESCRIPTION
### Description of Change

I came upon a situation where a BottomSheet had memory leaks, but the BottomSheet itself were GC'ed. Thus, we could not traverse its VisualTree and resolve the memory leaks. Now I suggest that we auto resolve memory leaks before checking if there are any. Checking memory leaks before using the auto resolve did not offer much to us anyway.

Furthermore, I fixed duplicate checking of memory leaks in `BindingContext` of BottomSheets. Because now we do that when trying to resolve memory leaks for the BottomSheet view.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->