### PR TITLE
Fixed Label not showing its correct Text after truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [35.3.2]
+- [Label] Made sure people can change `Text` after it has been truncated and has added the `TruncationText` to the end.
+
 ## [35.3.1]
 - [Button] Made sure to guard changing style if platformview is null.
 

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -10,27 +10,19 @@
                  x:Class="Playground.HåvardSamples.HåvardPage"
                  ShouldHideFloatingNavigationMenuButton="True"
                  Padding="0">
+    <dui:ContentPage.Resources>
+        <x:String x:Key="More">"More"</x:String>
+    </dui:ContentPage.Resources>
     <dui:ContentPage.BindingContext>
         <håvardSamples:HåvardPageViewModel />
     </dui:ContentPage.BindingContext>
 
-    <VerticalStackLayout>
-        <dui:NavigationListItem BackgroundColor="Red"
-                                Title="Modal Navigation"
-                                Tapped="ModalNavigation">
-            <dui:NavigationListItem.Effects>
-                <dui:MemoryLeakEffect />
-            </dui:NavigationListItem.Effects>
-        </dui:NavigationListItem>
-        <dui:NavigationListItem BackgroundColor="Blue"
-                                Title="Modal"
-                                Tapped="Modal">
-            <dui:NavigationListItem.Effects>
-                <dui:MemoryLeakEffect />
-            </dui:NavigationListItem.Effects>
-        </dui:NavigationListItem>
-        <dui:NavigationListItem BackgroundColor="Blue"
-                                Title="SwapRoot"
-                                Tapped="SwapRoot" />
-    </VerticalStackLayout>
+    <Grid Padding="{dui:Thickness size_2}">
+        <dui:Label Text="{Binding LongText}" MaxLines="3"  TruncatedText="More" x:Name="truncatingLabel"/>
+        <dui:HorizontalStackLayout HorizontalOptions="Start"
+                                   VerticalOptions="Center"
+                                   Spacing="{dui:Sizes size_1}">
+            <dui:Button Text="Remove" Command="{Binding Command}"/>
+        </dui:HorizontalStackLayout>
+    </Grid>
 </dui:ContentPage>

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml.cs
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml.cs
@@ -10,6 +10,13 @@ public partial class HåvardPage
     {
         InitializeComponent();
         m_håvardPageViewModel = BindingContext as HåvardPageViewModel;
+        // m_håvardPageViewModel.PropertyChanged += (sender, args) =>
+        // {
+        //     if (args.PropertyName == "LongText")
+        //     {
+        //         truncatingLabel.ForceUpdateText(m_håvardPageViewModel.LongText);
+        //     }
+        // };
     }
     
     private void ContextMenuItem_OnDidClick(object sender, EventArgs e)

--- a/src/app/Playground/HåvardSamples/HåvardPageViewModel.cs
+++ b/src/app/Playground/HåvardSamples/HåvardPageViewModel.cs
@@ -14,6 +14,7 @@ public class HåvardPageViewModel : ViewModel
     private List<Something> m_items2;
     private HåvardPage3ViewModel m_listener;
     private HåvardPage3ViewModel m_target;
+    private string m_longText;
 
     public ICommand Command { get; }
 
@@ -55,9 +56,16 @@ public class HåvardPageViewModel : ViewModel
 
         Command = new Command(() =>
         {
-            var oldItems = Items.Take(new Range(0,1));
-            Items = oldItems.ToList();
+//One line
+            var str = LongText[(LongText.Split()[0].Length + 1)..];
+
+//Multiple lines
+            var firstWord = str.Split()[0];
+            var charsToSkip = firstWord.Length + 1;
+            LongText = LongText[charsToSkip..];
         });
+        LongText =
+            "With this utility you generate a 16 character output based on your input of numbers and upper and lower case letters.  Random strings can be unique. Used in computing, a random string generator can also be called a random character string generator. This is an important tool if you want to generate a unique set of strings. The utility generates a sequence that lacks a pattern and is random.";
     }
 
     private void DeviceDisplayOnMainDisplayInfoChanged(object sender, DisplayInfoChangedEventArgs e)
@@ -103,6 +111,12 @@ public class HåvardPageViewModel : ViewModel
     {
         get => m_items2;
         set => RaiseWhenSet(ref m_items2, value);
+    }
+
+    public string LongText
+    {
+        get => m_longText;
+        set => RaiseWhenSet(ref m_longText, value);
     }
 
     public void SetListener(HåvardPage3ViewModel håvardPage3ViewModel)

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-android;</TargetFrameworks>
+        <TargetFrameworks>net8.0-ios;net8.0-android;</TargetFrameworks>
 
         <OutputType>Exe</OutputType>
         <RootNamespace>Playground</RootNamespace>

--- a/src/library/DIPS.Mobile.UI/Components/Labels/Android/MauiTextView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Labels/Android/MauiTextView.cs
@@ -61,7 +61,7 @@ public class MauiTextView : Microsoft.Maui.Platform.MauiTextView
 
     private void RemoveTextUntilNotTruncated()
     {
-        var modifiedOriginalText = m_originalText;
+        var modifiedOriginalText = GetTextFromLabel();
         while (true)
         {
             modifiedOriginalText = modifiedOriginalText.Substring(0, modifiedOriginalText.Length - 1);

--- a/src/library/DIPS.Mobile.UI/Components/Labels/Label.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Labels/Label.Properties.cs
@@ -48,4 +48,21 @@ public partial class Label
         typeof(bool),
         typeof(Label),
         defaultBindingMode: BindingMode.OneWayToSource);
+
+    public new static readonly BindableProperty TextProperty = BindableProperty.Create(
+        nameof(Text),
+        typeof(string),
+        typeof(Label), propertyChanged: ((bindable, _, _) =>
+        {
+            ((Label)bindable).OnTextChanged();
+        }));
+
+    /// <summary>
+    /// <inheritdoc cref="Microsoft.Maui.Controls.Label.Text"/>
+    /// </summary>
+    public new string Text
+    {
+        get => (string)GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Labels/Label.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Labels/Label.cs
@@ -11,5 +11,18 @@ namespace DIPS.Mobile.UI.Components.Labels
             MaxLines = int.MaxValue;
             Style = Styles.GetLabelStyle(LabelStyle.Body300);
         }
+        
+        
+        private void OnTextChanged()
+        {
+            var previousValue = ((Microsoft.Maui.Controls.Label)this).Text;
+            ((Microsoft.Maui.Controls.Label)this).Text = this.Text;
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            if (previousValue == null) //This happens due to the way we truncate text by using formatted text in our implementation. It nulls out Text and we have to reset it + invalidate for it to re-truncate.
+            {
+                this.InvalidateMeasure();
+            }
+        }
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Labels/iOS/MauiLabel.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Labels/iOS/MauiLabel.cs
@@ -81,7 +81,7 @@ public class MauiLabel : Microsoft.Maui.Platform.MauiLabel
 
     private void RemoveTextUntilNotTruncated()
     {
-        var modifiedOriginalText = m_originalText;
+        var modifiedOriginalText = GetTextFromLabel();
         while (true)
         {
             modifiedOriginalText = modifiedOriginalText.Substring(0, modifiedOriginalText.Length - 1);


### PR DESCRIPTION
### Description of Change

There was an issue where changing `Text` after the label was truncated did not reflect. This was due to `Text` getting nullified when we use `FormattedText` from MAUI, which meant that the binding that consumers was doing did not trigger when it changes. Fixed this by introducing our own `Text`, which sets the MAUI `Text` property, and handles it being null + invalidate measure to make sure we re-truncate if needed.


### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->