### PR TITLE
[ImageCapture] Tap to focus indicator fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [37.3.6]
+- [ImageCapture][Android] Fixed an issue where the tap to focus indicator were not animated
+- [ImageCapture][iOS] Fixed an issue where the tap to focus indicator were not placed correctly
+
 ## [37.3.5]
 - [ItemPicker] Fixed an issue where `IsEnabled` was ignored.
 


### PR DESCRIPTION
### Description of Change
* Fixed an issue on iOS where the tap to focus indicator were not placed correctly.
* Fixed an issue on Android where the tap to focus indicator were not animating. By placing the indicator inside a wrapper.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->