### PR TITLE
[iOS][ContextMenu] ContextMenu will now respect the property `IsEnabled` when the effect is attached to Element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [38.4.3]
+- [iOS][ContextMenu] ContextMenu will now respect the property `IsEnabled` when the effect is attached to Element.
+
 ## [38.4.2]
 - [Android] Fixed an issue where the status bar were not set to the correct color when pushing modals.
 - [Android] Fixed an issue where the icon's color were not set to the correct color in modal context.

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -18,6 +18,16 @@
     </dui:ContentPage.BindingContext>
     
     <VerticalStackLayout>
+        <dui:ItemPicker x:Name="ItemPicker"
+                        IsEnabled="False">
+            <dui:ItemPicker.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>Test 1</x:String>
+                    <x:String>Test 1</x:String>
+                    <x:String>Test 1</x:String>
+                </x:Array>
+            </dui:ItemPicker.ItemsSource>
+        </dui:ItemPicker>
         <dui:Button Text="diable"
                     Clicked="Button_OnClicked"></dui:Button>
     </VerticalStackLayout>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml.cs
@@ -136,7 +136,7 @@ public partial class VetlePage
 
     private void Button_OnClicked(object sender, EventArgs e)
     {
-        Navigation.PushModalAsync(new NavigationPage(new VetleTestPage1()));
+        ItemPicker.IsEnabled = !ItemPicker.IsEnabled;
     }
 
     private void SwapRoot(object sender, EventArgs e)

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.Pressed.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.Pressed.cs
@@ -37,6 +37,11 @@ public partial class ContextMenuPlatformEffect
         
         Control.AddSubview(uiButton);
         m_uiButtonToRemove = uiButton;
+
+        if (Element is VisualElement visualElement)
+        {
+            uiButton.Enabled = visualElement.IsEnabled;
+        }
         
         Element.PropertyChanged += ElementOnPropertyChanged;
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.cs
@@ -48,11 +48,9 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             if (Mode == PickerMode.ContextMenu)
             {
                 // If not enabled, no need to set context menu effect
-                if (IsEnabled)
-                {
-                    ContextMenuEffect.SetMenu(m_chip, m_contextMenu);
-                    m_contextMenu.ItemClickedCommand = new Command<ContextMenuItem>(SetSelectedItemBasedOnContextMenuItem);
-                }
+                ContextMenuEffect.SetMenu(m_chip, m_contextMenu);
+                m_contextMenu.ItemClickedCommand = new Command<ContextMenuItem>(SetSelectedItemBasedOnContextMenuItem);
+                
             }
             else if (Mode == PickerMode.BottomSheet)
             {


### PR DESCRIPTION
### Description of Change

When setting IsEnabled = false on ItemPicker when the page loads, the context menu would not respect it. But now it will!

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->