### PR TITLE
Made sure long press effect works for dui:Button and other non-MauiVi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [38.0.4]
+- [iOS] Made sure long press effect works for dui:Button and other non-MauiView views.
+
 ## [38.0.3]
 - [iOS][Layout] Fix crash.
 

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -17,12 +17,11 @@
         <håvardSamples:HåvardPageViewModel />
     </dui:ContentPage.BindingContext>
 
-    <Grid Padding="{dui:Thickness size_2}">
-        <dui:Label Text="{Binding LongText}" MaxLines="3"  TruncatedText="More" x:Name="truncatingLabel"/>
-        <dui:HorizontalStackLayout HorizontalOptions="Start"
-                                   VerticalOptions="Center"
-                                   Spacing="{dui:Sizes size_1}">
-            <dui:Button Text="Remove" Command="{Binding Command}"/>
-        </dui:HorizontalStackLayout>
-    </Grid>
+    <dui:Button Text="Remove" Command="{Binding Command}" dui:ContextMenuEffect.Mode="LongPressed">
+        <dui:ContextMenuEffect.Menu>
+            <dui:ContextMenu>
+                <dui:ContextMenuItem Title="Test"/>
+            </dui:ContextMenu>
+        </dui:ContextMenuEffect.Menu>
+    </dui:Button>
 </dui:ContentPage>

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.LongPressed.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.LongPressed.cs
@@ -24,6 +24,7 @@ public partial class ContextMenuPlatformEffect
 
         m_contextMenu.BindingContext = Element.BindingContext;
 
+        m_delegate.Element = Element;
         m_interaction = new UIContextMenuInteraction(m_delegate);
         
         Control.AddInteraction(m_interaction);
@@ -34,20 +35,19 @@ public partial class ContextMenuPlatformEffect
         public override void WillEnd(UIContextMenuInteraction interaction, UIContextMenuConfiguration configuration,
             IUIContextMenuInteractionAnimating? animator)
         {
-            if (interaction.View is not MauiView view)
+            if (Element is null)
                 return; 
 
-            Touch.SetIsEnabled((VisualElement)view.View, true);
+            Touch.SetIsEnabled(Element, true);
         }
         
         public override UIContextMenuConfiguration? GetConfigurationForMenu(UIContextMenuInteraction interaction, CGPoint location)
         {
-            if (interaction.View is not MauiView view)
-                return null; 
+            if (Element is null) return null;
             
-            Touch.SetIsEnabled((VisualElement)view.View, false);
+            Touch.SetIsEnabled(Element, false);
 
-            var contextMenu = ContextMenuEffect.GetMenu(((VisualElement)view.View!));
+            var contextMenu = ContextMenuEffect.GetMenu((Element));
             
             var dict = ContextMenuHelper.CreateMenuItems(
                 contextMenu!.ItemsSource!,
@@ -55,6 +55,14 @@ public partial class ContextMenuPlatformEffect
             var menu = UIMenu.Create(contextMenu.Title, dict.Select(k => k.Value).ToArray());
 
             return UIContextMenuConfiguration.Create(null, null, actions => menu);
+        }
+
+        public Element? Element { get; set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            Element = null;
+            base.Dispose(disposing);
         }
     }
 


### PR DESCRIPTION
### Description of Change

- Made sure long press effect works for dui:Button and other non-MauiViews

# Problem
We based our long press gesture on views that were based having to implement MAUIView.  dui:Button did not implement this.

# Solution
Made sure we use the visual Element from the LongPress effect instead of the passed native view when presenting long press behavior. 

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->