### PR TITLE
Fixed a bug where toggled icon were always visible if a `Chip` was set to be toggleable and a crash bug with `Layout` effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [38.3.1] 
+- Fixed a bug where toggled icon were always visible if a `Chip` was set to be toggleable.
+- Fixed a crash that sometimes would happen when `Layout` effect were detached on navigating away.
+
 ## [38.3.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/src/library/DIPS.Mobile.UI/Components/Chips/iOS/Chip.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/iOS/Chip.cs
@@ -101,7 +101,7 @@ public partial class Chip
             VerticalOptions = LayoutOptions.Center
         };
         
-        image.SetBinding(IsVisibleProperty, static (Chip chip) => chip.IsToggleable, source: this);
+        image.SetBinding(IsVisibleProperty, static (Chip chip) => chip.IsToggled, source: this);
         image.SetBinding(Images.Image.Image.TintColorProperty, static (Chip chip) => chip.TitleColor, source: this);
         
         return image;

--- a/src/library/DIPS.Mobile.UI/DIPS.Mobile.UI.csproj
+++ b/src/library/DIPS.Mobile.UI/DIPS.Mobile.UI.csproj
@@ -14,7 +14,7 @@
         <LangVersion>default</LangVersion>
         
         <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
-        <WarningsAsErrors>XC0022;XC0023</WarningsAsErrors>
+        <WarningsAsErrors>XC0022;XC0023;XC0045</WarningsAsErrors>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-ios|AnyCPU'">

--- a/src/library/DIPS.Mobile.UI/Effects/Layout/Android/LayoutPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Layout/Android/LayoutPlatformEffect.cs
@@ -32,6 +32,9 @@ public partial class  LayoutPlatformEffect
 
     protected override partial void OnDetached()
     {
+        if(Control is null)
+            return;
+        
         Control.Background = m_originalBackground;
     }
 }

--- a/src/library/DIPS.Mobile.UI/Effects/Layout/iOS/LayoutPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Layout/iOS/LayoutPlatformEffect.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace DIPS.Mobile.UI.Effects.Layout;
 
 public partial class LayoutPlatformEffect
@@ -18,8 +20,17 @@ public partial class LayoutPlatformEffect
     {
         if(Control is null)
             return;
-        
-        Control.ClipsToBounds = m_originalClipToBound;
-        Control.Layer.CornerRadius = m_prevCornerRadius;
+
+        try
+        {
+            Control.ClipsToBounds = m_originalClipToBound;
+            Control.Layer.CornerRadius = m_prevCornerRadius;
+        }
+        catch
+        {
+            // I believe this can happen if Layer is null
+            // We can safely swallow this, as the Control is no longer visible anyway when Layer is null
+            // The idea here was to reset the CornerRadius if consumer removes the effect while the Control is still visible
+        }
     }
 }

--- a/src/library/DIPS.Mobile.UI/Extensions/Markup/InvertedBoolExtension.cs
+++ b/src/library/DIPS.Mobile.UI/Extensions/Markup/InvertedBoolExtension.cs
@@ -6,6 +6,7 @@ namespace DIPS.Mobile.UI.Extensions.Markup
     /// This markup extension lets you use <see cref="InvertedBoolConverter"/> when you are referring a static property from some class.
     /// </summary>
     [ContentProperty(nameof(Input))]
+    [AcceptEmptyServiceProvider]
     public class InvertedBoolExtension : IMarkupExtension
     {
         /// <summary>

--- a/src/library/DIPS.Mobile.UI/Extensions/Markup/StringCaseExtension.cs
+++ b/src/library/DIPS.Mobile.UI/Extensions/Markup/StringCaseExtension.cs
@@ -35,6 +35,7 @@ namespace DIPS.Mobile.UI.Extensions.Markup
     /// To get the same functionality with a binding, <see cref="StringCaseConverter"/>
     /// </summary>
     [ContentProperty(nameof(Input))]
+    [AcceptEmptyServiceProvider]
     public class StringCaseExtension : IMarkupExtension
     {
         /// <summary>

--- a/src/library/DIPS.Mobile.UI/Extensions/Markup/TimeSpanExtension.cs
+++ b/src/library/DIPS.Mobile.UI/Extensions/Markup/TimeSpanExtension.cs
@@ -1,7 +1,7 @@
 namespace DIPS.Mobile.UI.Extensions.Markup;
 
 [ContentProperty(nameof(Ticks))]
-
+[AcceptEmptyServiceProvider]
 public class TimeSpanExtension : IMarkupExtension<TimeSpan>
 {
     public long Ticks { get; set; }


### PR DESCRIPTION
### Description of Change

Also tagged some MarkupExtensions with [AcceptEmptyServiceProvider].

Additionally, I enabled XC0045 warning to throw error. However, since we almost never use XAML, there was no errors to fix.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->