### PR TITLE
[ContentControl] Log and avoid possible crash if `BindingContext` and `SelectorItem` is the same object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [39.0.2]
+- [ContentControl] Log and avoid possible crash if `BindingContext` and `SelectorItem` is the same object.
+- [DatePickers][iOS] Remove popover if a datepicker is disconnected.
+
 ## [39.0.1]
 - [MultiLineInputField] Ensure that component resets when `IsSaving` is set to `false` manually
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageVersion Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
     <PackageVersion Include="LightInject" Version="6.6.4" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.22" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
     <PackageVersion Include="SkiaSharp.Extended.UI.Maui" Version="2.0.0-preview.92" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageVersion Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
     <PackageVersion Include="LightInject" Version="6.6.4" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.22" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
     <PackageVersion Include="SkiaSharp.Extended.UI.Maui" Version="2.0.0-preview.92" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/app/Playground/Playground.csproj
+++ b/src/app/Playground/Playground.csproj
@@ -24,9 +24,9 @@
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">30.0</SupportedOSPlatformVersion>
 
         <!--<_MauiForceXamlCForDebug>true</_MauiForceXamlCForDebug>-->
-        <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
-        <WarningsAsErrors>XC0022;XC0023</WarningsAsErrors>
-        <MauiStrictXamlCompilation>true</MauiStrictXamlCompilation>
+        <!--<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>-->
+        <!--<WarningsAsErrors>XC0022;XC0023;XC0045</WarningsAsErrors>-->
+        <!--<MauiStrictXamlCompilation>true</MauiStrictXamlCompilation>-->
     </PropertyGroup>
     
     <ItemGroup>

--- a/src/app/Playground/VetleSamples/TemplateSelector.cs
+++ b/src/app/Playground/VetleSamples/TemplateSelector.cs
@@ -1,3 +1,5 @@
+using DataTemplate = Microsoft.Maui.Controls.DataTemplate;
+
 namespace Playground.VetleSamples;
 
 public class TemplateSelector : DataTemplateSelector
@@ -6,8 +8,21 @@ public class TemplateSelector : DataTemplateSelector
     
     public DataTemplate Test2 { get; set; }
     
+    public static int Test = 0;
+    
     protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
     {
-        return Random.Shared.Next(0, 2) == 0 ? Test1 : Test2;
+        if (Test == 0)
+        {
+            Test++;
+            return new DataTemplate(() => new ViewCellTest());
+        }
+        else
+        {
+            return new DataTemplate(() => new VitalSignView());
+        }
+        
+        
     }
+
 }

--- a/src/app/Playground/VetleSamples/TimePlanningViewModel.cs
+++ b/src/app/Playground/VetleSamples/TimePlanningViewModel.cs
@@ -1,0 +1,25 @@
+using DIPS.Mobile.UI.MVVM;
+
+namespace Playground.VetleSamples;
+
+public class TimePlanningViewModel : ViewModel
+{
+    private readonly VetlePageViewModel m_vetlePageViewModel;
+    private DateTime m_dateTime;
+
+    public TimePlanningViewModel(VetlePageViewModel vetlePageViewModel)
+    {
+        m_vetlePageViewModel = vetlePageViewModel;
+    }
+    
+    public DateTime DateTime
+    {
+        get => m_dateTime;
+        set
+        {
+            if(value == m_dateTime) return;
+            RaiseWhenSet(ref m_dateTime, value);
+            m_vetlePageViewModel.OnDateChanged();
+        }
+    }
+}

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -8,7 +8,6 @@
                  xmlns:dui="http://dips.com/mobile.ui"
                  xmlns:system="clr-namespace:System;assembly=System.Runtime"
                  x:Class="Playground.VetleSamples.VetlePage"
-                 x:DataType="{x:Type vetleSamples:VetlePageViewModel}"
                  Padding="20"
                  x:Name="This"
                  HideSoftInputOnTapped="True">
@@ -17,20 +16,17 @@
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
     
-    <VerticalStackLayout>
-        <dui:ItemPicker x:Name="ItemPicker"
-                        IsEnabled="False">
-            <dui:ItemPicker.ItemsSource>
-                <x:Array Type="{x:Type x:String}">
-                    <x:String>Test 1</x:String>
-                    <x:String>Test 1</x:String>
-                    <x:String>Test 1</x:String>
-                </x:Array>
-            </dui:ItemPicker.ItemsSource>
-        </dui:ItemPicker>
-        <dui:Button Text="diable"
-                    
-                    Clicked="Button_OnClicked"></dui:Button>
-    </VerticalStackLayout>
+    <dui:ContentPage.Resources>
+        <vetleSamples:TemplateSelector x:Key="TemplateSelector" />
+    </dui:ContentPage.Resources>
     
+    <VerticalStackLayout WidthRequest="250"
+                         BindingContext="{Binding TimePlanningViewModel}">
+        <Switch x:Name="Switch"
+                Toggled="Switch_OnToggled"/>
+        
+        <dui:ContentControl 
+                            TemplateSelector="{StaticResource TemplateSelector}"
+                            x:Name="ContentControl" />
+    </VerticalStackLayout>
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml.cs
@@ -109,7 +109,11 @@ public partial class VetlePage
 
     private void Switch_OnToggled(object sender, ToggledEventArgs e)
     {
-        ShouldHideFloatingNavigationMenuButton = e.Value;
+        
+        
+        ContentControl.SelectorItem = e.Value;
+        
+        
     }
 
 

--- a/src/app/Playground/VetleSamples/VetlePageViewModel.cs
+++ b/src/app/Playground/VetleSamples/VetlePageViewModel.cs
@@ -26,6 +26,7 @@ public class VetlePageViewModel : ViewModel
     private DateTime m_date = new DateTime(2023, 2, 1, 23, 30, 0, DateTimeKind.Utc);
     private DateTime m_localDate = new DateTime(2023, 2, 1, 23, 30, 0, DateTimeKind.Local);
     private TestObject2 m_testObject2;
+    private TimePlanningViewModel m_timePlanningViewModel = null;
 
     public VetlePageViewModel()
     {
@@ -134,10 +135,8 @@ public class VetlePageViewModel : ViewModel
     private async Task DelayFunction()
     {
         await Task.Delay(2000);
-        GroupedTest.Add(["lol", "hehe"]);
-        GroupedTest.Add(["ok", "hehe"]);
 
-        TestObject2 = new TestObject2("lol");
+        TimePlanningViewModel = new TimePlanningViewModel(this);
     }
 
 
@@ -288,6 +287,17 @@ public class VetlePageViewModel : ViewModel
     });
 
     public ObservableCollection<GroupedTest> GroupedTest { get; } = [];
+
+    public TimePlanningViewModel TimePlanningViewModel
+    {
+        get => m_timePlanningViewModel;
+        set => RaiseWhenSet(ref m_timePlanningViewModel, value);
+    }
+
+    public void OnDateChanged()
+    {
+        TimePlanningViewModel = new TimePlanningViewModel(this);
+    }
 }
 
 public class GroupedTest : List<string>

--- a/src/app/Playground/VetleSamples/ViewCellTest.xaml
+++ b/src/app/Playground/VetleSamples/ViewCellTest.xaml
@@ -5,21 +5,9 @@
              xmlns:dui="http://dips.com/mobile.ui"
              xmlns:vetleSamples="clr-namespace:Playground.VetleSamples"
              x:Class="Playground.VetleSamples.ViewCellTest"
-             x:DataType="{x:Type vetleSamples:TestObject2}"
+             x:DataType="{x:Type vetleSamples:TimePlanningViewModel}"
              x:Name="This">
     
-        <Grid WidthRequest="40"
-                    HeightRequest="40"
-                    BackgroundColor="Red"
-                    Margin="{dui:Thickness Left=size_2_negative, Top=size_2_negative}"
-                    VerticalOptions="Center"
-                    dui:ContextMenuEffect.Mode="Pressed">
-            <dui:ContextMenuEffect.Menu>
-                <dui:ContextMenu IsEnabled="{Binding Source={x:Reference This}, Path=TestBool}">
-                    <dui:ContextMenuItem Title="Test" />
-                </dui:ContextMenu>
-                <!--<vetleSamples:ContextMenuTest TestBool="{Binding Source={x:Reference This}, Path=TestBool}" />-->
-            </dui:ContextMenuEffect.Menu>
-        </Grid>
+       <dui:DateAndTimePicker SelectedDateTime="{Binding DateTime, Mode=TwoWay}" />
     
 </ContentView>

--- a/src/library/DIPS.Mobile.UI/Components/Content/ContentControl.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Content/ContentControl.cs
@@ -1,4 +1,6 @@
-﻿namespace DIPS.Mobile.UI.Components.Content
+﻿using DIPS.Mobile.UI.Internal.Logging;
+
+namespace DIPS.Mobile.UI.Components.Content
 {
     /// <summary>
     /// Controls what content to display based on a <see cref="SelectorItem"/> with a <see cref="TemplateSelector"/>
@@ -12,8 +14,15 @@
                 return;
             }
 
+            if (BindingContext == SelectorItem && Content is not null)
+            {
+                DUILogService.LogError<ContentControl>("SelectorItem and BindingContext is the same, don't use SelectorItem as BindingContext. This can cause ContentControl to display the wrong content.");
+                return;
+            }
+            
             Content?.DisconnectHandlers();
             Content = TemplateSelector.SelectTemplate(SelectorItem ?? BindingContext, this).CreateContent() as View;;
+            
         }
 
         protected override void OnBindingContextChanged()

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DateAndTimePicker/iOS/DateAndTimePickerService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DateAndTimePicker/iOS/DateAndTimePickerService.cs
@@ -38,6 +38,21 @@ public partial class DateAndTimePickerService
         var currentViewController = Platform.GetCurrentUIViewController();
         
         _ = currentViewController?.PresentViewControllerAsync(presentedViewController, true);
+        
+        dateAndTimePicker.HandlerChanging += DateAndTimePickerOnHandlerChanging;
+    }
+
+    private static void DateAndTimePickerOnHandlerChanging(object? sender, HandlerChangingEventArgs e)
+    {
+        if (e.NewHandler is null)
+        {
+            Close();
+        }
+        
+        if(sender is DateAndTimePicker dateAndTimePicker)
+        {
+            dateAndTimePicker.HandlerChanging -= DateAndTimePickerOnHandlerChanging;
+        }
     }
 
     internal static partial bool IsOpen()

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/Service/iOS/DatePickerService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/Service/iOS/DatePickerService.cs
@@ -32,6 +32,21 @@ public partial class DatePickerService
         var currentViewController = Platform.GetCurrentUIViewController();
         
         _ = currentViewController?.PresentViewControllerAsync(presentedViewController, true);
+        
+        datePicker.HandlerChanging += DatePickerOnHandlerChanging;
+    }
+
+    private static void DatePickerOnHandlerChanging(object? sender, HandlerChangingEventArgs e)
+    {
+        if (e.NewHandler is null)
+        {
+            Close();
+        }
+        
+        if(sender is DatePicker datePicker)
+        {
+            datePicker.HandlerChanging -= DatePickerOnHandlerChanging;
+        }
     }
 
     internal static partial bool IsOpen()

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DatePickerShared/iOS/DateOrTimePickerPopoverViewController.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DatePickerShared/iOS/DateOrTimePickerPopoverViewController.cs
@@ -26,7 +26,7 @@ internal class DateOrTimePickerPopoverViewController : UIViewController, IDatePi
     {
         m_inlineDatePicker = inlineDatePicker;
         m_datePicker = datePicker;
-
+        
         var nativeSourceView = sourceView?.ToPlatform(DUI.GetCurrentMauiContext!);
 
         ModalPresentationStyle = UIModalPresentationStyle.Popover;

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/TimePicker/iOS/TimePickerService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/TimePicker/iOS/TimePickerService.cs
@@ -29,6 +29,21 @@ public partial class TimePickerService
         var currentViewController = Platform.GetCurrentUIViewController();
 
         _ = currentViewController?.PresentViewControllerAsync(presentedViewController, true);
+        
+        timePicker.HandlerChanging += TimePickerOnHandlerChanging;
+    }
+
+    private static void TimePickerOnHandlerChanging(object? sender, HandlerChangingEventArgs e)
+    {
+        if (e.NewHandler is null)
+        {
+            Close();
+        }
+        
+        if(sender is TimePicker timePicker)
+        {
+            timePicker.HandlerChanging -= TimePickerOnHandlerChanging;
+        }
     }
 
     internal static partial bool IsOpen()

--- a/src/library/DIPS.Mobile.UI/Internal/Logging/DUILogService.cs
+++ b/src/library/DIPS.Mobile.UI/Internal/Logging/DUILogService.cs
@@ -12,7 +12,7 @@ internal static partial class DUILogService
     /// <param name="message">The message to log as an error.</param>
     internal static void LogError<T>(string message) where T : class
     {
-        LogError(nameof(T), message);
+        LogError(typeof(T).ToString(), message);
     }
 
     /// <summary>


### PR DESCRIPTION
### Description of Change

Additionally, we will now dismiss the datepicker popovers on iOS if the controls are disconnected.

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->