### PR TITLE
Fixes for SegmentedControl and Switch on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [37.1.2] 
+- [SegmentedControl] Avoid setting static Height, instead use padding of content to calculate height so it scales better with font-size. Removing the static height also reduced its height so its similar to the design.
+- [Switch][iOS] Fixed an issue where the off color would blend into the background color of the view that is below the `Switch`.
+
 ## [37.1.1] 
 - [Chip] Fixed bug where consumer could not bind to `CustomIcon` because BindableProperty name did not correspond to the getter and setter
 - Will now localize text correctly

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -15,23 +15,10 @@
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
 
-    <CollectionView IsGrouped="True"
-                        ItemsSource="{Binding GroupedTest}">
-
-        <CollectionView.GroupFooterTemplate>
-            
-            <DataTemplate>
-                <Label Text="Lol"></Label>
-            </DataTemplate>
-        </CollectionView.GroupFooterTemplate>
+    <VerticalStackLayout BackgroundColor="{dui:Colors color_primary_90}">
         
-        <CollectionView.ItemTemplate>
-            <DataTemplate>
-                <Label Text="HEHE"></Label>
-            </DataTemplate>
-        </CollectionView.ItemTemplate>
-        
-    </CollectionView>
+        <dui:Switch OnColor="{dui:Colors color_secondary_60}"
+                    ThumbColor="{dui:Colors color_system_white}"/>
 
-
+    </VerticalStackLayout>
 </dui:ContentPage>

--- a/src/library/DIPS.Mobile.UI/API/Builder/iOS/AppHostBuilderExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Builder/iOS/AppHostBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.Components.Layout;
 using DIPS.Mobile.UI.Components.Pickers.DatePicker.Inline.iOS;
+using DIPS.Mobile.UI.Components.Selection.iOS;
 using Microsoft.Maui.LifecycleEvents;
 
 namespace DIPS.Mobile.UI.API.Builder;
@@ -14,6 +15,7 @@ public static partial class AppHostBuilderExtensions
         handlers.AddHandler<InlineTimePicker, InlineTimePickerHandler>();
         handlers.AddHandler<InlineDateAndTimePicker, InlineDateAndTimePickerHandler>();
         handlers.AddHandler<Layout, LayoutHandler>();
+        handlers.AddHandler<Switch, SwitchHandler>();
     }
 
     static partial void ConfigurePlatformLifecycleEvents(ILifecycleBuilder events)

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/SegmentedControl/SegmentedControl.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/SegmentedControl/SegmentedControl.cs
@@ -29,7 +29,7 @@ public partial class SegmentedControl : ContentView
             VerticalOptions = LayoutOptions.Start,
             HorizontalOptions = LayoutOptions.Start,
             ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal) {ItemSpacing = 0},
-            HeightRequest = Sizes.GetSize(SizeName.size_12),
+            /*HeightRequest = Sizes.GetSize(SizeName.size_10),*/
             HorizontalScrollBarVisibility = ScrollBarVisibility.Never,
             VerticalScrollBarVisibility = ScrollBarVisibility.Never,
             ItemSpacing = 0,
@@ -42,13 +42,12 @@ public partial class SegmentedControl : ContentView
 
     private View CreateSegment()
     {
-        var border = new Border()
+        var border = new Border
         {
             VerticalOptions = LayoutOptions.Center,
-            HeightRequest = Sizes.GetSize(SizeName.size_10),
             StrokeThickness = 1,
             Stroke = SegmentBorderColor,
-            StrokeShape = new RoundRectangle()
+            StrokeShape = new RoundRectangle
             {
                 CornerRadius = new CornerRadius(Sizes.GetSize(SizeName.size_8), 0,
                     Sizes.GetSize(SizeName.size_8), 0),
@@ -100,6 +99,12 @@ public partial class SegmentedControl : ContentView
         border.SizeChanged += ((sender, _) =>
         {
             if (sender is not View view) return;
+
+            if (m_collectionView.HeightRequest == -1)
+            {
+                m_collectionView.HeightRequest = view.Height;
+            }
+            
             if (view.BindingContext is not SelectableItemViewModel selectableListItem) return;
 
             var radius = (double)Sizes.GetSize(SizeName.size_8);

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/SegmentedControl/SegmentedControl.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/SegmentedControl/SegmentedControl.cs
@@ -29,7 +29,6 @@ public partial class SegmentedControl : ContentView
             VerticalOptions = LayoutOptions.Start,
             HorizontalOptions = LayoutOptions.Start,
             ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal) {ItemSpacing = 0},
-            /*HeightRequest = Sizes.GetSize(SizeName.size_10),*/
             HorizontalScrollBarVisibility = ScrollBarVisibility.Never,
             VerticalScrollBarVisibility = ScrollBarVisibility.Never,
             ItemSpacing = 0,

--- a/src/library/DIPS.Mobile.UI/Components/Selection/iOS/SwitchHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Selection/iOS/SwitchHandler.cs
@@ -1,0 +1,19 @@
+using Microsoft.Maui.Platform;
+using UIKit;
+using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
+
+namespace DIPS.Mobile.UI.Components.Selection.iOS;
+
+public class SwitchHandler : Microsoft.Maui.Handlers.SwitchHandler
+{
+    protected override void ConnectHandler(UISwitch platformView)
+    {
+        base.ConnectHandler(platformView);
+
+        // If the Switch is over a background color, this will ensure the Switch keeps its "off" color
+        // https://stackoverflow.com/questions/10348869/change-color-of-uiswitch-in-off-state
+        platformView.Layer.CornerRadius = platformView.Frame.Height / 2;
+        platformView.ClipsToBounds = true;
+        platformView.BackgroundColor = Colors.GetColor(ColorName.color_neutral_30).ToPlatform();
+    }
+}


### PR DESCRIPTION
### Description of Change

Designers complained that the SegmentedControl had too much height. This is because we set static height on the SegmentedControl, and additionally set padding. Instead, we should just use padding, and let maui calculate the height of the SegmentedControl based on font-size. This also has the benefit of scaling good with font-size changes.

On iOS, if the Switch was laid above another view that has a background color, the off state would blend in with the background color. With this fix, we set a static off color, so it will always be seen.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [X] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->