### PR TITLE
[ContentControl] Make sure to disconnect handlers of views.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [38.5.3]
+- [ContentControl] Make sure to disconnect handlers of views.
+
 ## [38.5.2]
 - [Localization] Swapped language of three properties in DUILocalizedStrings.
 

--- a/src/library/DIPS.Mobile.UI/Components/Content/ContentControl.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Content/ContentControl.cs
@@ -11,7 +11,8 @@
             {
                 return;
             }
-            
+
+            Content?.DisconnectHandlers();
             Content = TemplateSelector.SelectTemplate(SelectorItem ?? BindingContext, this).CreateContent() as View;;
         }
 


### PR DESCRIPTION
### Description of Change

When replacing content inside of a ContentControl, the views will not be cleaned up automatically by MAUI. We need to manually call DisconnectHandlers to clean the views up.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->