### PR TITLE
[ImageCapture][Android] Fixed an issue where the rotated image would have wrong translation in either X or Y direction, when in edit mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [37.3.4] 
+- [ImageCapture][Android] Fixed an issue where the rotated image would have wrong translation in either X or Y direction, when in edit mode.
+
 ## [37.3.3] 
 - [Button][iOS] Fixed an edge-case where some buttons did not get rounded corners.
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/CapturedImage.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/CapturedImage.cs
@@ -4,6 +4,7 @@
 
 
 using DIPS.Mobile.UI.API.Library;
+using IImage = Microsoft.Maui.IImage;
 using Image = Microsoft.Maui.Controls.Image;
 #if __IOS__
 using ImageIO;

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/CapturedImage.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/CapturedImage.cs
@@ -4,7 +4,6 @@
 
 
 using DIPS.Mobile.UI.API.Library;
-using IImage = Microsoft.Maui.IImage;
 using Image = Microsoft.Maui.Controls.Image;
 #if __IOS__
 using ImageIO;

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.ConfirmState.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.ConfirmState.cs
@@ -9,19 +9,21 @@ public partial class ImageCapture : IConfirmStateObserver
 #nullable disable
     private CapturedImage m_currentlyCapturedImage;
     private Image m_confirmImage;
+    private Grid m_confirmImageWrapper;
 #nullable enable
 
     private async void GoToConfirmState(CapturedImage capturedImage)
     {
         m_currentlyCapturedImage = capturedImage;
         
-        m_cameraPreview.RemoveViewFromRoot(m_confirmImage);
+        m_cameraPreview.RemoveViewFromRoot(m_confirmImageWrapper);
         m_confirmImage = new Image
         {
             Source = ImageSource.FromStream(() => new MemoryStream(capturedImage.AsByteArray)),
             InputTransparent = true
         };
-        m_cameraPreview.AddViewToRoot(m_confirmImage, 3, true);
+        m_confirmImageWrapper = new Grid { Children = { m_confirmImage }, InputTransparent = true };
+        m_cameraPreview.AddViewToRoot(m_confirmImageWrapper, 3, true);
         
         // We need to add a slight delay, because the camera preview will be black for a short moment if we don't, because the image is not yet loaded - "simulating a shutter effect", 
         await Task.Delay(10);

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.StreamingState.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.StreamingState.cs
@@ -32,7 +32,7 @@ public partial class ImageCapture : IStreamingStateObserver
 
         m_bottomToolbarView.SetShutterButtonEnabled(true);
 
-        m_cameraPreview.RemoveViewFromRoot(m_confirmImage);
+        m_cameraPreview.RemoveViewFromRoot(m_confirmImageWrapper);
 
         if (m_cameraPreview.CameraZoomView != null)
         {


### PR DESCRIPTION
### Description of Change

It seems that when setting Translation on a view, on Android the pivot point does not take into account the translation. However, it does on iOS. A workaround for this is to wrap the image inside a grid, and translate the grid instead.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->