### PR TITLE
[Button][iOS] Fixed an issue where buttons with `IconButtonSmall` style would have a glitchy icon.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [37.2.2] 
+- [Button][iOS] Fixed an issue where buttons with `IconButtonSmall` style would have a glitchy icon. 
+
 ## [37.2.1] 
 - Buttons will now calculate their own size instead of setting static height.
 

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -15,10 +15,13 @@
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
 
-    <VerticalStackLayout BackgroundColor="{dui:Colors color_primary_90}">
+    <VerticalStackLayout >
         
-        <dui:Switch OnColor="{dui:Colors color_secondary_60}"
-                    ThumbColor="{dui:Colors color_system_white}"/>
+        <dui:Button ImageSource="{dui:Icons comment_line}"
+                    Style="{dui:Styles Button=PrimaryIconButtonSmall}"
+                    Padding="0"/>
+        
+        <dui:Button Text="Lol" />
 
     </VerticalStackLayout>
 </dui:ContentPage>

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Button/ButtonTypeStyle.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Button/ButtonTypeStyle.cs
@@ -251,7 +251,7 @@ public static class ButtonTypeStyle
                 Property = Microsoft.Maui.Controls.Button.PaddingProperty,
                 Value = (DeviceInfo.Current.Platform == DevicePlatform.Android)
                     ? Sizes.Sizes.GetSize(SizeName.size_1)
-                    : Sizes.Sizes.GetSize(SizeName.size_2)
+                    : 0
             }
         }
     };
@@ -281,7 +281,7 @@ public static class ButtonTypeStyle
                 Property = Microsoft.Maui.Controls.Button.PaddingProperty,
                 Value = (DeviceInfo.Current.Platform == DevicePlatform.Android)
                     ? Sizes.Sizes.GetSize(SizeName.size_1)
-                    : Sizes.Sizes.GetSize(SizeName.size_2)
+                    : 0
             }
         }
     };

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Button/ButtonTypeStyle.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Button/ButtonTypeStyle.cs
@@ -221,7 +221,7 @@ public static class ButtonTypeStyle
                 Property = Microsoft.Maui.Controls.Button.PaddingProperty,
                 Value = (DeviceInfo.Current.Platform == DevicePlatform.Android)
                     ? Sizes.Sizes.GetSize(SizeName.size_1)
-                    : Sizes.Sizes.GetSize(SizeName.size_2)
+                    : 0
             }
         }
     };
@@ -311,7 +311,7 @@ public static class ButtonTypeStyle
                 Property = Microsoft.Maui.Controls.Button.PaddingProperty,
                 Value = (DeviceInfo.Current.Platform == DevicePlatform.Android)
                     ? Sizes.Sizes.GetSize(SizeName.size_1)
-                    : Sizes.Sizes.GetSize(SizeName.size_2)
+                    : 0
             }
         }
     };
@@ -341,7 +341,7 @@ public static class ButtonTypeStyle
                 Property = Microsoft.Maui.Controls.Button.PaddingProperty,
                 Value = (DeviceInfo.Current.Platform == DevicePlatform.Android)
                     ? Sizes.Sizes.GetSize(SizeName.size_1)
-                    : Sizes.Sizes.GetSize(SizeName.size_2)
+                    : 0
             }
         }
     };
@@ -371,7 +371,7 @@ public static class ButtonTypeStyle
                 Property = Microsoft.Maui.Controls.Button.PaddingProperty,
                 Value = (DeviceInfo.Current.Platform == DevicePlatform.Android)
                     ? Sizes.Sizes.GetSize(SizeName.size_1)
-                    : Sizes.Sizes.GetSize(SizeName.size_2)
+                    : 0
             }
         }
     };


### PR DESCRIPTION
### Description of Change

Just removed the padding, it had no effect anyways

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->