### PR TITLE
[ImageCapture] Fixed an issue where on some devices you could not rotate images because 'Thumbnail' was null.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [37.3.8]
+- [ImageCapture] Fixed an issue where on some devices you could not rotate images because 'Thumbnail' was null.
+
 ## [37.3.7]
 - [ListItem] Fixed an issue where the visibility of `Subtitle` were not updated when the `Subtitle` were set at a later point.
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/CapturedImage.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/CapturedImage.cs
@@ -32,7 +32,7 @@ public class CapturedImage
     public byte[] AsByteArray { get; }
 #if __ANDROID__
     public Bitmap ImageBitmap { get; }
-    public Bitmap ThumbnailBitmap { get; }
+    public Bitmap? ThumbnailBitmap { get; }
     public IImageProxy ImageProxy { get; }
 #elif __IOS__
     private CGImage m_cgImage;
@@ -109,7 +109,7 @@ public class CapturedImage
     }    
 
 #if __ANDROID__
-    public CapturedImage(byte[] asByteArray, Bitmap imageBitmap, byte[]? thumbnailAsByteArray, Bitmap thumbnailBitmap, IImageProxy imageProxy, ImageTransformation imageTransformation)
+    public CapturedImage(byte[] asByteArray, Bitmap imageBitmap, byte[]? thumbnailAsByteArray, Bitmap? thumbnailBitmap, IImageProxy imageProxy, ImageTransformation imageTransformation)
     {
         AsByteArray = asByteArray;
         ImageBitmap = imageBitmap;
@@ -136,11 +136,14 @@ public class CapturedImage
             newOrientationDegree = OrientationDegree.Orientation0;
         }
         
-        return new CapturedImage(rotatedImageBytes, rotatedImageBitmap, rotatedThumbnailBytes, rotatedThumbnailBitmap, ImageProxy, new ImageTransformation(newOrientationDegree, newOrientationDegree.ToString()));
+        return new CapturedImage(rotatedImageBytes ?? [], rotatedImageBitmap!, rotatedThumbnailBytes, rotatedThumbnailBitmap, ImageProxy, new ImageTransformation(newOrientationDegree, newOrientationDegree.ToString()));
     }
 
-    private static async Task<(Bitmap rotatedImageBitmap, byte[] rotatedImageBytes)> RotateBitmap(Bitmap bitmap, float degrees)
+    private static async Task<(Bitmap? rotatedImageBitmap, byte[]? rotatedImageBytes)> RotateBitmap(Bitmap? bitmap, float degrees)
     {
+        if (bitmap is null)
+            return (null!, null);
+        
         var matrix = new Matrix();
         matrix.PostRotate(degrees);
     


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [X] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->