### PR TITLE
[ContextMenuEffect] Fixed edge-case-crash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [38.5.4]
+- [ContextMenuEffect] Fixed edge-case-crash.
+
 ## [38.5.3]
 - [ContentControl] Make sure to disconnect handlers of views.
 

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -22,7 +22,8 @@
 
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.1</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">30.0</SupportedOSPlatformVersion>
-        
+
+        <_MauiForceXamlCForDebug>true</_MauiForceXamlCForDebug>
         <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
         <WarningsAsErrors>XC0022;XC0023</WarningsAsErrors>
         <MauiStrictXamlCompilation>true</MauiStrictXamlCompilation>

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -23,7 +23,7 @@
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.1</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">30.0</SupportedOSPlatformVersion>
 
-        <_MauiForceXamlCForDebug>true</_MauiForceXamlCForDebug>
+        <!--<_MauiForceXamlCForDebug>true</_MauiForceXamlCForDebug>-->
         <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
         <WarningsAsErrors>XC0022;XC0023</WarningsAsErrors>
         <MauiStrictXamlCompilation>true</MauiStrictXamlCompilation>

--- a/src/app/Playground/VetleSamples/TestBottomSheetNotFitToContent.xaml
+++ b/src/app/Playground/VetleSamples/TestBottomSheetNotFitToContent.xaml
@@ -17,6 +17,19 @@
     </dui:BottomSheet.Resources>
 
     
-    <CollectionView ItemsSource="{StaticResource Array}" BackgroundColor="Transparent" />
-    
+    <CollectionView ItemsSource="{StaticResource Array}" BackgroundColor="Transparent">
+        <CollectionView.ItemTemplate>
+            <DataTemplate>
+                <dui:Label Text="Test"
+                           dui:ContextMenuEffect.Mode="LongPressed">
+                    <dui:ContextMenuEffect.Menu>
+                        <dui:ContextMenu>
+                            <dui:ContextMenuItem Title="Test" />
+                        </dui:ContextMenu>
+                    </dui:ContextMenuEffect.Menu>
+                </dui:Label>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
+
 </dui:BottomSheet>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -29,7 +29,7 @@
             </dui:ItemPicker.ItemsSource>
         </dui:ItemPicker>
         <dui:Button Text="diable"
-                    IsEnabled="False"
+                    
                     Clicked="Button_OnClicked"></dui:Button>
     </VerticalStackLayout>
     

--- a/src/app/Playground/VetleSamples/VetlePage.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Input;
 using DIPS.Mobile.UI.Components.Alerting.Dialog;
+using DIPS.Mobile.UI.Components.BottomSheets;
 using DIPS.Mobile.UI.Resources.Icons;
 using Playground.HåvardSamples;
 using Shell = DIPS.Mobile.UI.Components.Shell.Shell;
@@ -136,7 +137,7 @@ public partial class VetlePage
 
     private void Button_OnClicked(object sender, EventArgs e)
     {
-        ItemPicker.IsEnabled = !ItemPicker.IsEnabled;
+        BottomSheetService.Open(new TestBottomSheetNotFitToContent());
     }
 
     private void SwapRoot(object sender, EventArgs e)

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/Touch.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/Touch.cs
@@ -4,9 +4,9 @@ namespace DIPS.Mobile.UI.Effects.Touch;
 
 public partial class Touch : RoutingEffect
 {
-    public static ICommand GetCommand(BindableObject view)
+    public static ICommand? GetCommand(BindableObject view)
     {
-        return (ICommand)view.GetValue(CommandProperty);
+        return (ICommand?)view.GetValue(CommandProperty);
     }
 
     public static void SetCommand(BindableObject view, ICommand command)
@@ -14,9 +14,9 @@ public partial class Touch : RoutingEffect
         view.SetValue(CommandProperty, command);
     }
     
-    public static ICommand GetLongPressCommand(BindableObject view)
+    public static ICommand? GetLongPressCommand(BindableObject view)
     {
-        return (ICommand)view.GetValue(LongPressCommandProperty);
+        return (ICommand?)view.GetValue(LongPressCommandProperty);
     }
 
     public static void SetLongPressCommand(BindableObject view, ICommand command)

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
@@ -41,15 +41,15 @@ public partial class TouchPlatformEffect
     {
         if (e.State != UIGestureRecognizerState.Began)
             return;
-
-        if (Touch.GetLongPressCommand(Element).CanExecute(Touch.GetLongPressCommandParameter(Element)))
-            Touch.GetLongPressCommand(Element).Execute(Touch.GetLongPressCommandParameter(Element));
+        
+        if (Touch.GetLongPressCommand(Element)?.CanExecute(Touch.GetLongPressCommandParameter(Element)) ?? false)
+            Touch.GetLongPressCommand(Element)?.Execute(Touch.GetLongPressCommandParameter(Element));
     }
 
     private void OnTap()
     {
-        if (Touch.GetCommand(Element).CanExecute(Touch.GetCommandParameter(Element)))
-            Touch.GetCommand(Element).Execute(Touch.GetCommandParameter(Element));
+        if (Touch.GetCommand(Element)?.CanExecute(Touch.GetCommandParameter(Element)) ?? false)
+            Touch.GetCommand(Element)?.Execute(Touch.GetCommandParameter(Element));
     }
 
     protected override partial void OnDetached()


### PR DESCRIPTION
### Description of Change

Very hard to reproduce. Previously we fixed a bug where the LongPressCommand were executed if you dismissed the ContextMenu at a perfect time, we fixed this by setting Touch.IsEnabled = false when opening the ContextMenu. However, this adds the Tap and LongPress delegates to the View, and if you have not set these Commands, you would get a very edge-case-crash when long pressing and then swiping down (In for example a BottomSheet).

In this PR I check if LongPressCommand is null, if it is, don't try to check if it can be executed.

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->