### PR TITLE
Set default date to `DateTime.Now` on datepickers to avoid a bug where the datepickers jumps two dates forward.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [36.0.1] 
+- Set default date to `DateTime.Now` on datepickers to avoid a bug where the datepickers jumps two dates forward.
+
 ## [36.0.0] 
 - Upgraded MAUI to 8.0.82.
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DateAndTimePicker/DateAndTimePicker.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DateAndTimePicker/DateAndTimePicker.Properties.cs
@@ -8,7 +8,9 @@ public partial class DateAndTimePicker
     public static readonly BindableProperty SelectedDateTimeProperty = BindableProperty.Create(
         nameof(SelectedDateTime),
         typeof(DateTime),
-        typeof(DateAndTimePicker), defaultBindingMode:BindingMode.TwoWay,
+        typeof(DateAndTimePicker), 
+        DateTime.Now,
+        defaultBindingMode:BindingMode.TwoWay,
         propertyChanged: (bindable, _, date) =>
         {
             if(date is not DateTime time)

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/DatePicker.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/DatePicker.Properties.cs
@@ -60,7 +60,7 @@ namespace DIPS.Mobile.UI.Components.Pickers.DatePicker
             typeof(DateTime),
             typeof(DatePicker),
             defaultBindingMode:BindingMode.TwoWay,
-            defaultValue:null,
+            defaultValue:DateTime.Now,
             propertyChanged: (bindable, _, _) => ((DatePicker)bindable).OnSelectedDateChanged());
         
         public static readonly BindableProperty SelectedDateCommandProperty = BindableProperty.Create(


### PR DESCRIPTION
### Description of Change

For some reason, using the default date (01.01.0001) breaks the inline datepicker. It jumps forward two dates when selecting a date. Setting the default date to `DateTime.Now` fixes this issue. 

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->