### PR TITLE
[Button] Fixed an issue where if a button has bound to a property that returns false, the button would not change its style to disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [40.3.3] 
+- [Button] Fixed an issue where if a button has bound to a property that returns false, the button would not change its style to disabled.
+
 ## [40.3.2] 
 - [Android15] Opts out of edge-to-edge to fix layout issues.
 

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -21,13 +21,10 @@
     </dui:ContentPage.Resources>
 
     <VerticalStackLayout>
-        <dui:MultiLineInputField Text="he"   />
-        <dui:SingleLineInputField Text="Gasd" IsEnabled="True" />
-        <dui:Entry />
-        <dui:Editor />
-        <dui:SearchBar />
-        <dui:Button Text="Open modal"
-                    Clicked="Button_OnClicked"/>            
+        
+        <dui:Button Text="Test"
+                    Style="{dui:Styles Button=SecondarySmall}"
+                    IsEnabled="{Binding IsEnabled}" />            
     </VerticalStackLayout>
 
     

--- a/src/app/Playground/VetleSamples/VetlePageViewModel.cs
+++ b/src/app/Playground/VetleSamples/VetlePageViewModel.cs
@@ -27,6 +27,8 @@ public class VetlePageViewModel : ViewModel
     private DateTime m_localDate = new DateTime(2023, 2, 1, 23, 30, 0, DateTimeKind.Local);
     private TestObject2 m_testObject2;
     private TimePlanningViewModel m_timePlanningViewModel = null;
+    private bool m_isEnabled;
+    private List<string> m_testStrings = [];
 
     public VetlePageViewModel()
     {
@@ -47,8 +49,16 @@ public class VetlePageViewModel : ViewModel
             IsSavingCompleted = true;
         });
 
-        CompletedCommand = new Command(() => DialogService.ShowMessage("Test asd asdasd a sadasdas dsa", "test lang tesktsdtsdfsefseasdaawdkjawoidjiaowjdo iawjd9oia jwodijawo dijaw uoid jawuidjh awiudhawiud hiawuh " +
-            "asdasdasdasdsadasd diuawhdiuawhdiuawhdiuawhiduhawiudhwaiu dhiauw dhiawudh iawuhd iauwhd iawhdiuawhdiawuhdiaw diuwa hdiuhwaid uhawiduhawdfsefasefase fse fase fase fase fasefasefasefseaf saef sae fsaef seaf sea efsa fsae", "ok"));
+        CompletedCommand = new Command(() =>
+        {
+            if(m_testStrings.Count == 0)
+                m_testStrings.Add("Test");
+            else
+            {
+                m_testStrings.Clear();
+            }
+            RaisePropertyChanged(nameof(IsEnabled));
+        });
 
         SetMaxLinesCommand = new Command<string>(s => MaxLines = int.Parse(s));
 
@@ -293,6 +303,8 @@ public class VetlePageViewModel : ViewModel
         get => m_timePlanningViewModel;
         set => RaiseWhenSet(ref m_timePlanningViewModel, value);
     }
+
+    public bool IsEnabled => m_testStrings.Any(x => x.Equals("Test"));
 
     public void OnDateChanged()
     {

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
@@ -42,11 +42,11 @@ namespace DIPS.Mobile.UI.Components.Buttons
             }
         }
 
-        protected override void OnHandlerChanging(HandlerChangingEventArgs args)
+        protected override void OnHandlerChanged()
         {
-            base.OnHandlerChanging(args);
-
-            if (args.NewHandler is null)
+            base.OnHandlerChanged();
+            
+            if(Handler is null)
                 return;
             
             // If the button is not enabled as the default, we need to update the style to the disabled style


### PR DESCRIPTION
### Description of Change

OnHandlerChanging is run before the Handler is set, therefore we need to use OnHandlerChanged. I have no idea why this was implemented in the first place, it did not work

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->