### PR TITLE
[ContextMenu] ContextMenu will now respect the property `IsEnabled`, if setting context menu on non-buttons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [38.4.1]
+- [ContextMenu] ContextMenu will now respect the property `IsEnabled`, if setting context menu on non-buttons.
+
 ## [38.4.0]
 - [JsonViewer] Added a new JsonViewer that can be used to view JSON with syntax highligthing. 
 

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -18,7 +18,20 @@
     </dui:ContentPage.BindingContext>
     
     <VerticalStackLayout>
-        <Entry Keyboard="Numeric" Text="helo"></Entry>
+        <dui:Editor Keyboard="Numeric"
+                    />
+        <dui:ItemPicker Mode="ContextMenu"
+                        x:Name="ItemPicker">
+            <dui:ItemPicker.ItemsSource>
+                <x:Array Type="{x:Type x:String}" x:Key="Array">
+                    <x:String>Item 1</x:String>
+                    <x:String>Item 2</x:String>
+                    <x:String>Item 3</x:String>
+                </x:Array>
+            </dui:ItemPicker.ItemsSource>
+        </dui:ItemPicker>
+        <dui:Button Text="diable"
+                    Clicked="Button_OnClicked"></dui:Button>
     </VerticalStackLayout>
     
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml.cs
@@ -136,7 +136,7 @@ public partial class VetlePage
 
     private void Button_OnClicked(object sender, EventArgs e)
     {
-        Test = "Clicked";
+        ItemPicker.IsEnabled = false;
     }
 
     private void SwapRoot(object sender, EventArgs e)
@@ -178,6 +178,7 @@ public partial class VetlePage
             OnPropertyChanged();
         }
     }
+
 
     
 }

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.Pressed.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.Pressed.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using CoreGraphics;
 using DIPS.Mobile.UI.Components.ContextMenus.iOS;
 using Foundation;
@@ -36,8 +37,21 @@ public partial class ContextMenuPlatformEffect
         
         Control.AddSubview(uiButton);
         m_uiButtonToRemove = uiButton;
+        
+        Element.PropertyChanged += ElementOnPropertyChanged;
 
         return uiButton;
+    }
+
+    private void ElementOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if(Element is not VisualElement visualElement)
+            return;
+        
+        if (e.PropertyName == nameof(VisualElement.IsEnabled))
+        {
+            m_uiButton.Enabled = visualElement.IsEnabled;
+        }
     }
 
     // We need to update the frame of the overlay button when the Control is resized (For example when an Item in ItemPicker is selected, thus the title is changed)
@@ -78,5 +92,8 @@ public partial class ContextMenuPlatformEffect
         m_uiButtonToRemove?.RemoveFromSuperview();
         
         m_contextMenu.ItemsSourceUpdated -= RebuildMenu;
+        
+        if(Element is not null)
+            Element.PropertyChanged -= ElementOnPropertyChanged;
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Mode.ContextMenu.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Mode.ContextMenu.cs
@@ -1,72 +1,74 @@
 using DIPS.Mobile.UI.API.Vibration;
 using DIPS.Mobile.UI.Components.ContextMenus;
 
-namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker;
-
-public partial class ItemPicker
+namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
 {
-    private void UpdateContextMenuItems()
+    public partial class ItemPicker
     {
-        if (m_contextMenu == null ||
-            m_contextMenu.ItemsSource!.FirstOrDefault() is not ContextMenuGroup contextMenuGroup)
+        private void UpdateContextMenuItems()
         {
-            return;
-        }
-            
-        if (contextMenuGroup.ItemsSource == null)
-        {
-            return;
-        }
-            
-        foreach (var item in contextMenuGroup.ItemsSource)
-        {
-            item.IsChecked = false;
-        }
-
-        if (SelectedItem is not null)
-        {
-            var contextMenuItem = contextMenuGroup.ItemsSource?.FirstOrDefault(i =>
-                i.Title != null && i.Title.Equals(SelectedItem.GetPropertyValue(ItemDisplayProperty),
-                    StringComparison.InvariantCultureIgnoreCase));
-            if (contextMenuItem != null)
+            if (m_contextMenu == null ||
+                m_contextMenu.ItemsSource!.FirstOrDefault() is not ContextMenuGroup contextMenuGroup)
             {
-                contextMenuItem.IsChecked = true;
+                return;
             }
-        }
             
-        m_contextMenu.SendItemsSourceUpdated();
-    }
-
-    private void AddContextMenuItems()
-    {
-        if (ItemsSource == null)
-        {
-            return;
-        }
-
-        var group = new ContextMenuGroup() {IsCheckable = true};
-        foreach (var obj in ItemsSource)
-        {
-            var itemDisplayName = obj.GetPropertyValue(ItemDisplayProperty);
-            group.ItemsSource?.Add(new ContextMenuItem()
+            if (contextMenuGroup.ItemsSource == null)
             {
-                Title = itemDisplayName, IsChecked = SelectedItem == obj
-            });
+                return;
+            }
+            
+            foreach (var item in contextMenuGroup.ItemsSource)
+            {
+                item.IsChecked = false;
+            }
+
+            if (SelectedItem is not null)
+            {
+                var contextMenuItem = contextMenuGroup.ItemsSource?.FirstOrDefault(i =>
+                    i.Title != null && i.Title.Equals(SelectedItem.GetPropertyValue(ItemDisplayProperty),
+                        StringComparison.InvariantCultureIgnoreCase));
+                if (contextMenuItem != null)
+                {
+                    contextMenuItem.IsChecked = true;
+                }
+            }
+            
+            m_contextMenu.SendItemsSourceUpdated();
         }
 
-        m_contextMenu.ItemsSource!.Clear();
-        m_contextMenu.ItemsSource.Add(group);
-            
-        m_contextMenu.SendItemsSourceUpdated();
-    }
-
-    private void SetSelectedItemBasedOnContextMenuItem(ContextMenuItem item)
-    {
-        if (HasHaptics)
+        private void AddContextMenuItems()
         {
-            VibrationService.SelectionChanged();    
-        }
+            if (ItemsSource == null)
+            {
+                return;
+            }
+
+            var group = new ContextMenuGroup() {IsCheckable = true};
+            foreach (var obj in ItemsSource)
+            {
+                var itemDisplayName = obj.GetPropertyValue(ItemDisplayProperty);
+                group.ItemsSource?.Add(new ContextMenuItem()
+                {
+                    Title = itemDisplayName, IsChecked = SelectedItem == obj
+                });
+            }
+
+            m_contextMenu.ItemsSource!.Clear();
+            m_contextMenu.ItemsSource.Add(group);
             
-        SelectedItem = GetItemFromDisplayProperty(item.Title!);
+            m_contextMenu.SendItemsSourceUpdated();
+        }
+
+        private void SetSelectedItemBasedOnContextMenuItem(ContextMenuItem item)
+        {
+            if (HasHaptics)
+            {
+                VibrationService.SelectionChanged();    
+            }
+            
+            SelectedItem = GetItemFromDisplayProperty(item.Title!);
+        }
+
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Mode.ContextMenu.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Mode.ContextMenu.cs
@@ -69,6 +69,5 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             
             SelectedItem = GetItemFromDisplayProperty(item.Title!);
         }
-
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Mode.ContextMenu.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Mode.ContextMenu.cs
@@ -1,74 +1,72 @@
 using DIPS.Mobile.UI.API.Vibration;
 using DIPS.Mobile.UI.Components.ContextMenus;
-using DIPS.Mobile.UI.Extensions;
 
-namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
+namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker;
+
+public partial class ItemPicker
 {
-    public partial class ItemPicker
+    private void UpdateContextMenuItems()
     {
-        private void UpdateContextMenuItems()
+        if (m_contextMenu == null ||
+            m_contextMenu.ItemsSource!.FirstOrDefault() is not ContextMenuGroup contextMenuGroup)
         {
-            if (m_contextMenu == null ||
-                m_contextMenu.ItemsSource!.FirstOrDefault() is not ContextMenuGroup contextMenuGroup)
-            {
-                return;
-            }
+            return;
+        }
             
-            if (contextMenuGroup.ItemsSource == null)
-            {
-                return;
-            }
+        if (contextMenuGroup.ItemsSource == null)
+        {
+            return;
+        }
             
-            foreach (var item in contextMenuGroup.ItemsSource)
-            {
-                item.IsChecked = false;
-            }
-
-            if (SelectedItem is not null)
-            {
-                var contextMenuItem = contextMenuGroup.ItemsSource?.FirstOrDefault(i =>
-                    i.Title != null && i.Title.Equals(SelectedItem.GetPropertyValue(ItemDisplayProperty),
-                        StringComparison.InvariantCultureIgnoreCase));
-                if (contextMenuItem != null)
-                {
-                    contextMenuItem.IsChecked = true;
-                }
-            }
-            
-            m_contextMenu.SendItemsSourceUpdated();
+        foreach (var item in contextMenuGroup.ItemsSource)
+        {
+            item.IsChecked = false;
         }
 
-        private void AddContextMenuItems()
+        if (SelectedItem is not null)
         {
-            if (ItemsSource == null)
+            var contextMenuItem = contextMenuGroup.ItemsSource?.FirstOrDefault(i =>
+                i.Title != null && i.Title.Equals(SelectedItem.GetPropertyValue(ItemDisplayProperty),
+                    StringComparison.InvariantCultureIgnoreCase));
+            if (contextMenuItem != null)
             {
-                return;
+                contextMenuItem.IsChecked = true;
             }
-
-            var group = new ContextMenuGroup() {IsCheckable = true};
-            foreach (var obj in ItemsSource)
-            {
-                var itemDisplayName = obj.GetPropertyValue(ItemDisplayProperty);
-                group.ItemsSource?.Add(new ContextMenuItem()
-                {
-                    Title = itemDisplayName, IsChecked = SelectedItem == obj
-                });
-            }
-
-            m_contextMenu.ItemsSource!.Clear();
-            m_contextMenu.ItemsSource.Add(group);
+        }
             
-            m_contextMenu.SendItemsSourceUpdated();
+        m_contextMenu.SendItemsSourceUpdated();
+    }
+
+    private void AddContextMenuItems()
+    {
+        if (ItemsSource == null)
+        {
+            return;
         }
 
-        private void SetSelectedItemBasedOnContextMenuItem(ContextMenuItem item)
+        var group = new ContextMenuGroup() {IsCheckable = true};
+        foreach (var obj in ItemsSource)
         {
-            if (HasHaptics)
+            var itemDisplayName = obj.GetPropertyValue(ItemDisplayProperty);
+            group.ItemsSource?.Add(new ContextMenuItem()
             {
-                VibrationService.SelectionChanged();    
-            }
-            
-            SelectedItem = GetItemFromDisplayProperty(item.Title!);
+                Title = itemDisplayName, IsChecked = SelectedItem == obj
+            });
         }
+
+        m_contextMenu.ItemsSource!.Clear();
+        m_contextMenu.ItemsSource.Add(group);
+            
+        m_contextMenu.SendItemsSourceUpdated();
+    }
+
+    private void SetSelectedItemBasedOnContextMenuItem(ContextMenuItem item)
+    {
+        if (HasHaptics)
+        {
+            VibrationService.SelectionChanged();    
+        }
+            
+        SelectedItem = GetItemFromDisplayProperty(item.Title!);
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Mode.ContextMenu.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Mode.ContextMenu.cs
@@ -1,5 +1,6 @@
 using DIPS.Mobile.UI.API.Vibration;
 using DIPS.Mobile.UI.Components.ContextMenus;
+using DIPS.Mobile.UI.Extensions;
 
 namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
 {


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->