### PR TITLE
[Android][DateAndTimePicker] If there is not enough space to show all characters in DateAndTimePicker, the date will be truncated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [35.2.1] 
+- [Android][DateAndTimePicker] If there is not enough space to show all characters in DateAndTimePicker, the date will be truncated.
+
 ## [35.2.0] 
 - [MemoryLeak] Added a bindable attached property so that consumers can ignore memory leak resolving on certain views/pages.
 

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-ios;</TargetFrameworks>
+        <TargetFrameworks>net8.0-android;</TargetFrameworks>
 
         <OutputType>Exe</OutputType>
         <RootNamespace>Playground</RootNamespace>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -15,31 +15,11 @@
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
 
-    <dui:ContentPage.Resources>
-
-        <DataTemplate x:Key="Test1"
-                      x:DataType="{x:Type vetleSamples:TestObject2}">
-            
-            <vetleSamples:ViewCellTest TestCommand="{Binding Source={x:Reference This}, Path=TestCommand}" />
-
-        </DataTemplate>
-
-        <DataTemplate x:Key="Test2"
-                      x:DataType="{x:Type vetleSamples:TestObject2}">
-
-            <vetleSamples:ViewCellTest TestCommand="{Binding Source={x:Reference This}, Path=TestCommand}" />
-            
-        </DataTemplate>
-
-        <vetleSamples:TemplateSelector Test1="{StaticResource Test1}"
-                                       Test2="{StaticResource Test2}"
-                                       x:Key="TemplateSelector" />
-
-    </dui:ContentPage.Resources>
-
-    
-    <vetleSamples:ViewCellTest TestBool="{Binding Source={x:Reference This}, Path=TestBool}"
-                               dui:MemoryLeaks.SkipAutomaticMemoryLeakResolving="True" />
+    <VerticalStackLayout>
         
+        <Grid ColumnDefinitions="*, 1.25*">
+            <dui:DateAndTimePicker Grid.Column="1" />
+        </Grid>
+    </VerticalStackLayout>
 
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -17,8 +17,18 @@
 
     <VerticalStackLayout>
         
-        <Grid ColumnDefinitions="*, 1.25*">
-            <dui:DateAndTimePicker Grid.Column="1" />
+        <Grid>
+            <dui:ListItem>
+                <dui:ListItem.UnderlyingContent>
+                    
+                    <VerticalStackLayout Margin="{dui:Thickness Top=size_1}">
+                        <dui:Label Text="test"></dui:Label>
+                    <dui:ListItem Title="Date">
+                        <dui:NullableDateAndTimePicker SelectedDateTime="{Binding Date, Mode=TwoWay}" />
+                    </dui:ListItem>
+                    </VerticalStackLayout>
+                </dui:ListItem.UnderlyingContent>
+            </dui:ListItem>
         </Grid>
     </VerticalStackLayout>
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DateAndTimePicker/Android/DateAndTimePickerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DateAndTimePicker/Android/DateAndTimePickerHandler.cs
@@ -1,32 +1,39 @@
 using Android.Widget;
+using DIPS.Mobile.UI.API.Library;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using ActionMenuView = AndroidX.AppCompat.Widget.ActionMenuView;
+using View = Android.Views.View;
 
 // ReSharper disable once CheckNamespace
 namespace DIPS.Mobile.UI.Components.Pickers.DateAndTimePicker;
 
-public partial class DateAndTimePickerHandler : ViewHandler<DateAndTimePicker, LinearLayout>
+public partial class DateAndTimePickerHandler : ViewHandler<DateAndTimePicker, View>
 {
     private DateTime m_dateSetFromPickers;
+
+    private Grid m_grid;
+    
     private Pickers.DatePicker.DatePicker DatePicker { get; } = new();
     private Pickers.TimePicker.TimePicker TimePicker { get; } = new();
     
-    protected override LinearLayout CreatePlatformView()
+    protected override View CreatePlatformView()
     {
-        return new LinearLayout(Context) { Orientation = Orientation.Horizontal };
+        m_grid = new Grid
+        {
+            ColumnDefinitions = [new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto)],
+            ColumnSpacing = Sizes.GetSize(SizeName.size_1)
+        };
+
+        return m_grid.ToPlatform(DUI.GetCurrentMauiContext!);
     }
 
-    protected override void ConnectHandler(LinearLayout platformView)
+    protected override void ConnectHandler(View platformView)
     {
         base.ConnectHandler(platformView);
 
-        var space = new Space(Context);
-        space.LayoutParameters = new ActionMenuView.LayoutParams(Sizes.GetSize(SizeName.size_3), 0);
-
-        platformView.AddView(DatePicker.ToPlatform(MauiContext!));
-        platformView.AddView(space);
-        platformView.AddView(TimePicker.ToPlatform(MauiContext!));
+        m_grid.Add(DatePicker);
+        m_grid.Add(TimePicker, 1, 0);
 
         TimePicker.SelectedTimeCommand = new Command(() =>
         {

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/NullableDatePickerShared/BaseNullableDatePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/NullableDatePickerShared/BaseNullableDatePicker.cs
@@ -1,6 +1,6 @@
 namespace DIPS.Mobile.UI.Components.Pickers.NullableDatePickerShared;
 
-public abstract class BaseNullableDatePicker : HorizontalStackLayout
+public abstract class BaseNullableDatePicker : Grid
 {
     protected readonly Switch DateEnabledSwitch;
     
@@ -10,12 +10,15 @@ public abstract class BaseNullableDatePicker : HorizontalStackLayout
 
     protected BaseNullableDatePicker()
     {
-        Spacing = Sizes.GetSize(SizeName.size_3);
+        ColumnSpacing = Sizes.GetSize(SizeName.size_3);
+        
+        AddColumnDefinition(new ColumnDefinition(GridLength.Star));
+        AddColumnDefinition(new ColumnDefinition(GridLength.Auto));
 
         DateEnabledSwitch = new Switch { VerticalOptions = LayoutOptions.Center };
         DateEnabledSwitch.Toggled += OnSwitchToggled;
         
-        Add(DateEnabledSwitch);
+        this.Add(DateEnabledSwitch, 1);
     }
 
     protected override void OnHandlerChanged()
@@ -29,7 +32,7 @@ public abstract class BaseNullableDatePicker : HorizontalStackLayout
         m_dateOrTimePicker.SetBinding(HorizontalOptionsProperty, new Binding(nameof(HorizontalOptions), BindingMode.OneWay, source: this));
 #endif
         
-        Insert(0, m_dateOrTimePicker);
+        Add(m_dateOrTimePicker);
         var size = m_dateOrTimePicker.Measure(int.MaxValue, int.MaxValue);
         MinimumHeightRequest = size.Request.Height;
         


### PR DESCRIPTION
### Description of Change

If the textsize on Android were increased, the DateAndTimePicker would not truncate its contents, and sometimes the TimePicker would disappear. This is now fixed, and its date will truncate itself.

I have also fixed a bug in NullableDateAndTimePicker where the Switch would disappear if there were not enough space. This is also fixed.

### Todos
- [X] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->