### PR TITLE
Make sure we handle unchecked orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [39.0.3]
+- [ImageCapture] Make sure we handle unchecked orientation data
+
 ## [39.0.2]
 - [ContentControl] Log and avoid possible crash if `BindingContext` and `SelectorItem` is the same object.
 - [DatePickers][iOS] Remove popover if a datepicker is disconnected.

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ExifOrientationExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ExifOrientationExtensions.cs
@@ -14,6 +14,7 @@ public static class ExifOrientationExtensions
             ExifInterface.OrientationRotate180 => OrientationDegree.Orientation90,
             ExifInterface.OrientationRotate270 => OrientationDegree.Orientation180,
             ExifInterface.OrientationNormal => OrientationDegree.Orientation270,
+            _ => OrientationDegree.Orientation0
         };
     }
 }


### PR DESCRIPTION
### Description of Change
When retrieving orientation from image data on image capture, there are some values that are not handled. We only really handle rotational orientation, so we just handle any other value than expected as default orientation.