### PR TITLE
Make sure functions does not run when handler is null.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [40.0.3]
+- [ChipGroup] Make sure functions does not run when handler is null.
+
 ## [40.0.2]
 - [ImageCapture] Make sure we handle unchecked orientation data
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [40.0.3]
-- [ChipGroup] Make sure functions does not run when handler is null.
+- Make sure functions does not run when handler is null.
+- Make sure to null check `PlatformView` in some handlers and log if it is.
 
 ## [40.0.2]
 - [ImageCapture] Make sure we handle unchecked orientation data

--- a/src/app/Playground/VetleSamples/TemplateSelector.cs
+++ b/src/app/Playground/VetleSamples/TemplateSelector.cs
@@ -12,17 +12,7 @@ public class TemplateSelector : DataTemplateSelector
     
     protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
     {
-        if (Test == 0)
-        {
-            Test++;
-            return new DataTemplate(() => new ViewCellTest());
-        }
-        else
-        {
-            return new DataTemplate(() => new VitalSignView());
-        }
-        
-        
+        return new DataTemplate(() => new ViewCellTest());
     }
 
 }

--- a/src/app/Playground/VetleSamples/TimePlanningViewModel.cs
+++ b/src/app/Playground/VetleSamples/TimePlanningViewModel.cs
@@ -22,4 +22,6 @@ public class TimePlanningViewModel : ViewModel
             m_vetlePageViewModel.OnDateChanged();
         }
     }
+
+    public List<object> Tests { get; set; } = ["Test"];
 }

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -19,36 +19,14 @@
     <dui:ContentPage.Resources>
         <vetleSamples:TemplateSelector x:Key="TemplateSelector" />
     </dui:ContentPage.Resources>
-    
-    <CollectionView>
-        
-        <CollectionView.ItemsSource>
-            <x:Array Type="{x:Type x:String}">
-                <x:String>First</x:String>
-                <x:String>Second</x:String>
-                <x:String>Third</x:String>
-            </x:Array>
-        </CollectionView.ItemsSource>
-        
-        <CollectionView.Header>
-            <VerticalStackLayout>
-                
-            <dui:SegmentedControl SelectionMode="Multi">
-                <x:Array Type="{x:Type x:String}">
-                    <x:String>First</x:String>
-                    <x:String>Second askdlnjasoidjnaso</x:String>
-                    <x:String>Third asoidkjaoisdjoiasjdoia</x:String>
-                </x:Array>
-            </dui:SegmentedControl>
-            </VerticalStackLayout>
 
-        </CollectionView.Header>
+    <VerticalStackLayout WidthRequest="250"
+                         BindingContext="{Binding TimePlanningViewModel}">
+        <Switch x:Name="Switch"
+                Toggled="Switch_OnToggled"/>
 
-        <CollectionView.ItemTemplate>
-            <DataTemplate>
-                <Label Text="{Binding .}" />
-            </DataTemplate>
-        </CollectionView.ItemTemplate>
-        
-    </CollectionView>
+        <dui:ContentControl 
+            TemplateSelector="{StaticResource TemplateSelector}"
+            x:Name="ContentControl" />
+    </VerticalStackLayout>
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/ViewCellTest.xaml
+++ b/src/app/Playground/VetleSamples/ViewCellTest.xaml
@@ -8,6 +8,20 @@
              x:DataType="{x:Type vetleSamples:TimePlanningViewModel}"
              x:Name="This">
     
+    <VerticalStackLayout>
        <dui:DateAndTimePicker SelectedDateTime="{Binding DateTime, Mode=TwoWay}" />
     
+       <dui:ChipGroup SelectedItems="{Binding Tests}"
+                      SelectionMode="Single">
+           <dui:ChipGroup.ItemsSource>
+               <x:Array Type="{x:Type x:String}">
+                   <x:String>Test</x:String>
+                   <x:String>Test2</x:String>
+                   <x:String>Test3</x:String>
+
+               </x:Array>
+           </dui:ChipGroup.ItemsSource>
+       </dui:ChipGroup>
+    </VerticalStackLayout>
+       
 </ContentView>

--- a/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/GalleryBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/GalleryBottomSheet.cs
@@ -193,14 +193,17 @@ internal partial class GalleryBottomSheet : Components.BottomSheets.BottomSheet,
         m_onRemoveImage.Invoke(m_carouselView.Position);
     }
 
-    protected override void OnHandlerChanged()
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
-        
-        OnImagesChanged();
-        _ = OnCarouselViewPositionChanged(m_carouselView!.Position);
+        base.OnHandlerChanging(args);
+
+        if (args.NewHandler is not null)
+        {
+            OnImagesChanged();
+            _ = OnCarouselViewPositionChanged(m_carouselView!.Position);    
+        }
     }
-    
+
     private void CarouselViewOnPositionChanged(object? sender, PositionChangedEventArgs e)
     {
         m_cancellationTokenSource.Cancel();

--- a/src/library/DIPS.Mobile.UI/API/Camera/Gallery/GalleryThumbnails.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Gallery/GalleryThumbnails.cs
@@ -50,11 +50,12 @@ public partial class GalleryThumbnails : Grid
         CameraButtonTapped?.Invoke(this, EventArgs.Empty);
     }
 
-    protected override void OnHandlerChanged()
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
+        base.OnHandlerChanging(args);
         
-        OnImagesChanged();
+        if(args.NewHandler is not null)
+            OnImagesChanged();
     }
 
     private void OnTappedImage(int imageIndex)

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
@@ -48,7 +48,7 @@ namespace DIPS.Mobile.UI.Components.Buttons
                 return;
             
             // If the button is not enabled as the default, we need to update the style to the disabled style
-            if(!IsEnabled && Handler is not null)
+            if(!IsEnabled)
                 OnIsEnabledChanged();
         }
 

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
@@ -40,9 +40,12 @@ namespace DIPS.Mobile.UI.Components.Buttons
             }
         }
 
-        protected override void OnHandlerChanged()
+        protected override void OnHandlerChanging(HandlerChangingEventArgs args)
         {
-            base.OnHandlerChanged();
+            base.OnHandlerChanging(args);
+
+            if (args.NewHandler is null)
+                return;
             
             // If the button is not enabled as the default, we need to update the style to the disabled style
             if(!IsEnabled && Handler is not null)

--- a/src/library/DIPS.Mobile.UI/Components/CheckBoxes/FilledCheckBox.cs
+++ b/src/library/DIPS.Mobile.UI/Components/CheckBoxes/FilledCheckBox.cs
@@ -46,9 +46,12 @@ public partial class FilledCheckBox : ContentView
     private Grid InnerGrid { get; }
     private Border Container { get; }
 
-    protected override void OnHandlerChanged()
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
+        base.OnHandlerChanging(args);
+
+        if (args.NewHandler is null)
+            return;
 
         _ = SetContainerContent();
         Container.StrokeShape = new RoundRectangle {CornerRadius = CornerRadius};

--- a/src/library/DIPS.Mobile.UI/Components/ChipGroup/ChipGroup.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ChipGroup/ChipGroup.cs
@@ -16,14 +16,12 @@ public partial class ChipGroup : ContentView
         Content = m_flexLayout;
     }
 
-    protected override void OnHandlerChanged()
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
-
-        if (SelectedItems is not null)
-        {
+        base.OnHandlerChanging(args);
+        
+        if(args.NewHandler is not null)
             SetChipsToggledBasedOnSelectedItems();
-        }
     }
 
     private void SetChipsToggledBasedOnSelectedItems()

--- a/src/library/DIPS.Mobile.UI/Components/Chips/Android/OnToggledChangedListener.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/Android/OnToggledChangedListener.cs
@@ -1,4 +1,5 @@
 using Android.Widget;
+using DIPS.Mobile.UI.Internal.Logging;
 using Microsoft.Maui.Platform;
 
 namespace DIPS.Mobile.UI.Components.Chips;
@@ -16,6 +17,12 @@ internal class OnToggledChangedListener : Java.Lang.Object, CompoundButton.IOnCh
         m_handler.VirtualView.IsToggled = isChecked;
 
         await Task.Delay(1);
+        
+        if (m_handler.PlatformView is null)
+        {
+            DUILogService.LogError<OnToggledChangedListener>("PlatformView is null, this should not happen, most likely the issue is that the Content is rendered and then the handler is instantly disconnected");
+            return;
+        }
         m_handler.PlatformView.CheckedIconTint = m_handler.VirtualView.TitleColor?.ToDefaultColorStateList();
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Images/Image/iOS/ImageHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Images/Image/iOS/ImageHandler.cs
@@ -1,3 +1,4 @@
+using DIPS.Mobile.UI.Internal.Logging;
 using Microsoft.Maui.Platform;
 using UIKit;
 
@@ -14,15 +15,23 @@ public partial class ImageHandler
             // Wait for Image to be set
             while (handler.PlatformView.Image is null)
             {
-                if(tries > 10)
+                if (tries > 10)
                     return;
-                
+
                 await Task.Delay(1);
                 tries++;
             }
-            
+
             if (image.TintColor == null) return;
-            handler.PlatformView.Image = handler.PlatformView.Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+
+            if (handler.PlatformView is null)
+            {
+                DUILogService.LogError<ImageHandler>("PlatformView is null, this should not happen, most likely the issue is that the Content is rendered and then the handler is instantly disconnected");
+                return;
+            }
+
+            handler.PlatformView.Image =
+                handler.PlatformView.Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
             handler.PlatformView.TintColor = image.TintColor.ToPlatform();
         }
         catch

--- a/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/Android/ImageButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/Android/ImageButtonHandler.cs
@@ -1,11 +1,10 @@
-using System.ComponentModel;
 using Android.Content.Res;
 using Android.Graphics.Drawables;
 using DIPS.Mobile.UI.Effects.Touch;
 using DIPS.Mobile.UI.Extensions.Android;
+using DIPS.Mobile.UI.Internal.Logging;
 using Google.Android.Material.ImageView;
 using Microsoft.Maui.Platform;
-using View = Android.Views.View;
 
 // ReSharper disable once CheckNamespace
 namespace DIPS.Mobile.UI.Components.Images.ImageButton;
@@ -29,14 +28,26 @@ public partial class ImageButtonHandler
 
     private static partial void TrySetTintColor(ImageButtonHandler handler, ImageButton imageButton)
     {
-        handler.PlatformView.SetColorFilter(imageButton.TintColor.ToPlatform());
+        if (handler.PlatformView is null)
+        {
+            DUILogService.LogError<ImageButtonHandler>("PlatformView is null, this should not happen, most likely the issue is that the Content is rendered and then the handler is instantly disconnected");
+            return;
+        }
+            
+        handler.PlatformView?.SetColorFilter(imageButton.TintColor.ToPlatform());
     }
 
     private static async partial void MapAdditionalHitBoxSize(ImageButtonHandler handler, ImageButton imageButton)
     {
         await Task.Delay(1);
 
-        handler.PlatformView.SetAdditionalHitBoxSize(imageButton, imageButton.AdditionalHitBoxSize, handler.MauiContext!);
+        if (handler.PlatformView is null)
+        {
+            DUILogService.LogError<ImageButtonHandler>("PlatformView is null, this should not happen, most likely the issue is that the Content is rendered and then the handler is instantly disconnected");
+            return;
+        }
+        
+        handler.PlatformView?.SetAdditionalHitBoxSize(imageButton, imageButton.AdditionalHitBoxSize, handler.MauiContext!);
         
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/iOS/ImageButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/iOS/ImageButtonHandler.cs
@@ -1,3 +1,4 @@
+using DIPS.Mobile.UI.Internal.Logging;
 using DIPS.Mobile.UI.Platforms.iOS;
 using Microsoft.Maui.Platform;
 using UIKit;
@@ -41,9 +42,16 @@ public partial class ImageButtonHandler
             await Task.Delay(1);
             tries++;
         }
-        
-        handler.PlatformView.SetImage(handler.PlatformView.ImageView.Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate), UIControlState.Normal);
-        handler.PlatformView.TintColor = imageButton.TintColor.ToPlatform();
+
+        if (handler.PlatformView is not null)
+        {
+            handler.PlatformView.SetImage(handler.PlatformView.ImageView.Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate), UIControlState.Normal);
+            handler.PlatformView.TintColor = imageButton.TintColor.ToPlatform();
+        }
+        else
+        {
+            DUILogService.LogError<ImageButtonHandler>("PlatformView is null, this should not happen, most likely the issue is that the Content is rendered and then the handler is instantly disconnected");
+        }
     }
 
     private static partial void MapAdditionalHitBoxSize(ImageButtonHandler handler, ImageButton imageButton)

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Extensions/LoadableListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Extensions/LoadableListItem.cs
@@ -62,10 +62,13 @@ public partial class LoadableListItem : ListItem
         CreateBusyContent();
         CreateErrorContent();
     }
-    
-    protected override void OnHandlerChanged()
+
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
+        base.OnHandlerChanging(args);
+        
+        if(args.NewHandler is null)
+            return;
         
         m_cachedCommand = Command;
         m_cachedCommandParameter = CommandParameter;

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Extensions/NavigationListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Extensions/NavigationListItem.cs
@@ -32,9 +32,12 @@ public partial class NavigationListItem : ListItem
         InLineContentOptions = new InLineContentOptions() {Width = GridLength.Auto};
     }
 
-    protected override void OnHandlerChanged()
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
+        base.OnHandlerChanging(args);
+        
+        if(args.NewHandler is null)
+            return;
         
         if (InLineContent is null)
         {

--- a/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/NavigationMenuButton/NavigationMenuButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Navigation/FloatingNavigationButton/NavigationMenuButton/NavigationMenuButton.cs
@@ -76,10 +76,13 @@ internal partial class NavigationMenuButton : Grid
 
     internal View Button { get; }
 
-    protected override async void OnHandlerChanged()
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
+        base.OnHandlerChanging(args);
 
+        if (args.NewHandler is null)
+            return;
+        
         // We must set this here, because on Android, the ImageButton disappears when binding rotation
         Button.Rotation = IconRotation;
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DateAndTimePicker/DateAndTimePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DateAndTimePicker/DateAndTimePicker.cs
@@ -93,10 +93,13 @@ public partial class DateAndTimePicker : Grid, IDatePicker
         return SelectedDateTime.Kind;
     }
 
-    protected override void OnHandlerChanged()
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
-
+        base.OnHandlerChanging(args);
+        
+        if(args.NewHandler is null)
+            return;
+        
         SelectedDateTime = ValidateDateTime(SelectedDateTime);
         OnSelectedDateTimeChanged(SelectedDateTime);
     }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/DatePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/DatePicker.cs
@@ -19,9 +19,12 @@ namespace DIPS.Mobile.UI.Components.Pickers.DatePicker
             DatePickerService.Open(this, this);
         }
 
-        protected override void OnHandlerChanged()
+        protected override void OnHandlerChanging(HandlerChangingEventArgs args)
         {
-            base.OnHandlerChanged();
+            base.OnHandlerChanging(args);
+            
+            if(args.NewHandler is null)
+                return;
             
             SelectedDate = ValidateDateTime(SelectedDate);            
             OnSelectedDateChanged();

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/NullableDateAndTimePicker/NullableDateAndTimePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/NullableDateAndTimePicker/NullableDateAndTimePicker.cs
@@ -13,10 +13,13 @@ public partial class NullableDateAndTimePicker : DateAndTimePicker.DateAndTimePi
         DateChip.CloseCommand = new Command(OnCloseTapped);
         TimeChip.CloseCommand = new Command(OnCloseTapped);
     }
-    
-    protected override void OnHandlerChanged()
+
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
+        base.OnHandlerChanging(args);
+        
+        if(args.NewHandler is null)
+            return;
         
         OnSelectedDateTimeChanged();
     }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/NullableDatePicker/NullableDatePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/NullableDatePicker/NullableDatePicker.cs
@@ -22,9 +22,12 @@ public partial class NullableDatePicker : DatePicker.DatePicker, INullableDatePi
         SelectedDate = null;
     }
 
-    protected override void OnHandlerChanged()
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
+        base.OnHandlerChanging(args);
+        
+        if(args.NewHandler is null)
+            return;
         
         OnSelectedDateChanged();
     }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/NullableDatePickerShared/BaseNullableDatePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/NullableDatePickerShared/BaseNullableDatePicker.cs
@@ -21,9 +21,13 @@ public abstract class BaseNullableDatePicker : Grid
         this.Add(DateEnabledSwitch, 1);
     }
 
-    protected override void OnHandlerChanged()
+
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
+        base.OnHandlerChanging(args);
+        
+        if(args.NewHandler is null)
+            return;
         
         m_dateOrTimePicker = CreateDateOrTimePicker();
         m_dateOrTimePicker.IsVisible = false;

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/NullableTimePicker/NullableTimePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/NullableTimePicker/NullableTimePicker.cs
@@ -17,9 +17,12 @@ public partial class NullableTimePicker : TimePicker.TimePicker, INullableDatePi
         SelectedTime = null;
     }
 
-    protected override void OnHandlerChanged()
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
+        base.OnHandlerChanging(args);
+        
+        if(args.NewHandler is null)
+            return;
         
         OnSelectedTimeChanged();
     }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/TimePicker/TimePicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/TimePicker/TimePicker.cs
@@ -18,9 +18,12 @@ public partial class TimePicker : Chip, IDatePicker
         TimePickerService.Open(this, this);
     }
 
-    protected override void OnHandlerChanged()
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
+        base.OnHandlerChanging(args);
+        
+        if(args.NewHandler is null)
+            return;
         
         OnTimeChanged();
     }

--- a/src/library/DIPS.Mobile.UI/Components/Saving/SaveView/SaveView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Saving/SaveView/SaveView.cs
@@ -53,9 +53,13 @@ public partial class SaveView : ContentView
     
     private bool DidTapToSave { get; set; }
 
-    protected override void OnHandlerChanged()
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
+        base.OnHandlerChanging(args);
+
+        if (args.NewHandler is null)
+            return;
+        
         SetSavingText();
     }
 


### PR DESCRIPTION
### Description of Change

OnHandlerChanged can't be used, because it runs either when handler is attached or deattached. One must use OnHandlerChanging, and then check if the handler is null or not null. Otherwise, the mappers to the handler could be fired if changing some of the properties after handler is disconnected. Additionally, it saves some resources as the functions are being run when they don't need to.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->