### PR TITLE
[ScrollPicker][iOS] Fixed crash when trying to display scroll pickers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [35.5.1] 
+- [ScrollPicker][iOS] Fixed crash when trying to display scroll pickers.
+
 ## [35.5.0] 
 - [Chip][Android] Made sure the text is centered horizontally.
 - [Chip] Changed its styling so that it corresponds better to the design.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [35.5.1] 
 - [ScrollPicker][iOS] Fixed crash when trying to display scroll pickers.
+- [MemoryLeak] Added navigation testing.
 
 ## [35.5.0] 
 - [Chip][Android] Made sure the text is centered horizontally.

--- a/src/app/MemoryLeakTests/App.xaml.cs
+++ b/src/app/MemoryLeakTests/App.xaml.cs
@@ -12,9 +12,9 @@ public partial class App
     {
         InitializeComponent();
 
-        var container = new ServiceContainer(options => options.EnablePropertyInjection = false);
-        container.Register<MainPage>();
-        TestRegistrator.Register(container);
+        Container = new ServiceContainer(options => options.EnablePropertyInjection = false);
+        Container.Register<MainPage>();
+        TestRegistrator.Register(Container);
         
         var shell = new DIPS.Mobile.UI.Components.Shell.Shell()
         {
@@ -26,11 +26,13 @@ public partial class App
         tab.Items.Add(new ShellContent()
         {
             ContentTemplate =
-                new DataTemplate(() => container.GetInstance<MainPage>())
+                new DataTemplate(() => Container.GetInstance<MainPage>())
 
         });
         tabBar.Items.Add(tab);
         shell.Items.Add(tabBar);
         MainPage = shell;
     }
+
+    public static ServiceContainer Container { get; set; }
 }

--- a/src/app/MemoryLeakTests/Tests/NavigationTests.cs
+++ b/src/app/MemoryLeakTests/Tests/NavigationTests.cs
@@ -1,0 +1,60 @@
+using DIPS.Mobile.UI.Components.ListItems;
+
+namespace MemoryLeakTests.Tests;
+
+public class NavigationTests : UITest
+{
+    public override void BeforeTest(ContentPage contentPage)
+    {
+        var verticalStackLayout = new VerticalStackLayout();
+        var popToRoot = new ListItem() { Title = "Pop to root", Command = new Command(() =>
+        {
+            Shell.Current.Navigation.PopToRootAsync();
+        })};
+        var swapRoot = new ListItem() { Title = "Swap root", Command = new Command(async () =>
+        {
+            await Shell.Current.Navigation.PopToRootAsync();
+            var tabBar = new TabBar();
+            var tab = new Tab();
+
+            tab.Items.Add(new ShellContent()
+            {
+                ContentTemplate = new DataTemplate(() => new DummyRootPage())
+            });
+            tabBar.Items.Add(tab);
+            Shell.Current.Items.RemoveAt(0);
+            Shell.Current.Items.Add(tabBar);   
+        })};
+
+        verticalStackLayout.Add(popToRoot);
+        verticalStackLayout.Add(swapRoot);
+        
+        contentPage.Content = verticalStackLayout;
+    }
+
+    public override string Name => "Navigation tests";
+
+    private class DummyRootPage : ContentPage
+    {
+        public DummyRootPage()
+        {
+            Content = new ListItem()
+            {
+                Title = "Switch back",
+                Command = new Command(() =>
+                {
+                    var tabBar = new TabBar();
+                    var tab = new Tab();
+
+                    tab.Items.Add(new ShellContent()
+                    {
+                        ContentTemplate = new DataTemplate(() => App.Container.GetInstance(typeof(MainPage)))
+                    });
+                    tabBar.Items.Add(tab);
+                    Shell.Current.Items.RemoveAt(0);
+                    Shell.Current.Items.Add(tabBar);   
+                })
+            };
+        }
+    }
+}

--- a/src/app/MemoryLeakTests/Tests/TestRegistrator.cs
+++ b/src/app/MemoryLeakTests/Tests/TestRegistrator.cs
@@ -7,7 +7,8 @@ public static class TestRegistrator
     public static void Register(ServiceContainer serviceContainer)
     {
         serviceContainer.Register<CollectionViewTests>()
-                        .Register<ModalTests>();
+                        .Register<ModalTests>()
+                        .Register<NavigationTests>();
         
         
     }

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -15,10 +15,19 @@
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
 
-
-        <dui:ListItem Title="Due date">
-            <dui:NullableDateAndTimePicker />
+    <Grid>
+        <dui:ListItem>
+            <dui:ListItem.UnderlyingContent>
+                
+                <VerticalStackLayout Margin="{dui:Thickness Top=size_1}">
+                    <dui:Label Text="test"></dui:Label>
+                <dui:ListItem Title="Date">
+                    <dui:NullableDateAndTimePicker SelectedDateTime="{Binding Date, Mode=TwoWay}" />
+                </dui:ListItem>
+                </VerticalStackLayout>
+            </dui:ListItem.UnderlyingContent>
         </dui:ListItem>
+    </Grid>
 
     
 </dui:ContentPage>

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/iOS/ScrollPickerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/iOS/ScrollPickerHandler.cs
@@ -15,20 +15,20 @@ using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 
 namespace DIPS.Mobile.UI.Components.Pickers.ScrollPicker;
 
-public partial class ScrollPickerHandler : ViewHandler<ScrollPicker, UIButton>
+public partial class ScrollPickerHandler : ViewHandler<ScrollPicker, UIView>
 {
     private Chip m_chip;
     private ScrollPickerViewController? m_scrollPickerViewController;
 
-    protected override UIButton CreatePlatformView()
+    protected override UIView CreatePlatformView()
     {
         m_chip = new Chip { Style = Styles.GetChipStyle(ChipStyle.Input) };
         m_chip.Command = new Command(() => OnTapped(m_chip));
 
-        return (UIButton)m_chip.ToPlatform(DUI.GetCurrentMauiContext!);
+        return m_chip.ToPlatform(DUI.GetCurrentMauiContext!);
     }
 
-    protected override void ConnectHandler(UIButton platformView)
+    protected override void ConnectHandler(UIView platformView)
     {
         base.ConnectHandler(platformView);
 
@@ -86,7 +86,7 @@ public partial class ScrollPickerHandler : ViewHandler<ScrollPicker, UIButton>
         m_scrollPickerViewModel.SetToNull();
     }
     
-    protected override void DisconnectHandler(UIButton platformView)
+    protected override void DisconnectHandler(UIView platformView)
     {
         base.DisconnectHandler(platformView);
 
@@ -133,7 +133,7 @@ internal class ScrollPickerViewController : UIViewController
 #nullable disable
     private IScrollPickerViewModel m_scrollPickerViewModel;
     private UIPickerView m_uiPicker;
-    private UIButton m_uiButton;
+    private UIView m_uiButton;
     private UIButton m_clearButton;
 #nullable enable
 
@@ -141,7 +141,7 @@ internal class ScrollPickerViewController : UIViewController
     {
         m_scrollPickerViewModel = scrollPickerViewModel;
         m_uiPicker = new UIPickerView();
-        m_uiButton = chip.ToPlatform(DUI.GetCurrentMauiContext!) as UIButton;
+        m_uiButton = chip.ToPlatform(DUI.GetCurrentMauiContext!);
         
         var vm = new DUIPickerViewModel { ScrollPickerViewModel = m_scrollPickerViewModel };
         m_uiPicker.Model = vm;


### PR DESCRIPTION
### Description of Change

After removing the `ChipHandler` in the previous PR, `Chip` is no longer a `UIButton`, thus, invoking a crash on iOS trying to convert `Chip` to a `UIButton`.

Additionally, I added some more memory leak testing for navigation

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->