### PR TITLE
[Button][iOS] Fixed an edge-case where some buttons did not get rounded corners.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [37.3.3] 
-- [Button] Fixed an edge-case where some buttons did not get rounded corners.
+- [Button][iOS] Fixed an edge-case where some buttons did not get rounded corners.
 
 ## [37.3.2] 
 - [ImageCapture] Fixed toolbar height on smaller devices.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [37.3.3] 
-- Test 
+- [Button] Fixed an edge-case where some buttons did not get rounded corners.
 
 ## [37.3.2] 
 - [ImageCapture] Fixed toolbar height on smaller devices.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [37.3.3] 
+- Test 
+
 ## [37.3.2] 
 - [ImageCapture] Fixed toolbar height on smaller devices.
 

--- a/src/app/Components/ComponentsSamples/Buttons/ButtonsSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Buttons/ButtonsSamples.xaml
@@ -4,12 +4,10 @@
                  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                  xmlns:dui="http://dips.com/mobile.ui"
                  xmlns:localizedStrings="clr-namespace:Components.Resources.LocalizedStrings"
-                 xmlns:iOsSpecific="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
                  x:Class="Components.ComponentsSamples.Buttons.ButtonsSamples"
                  x:Name="This"
                  Title="{x:Static localizedStrings:LocalizedStrings.Buttons}"
-                 Padding="{dui:Sizes size_4}"
-                 iOsSpecific:Page.PrefersStatusBarHidden="True">
+                 Padding="{dui:Sizes size_4}">
     <dui:ScrollView>
         <Grid RowDefinitions="Auto, 20, Auto, 20, Auto">
             <dui:VerticalStackLayout>

--- a/src/app/Components/ComponentsSamples/ImageCapturing/ImageCaptureSample.xaml
+++ b/src/app/Components/ComponentsSamples/ImageCapturing/ImageCaptureSample.xaml
@@ -6,9 +6,7 @@
                  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                  xmlns:dui="http://dips.com/mobile.ui"
                  xmlns:localizedStrings="clr-namespace:DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;assembly=DIPS.Mobile.UI"
-                 xmlns:iOsSpecific="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
-                 x:Class="Components.ComponentsSamples.ImageCapturing.ImageCaptureSample"
-                 iOsSpecific:Page.PrefersStatusBarHidden="True">
+                 x:Class="Components.ComponentsSamples.ImageCapturing.ImageCaptureSample">
     
     <dui:ContentPage.ToolbarItems>
         <ToolbarItem Text="{x:Static localizedStrings:DUILocalizedStrings.Close}"

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -15,13 +15,17 @@
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
     
-    <VerticalStackLayout >
+    <Grid RowDefinitions="*, Auto">
         
-        <dui:Button ImageSource="{dui:Icons comment_line}"
-                    Style="{dui:Styles Button=PrimaryIconButtonSmall}"
-                    Padding="0"/>
+        <Grid Grid.Row="1"
+              VerticalOptions="End"
+              x:Name="Button"
+              IsVisible="False">
+            <dui:Button Text="Donzo"
+                        
+                         />
+        </Grid>
         
-        <dui:Button Text="Lol" />
 
-    </VerticalStackLayout>
+    </Grid>
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -14,9 +14,7 @@
     <dui:ContentPage.BindingContext>
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
-    <Grid>
-        <dui:Button Command="{Binding CheckCommand}" />
-
+    
     <VerticalStackLayout >
         
         <dui:Button ImageSource="{dui:Icons comment_line}"

--- a/src/app/Playground/VetleSamples/VetlePage.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml.cs
@@ -66,8 +66,10 @@ public partial class VetlePage
     {
         base.OnAppearing();
 
-        await Task.Delay(4000);
-        
+        await Task.Delay(1000);
+
+        Button.IsVisible = true;
+
         /*
         ToolbarItems.Add(new ContextMenuToolbarItem()
         {

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
@@ -1,13 +1,10 @@
-using DIPS.Mobile.UI.Converters.ValueConverters;
 using DIPS.Mobile.UI.Resources.Styles.Button;
-using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 
 namespace DIPS.Mobile.UI.Components.Buttons
 {
     public partial class Button : Microsoft.Maui.Controls.Button
     {
         private Style? m_buttonStyleBasedOn;
-        private int m_tries;
 
         public Button()
         {
@@ -22,28 +19,15 @@ namespace DIPS.Mobile.UI.Components.Buttons
         /// <br /><br/>
         /// If the user increases the font-size to for example 200% (Which increases the button's Width/Height), the CornerRadius value should also increase to match a RoundRectangle
         /// </summary>
-        protected override async void OnSizeAllocated(double width, double height)
+        protected override void OnSizeAllocated(double width, double height)
         {
             base.OnSizeAllocated(width, height);
 
-            if (CornerRadius == -1)
-            {
-                m_tries = 0;
-                
-                // The Width/Height can be 0 if the button is inside a Grid that has IsVisible changed, with a * Row/Column definition
-                // Most likely a bug in MAUI, because the Width/Height is set on a later frame
-                while (Width == 0 || Height == 0)
-                {
-                    // Safe guard to prevent infinite loop
-                    if(m_tries > 50) 
-                        return;
-                    
-                    await Task.Delay(1);
-                    m_tries++;
-                }
-                
+            if (CornerRadius != -1)
+                return;
+
+            if(!(Height == 0 || Width == 0))
                 CornerRadius = (int)(Math.Min(Width, Height) / 2);
-            }
         }
 
         protected override void OnPropertyChanged(string propertyName = null)

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
@@ -12,6 +12,7 @@ namespace DIPS.Mobile.UI.Components.Buttons
         {
             Style = ButtonTypeStyle.PrimaryLarge;
             HorizontalOptions = LayoutOptions.Center;
+            VerticalOptions = LayoutOptions.Center;
         }
 
         protected override void OnSizeAllocated(double width, double height)

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
@@ -7,6 +7,7 @@ namespace DIPS.Mobile.UI.Components.Buttons
     public partial class Button : Microsoft.Maui.Controls.Button
     {
         private Style? m_buttonStyleBasedOn;
+        private int m_tries;
 
         public Button()
         {
@@ -14,16 +15,31 @@ namespace DIPS.Mobile.UI.Components.Buttons
             HorizontalOptions = LayoutOptions.Center;
         }
 
+        /// <summary>
+        /// This method is overriden to try replicating the CornerRadius of a RoundRectangle if the button is not an icon button (Or if the consumer has not set the CornerRadius themselves)
+        /// <br /><br/>
+        /// We can't specify a CornerRadius in the Style for text buttons, because the CornerRadius is relative to the Width/Height of a text button
+        /// <br /><br/>
+        /// If the user increases the font-size to for example 200% (Which increases the button's Width/Height), the CornerRadius value should also increase to match a RoundRectangle
+        /// </summary>
         protected override async void OnSizeAllocated(double width, double height)
         {
             base.OnSizeAllocated(width, height);
 
-            // If the CornerRadius has not been set by consumer, set it so it replicates a RoundRectangle
             if (CornerRadius == -1)
             {
+                m_tries = 0;
+                
+                // The Width/Height can be 0 if the button is inside a Grid that has IsVisible changed, with a * Row/Column definition
+                // Most likely a bug in MAUI, because the Width/Height is set on a later frame
                 while (Width == 0 || Height == 0)
                 {
+                    // Safe guard to prevent infinite loop
+                    if(m_tries > 50) 
+                        return;
+                    
                     await Task.Delay(1);
+                    m_tries++;
                 }
                 
                 CornerRadius = (int)(Math.Min(Width, Height) / 2);

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
@@ -12,16 +12,22 @@ namespace DIPS.Mobile.UI.Components.Buttons
         {
             Style = ButtonTypeStyle.PrimaryLarge;
             HorizontalOptions = LayoutOptions.Center;
-            VerticalOptions = LayoutOptions.Center;
         }
 
-        protected override void OnSizeAllocated(double width, double height)
+        protected override async void OnSizeAllocated(double width, double height)
         {
             base.OnSizeAllocated(width, height);
 
             // If the CornerRadius has not been set by consumer, set it so it replicates a RoundRectangle
-            if(CornerRadius == -1)
+            if (CornerRadius == -1)
+            {
+                while (Width == 0 || Height == 0)
+                {
+                    await Task.Delay(1);
+                }
+                
                 CornerRadius = (int)(Math.Min(Width, Height) / 2);
+            }
         }
 
         protected override void OnPropertyChanged(string propertyName = null)


### PR DESCRIPTION
### Description of Change

[iOS] I found out that the Width/Height can be 0 (which we use to calculate the Corner Radius) if the button is inside a Grid that has IsVisible changed, with a * Row/Column definition. This is most likely a bug in MAUI, because the Width/Height is set on a later frame.

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->