### PR TITLE
[ImageButton][Button][Android] Fixed a rare crash when setting `AdditionalHitBoxSize`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [40.3.4] 
+- [ImageButton][Button][Android] Fixed a rare crash when setting `AdditionalHitBoxSize`.
+
 ## [40.3.3] 
 - [Button] Fixed an issue where if a button has bound to a property that returns false, the button would not change its style to disabled.
 

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -20,12 +20,19 @@
         <vetleSamples:TemplateSelector x:Key="TemplateSelector" />
     </dui:ContentPage.Resources>
 
-    <VerticalStackLayout>
-        
-        <dui:Button Text="Test"
-                    Style="{dui:Styles Button=SecondarySmall}"
-                    IsEnabled="{Binding IsEnabled}" />            
-    </VerticalStackLayout>
-
+    <Grid>
     
+    
+        <dui:ImageButton Source="{dui:Icons arrow_back_line}"
+                         AdditionalHitBoxSize="100"
+                         VerticalOptions="Start"/>
+        
+        <!--<dui:Button Text="Test"
+                    Style="{dui:Styles Button=SecondarySmall}"
+                    IsEnabled="{Binding IsEnabled}"
+                    AdditionalHitBoxSize="{dui:Sizes size_2}" />   -->  
+        
+             
+
+    </Grid>
 </dui:ContentPage>

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/Android/ButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/Android/ButtonHandler.cs
@@ -3,13 +3,19 @@ using DIPS.Mobile.UI.Extensions.Android;
 using Google.Android.Material.Button;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Platform;
-using Colors = Microsoft.Maui.Graphics.Colors;
-using TextAlignment = Android.Views.TextAlignment;
 
 namespace DIPS.Mobile.UI.Components.Buttons;
 
 public partial class ButtonHandler : Microsoft.Maui.Handlers.ButtonHandler
 {
+    protected override MaterialButton CreatePlatformView()
+    {
+        return new Android.MaterialButton(Context)
+        {
+            Button = VirtualView as Button
+        };
+    }
+
     /// <summary>
     ///  MAUI changes the Background to a BorderDrawable if the Background changes
     ///  Thus we have to set a RippleDrawable to the Foreground
@@ -88,12 +94,8 @@ public partial class ButtonHandler : Microsoft.Maui.Handlers.ButtonHandler
         UpdateForegroundRipple();
     }
 
-    private static async partial void MapAdditionalHitBoxSize(ButtonHandler handler, Button button)
+    private static partial void MapAdditionalHitBoxSize(ButtonHandler handler, Button button)
     {
-        // Small delay to wait for initialization of hitrect
-        await Task.Delay(1);
-
-        if(button is not null && handler.PlatformView is not null)
-            handler.PlatformView.SetAdditionalHitBoxSize(button, button.AdditionalHitBoxSize, handler.MauiContext!);
+        handler.PlatformView.SetAdditionalHitBoxSize(button.AdditionalHitBoxSize);
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/Android/MaterialButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/Android/MaterialButton.cs
@@ -1,0 +1,38 @@
+using Android.Content;
+using Android.Graphics;
+using Android.Runtime;
+using Android.Util;
+using DIPS.Mobile.UI.Extensions.Android;
+
+namespace DIPS.Mobile.UI.Components.Buttons.Android;
+
+public class MaterialButton : Google.Android.Material.Button.MaterialButton
+{
+    protected MaterialButton(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+    {
+    }
+
+    public MaterialButton(Context context) : base(context)
+    {
+    }
+
+    public MaterialButton(Context context, IAttributeSet? attrs) : base(context, attrs)
+    {
+    }
+
+    public MaterialButton(Context context, IAttributeSet? attrs, int defStyleAttr) : base(context, attrs, defStyleAttr)
+    {
+    }
+    
+    public Button? Button { get; set; }
+
+    protected override void OnDraw(Canvas canvas)
+    {
+        base.OnDraw(canvas);
+        
+        if(Button is null || Button.AdditionalHitBoxSize == Thickness.Zero)
+            return;
+        
+        this.SetAdditionalHitBoxSize(Button.AdditionalHitBoxSize);
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/Android/ImageButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/Android/ImageButtonHandler.cs
@@ -2,8 +2,6 @@ using Android.Content.Res;
 using Android.Graphics.Drawables;
 using DIPS.Mobile.UI.Effects.Touch;
 using DIPS.Mobile.UI.Extensions.Android;
-using DIPS.Mobile.UI.Internal.Logging;
-using Google.Android.Material.ImageView;
 using Microsoft.Maui.Platform;
 
 // ReSharper disable once CheckNamespace
@@ -11,14 +9,20 @@ namespace DIPS.Mobile.UI.Components.Images.ImageButton;
 
 public partial class ImageButtonHandler
 {
-    protected override void ConnectHandler(ShapeableImageView platformView)
+    protected override Google.Android.Material.ImageView.ShapeableImageView CreatePlatformView()
+    {
+        return new ShapeableImageView(Context)
+        {
+            ImageButton = VirtualView as ImageButton
+        };
+    }
+
+    protected override void ConnectHandler(Google.Android.Material.ImageView.ShapeableImageView platformView)
     {
         base.ConnectHandler(platformView);
         
         // We need to set ripple effect because MAUI has not yet done this for ImageButtons
-        var colorStateList = new ColorStateList(
-            new[] { Array.Empty<int>() },
-            new[] { (int)TouchPlatformEffect.DefaultNativeAnimationColor.ToPlatform() });
+        var colorStateList = new ColorStateList([[]], [TouchPlatformEffect.DefaultNativeAnimationColor.ToPlatform()]);
         
         var ripple = new RippleDrawable(colorStateList, null,  null);
         platformView.Foreground = ripple;
@@ -29,11 +33,9 @@ public partial class ImageButtonHandler
         handler.PlatformView.SetColorFilter(imageButton.TintColor.ToPlatform());
     }
 
-    private static async partial void MapAdditionalHitBoxSize(ImageButtonHandler handler, ImageButton imageButton)
+    private static partial void MapAdditionalHitBoxSize(ImageButtonHandler handler, ImageButton imageButton)
     {
-        await Task.Delay(1);
-
-        handler.PlatformView.SetAdditionalHitBoxSize(imageButton, imageButton.AdditionalHitBoxSize, handler.MauiContext!);
+        handler.PlatformView.SetAdditionalHitBoxSize(imageButton.AdditionalHitBoxSize);
     }
 }
 

--- a/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/Android/ShapeableImageView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/Android/ShapeableImageView.cs
@@ -1,0 +1,38 @@
+using Android.Content;
+using Android.Graphics;
+using Android.Runtime;
+using Android.Util;
+using DIPS.Mobile.UI.Extensions.Android;
+
+namespace DIPS.Mobile.UI.Components.Images.ImageButton;
+
+public class ShapeableImageView : Google.Android.Material.ImageView.ShapeableImageView
+{
+    protected ShapeableImageView(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+    {
+    }
+
+    public ShapeableImageView(Context? context) : base(context)
+    {
+    }
+
+    public ShapeableImageView(Context? context, IAttributeSet? attrs) : base(context, attrs)
+    {
+    }
+
+    public ShapeableImageView(Context? context, IAttributeSet? attrs, int defStyle) : base(context, attrs, defStyle)
+    {
+    }
+    
+    public ImageButton? ImageButton { get; set; }
+
+    protected override void OnDraw(Canvas canvas)
+    {
+        base.OnDraw(canvas);
+        
+        if(ImageButton is null || ImageButton.AdditionalHitBoxSize == Thickness.Zero)
+            return;
+        
+        this.SetAdditionalHitBoxSize(ImageButton.AdditionalHitBoxSize);
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/Android/MaterialScrollPickerFragment.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/Android/MaterialScrollPickerFragment.cs
@@ -45,12 +45,12 @@ internal class MaterialScrollPickerFragment(
             linearLayout.AddView(title);
         linearLayout.AddView(new Space(Context)
         {
-            LayoutParameters = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, 20.0.ToMauiPixel())
+            LayoutParameters = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, 20.0.ToMauiPixel() ?? 0)
         });
         linearLayout.AddView(numberPickersLayout);
         linearLayout.AddView(new Space(Context)
         {
-            LayoutParameters = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, 20.0.ToMauiPixel())
+            LayoutParameters = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, 20.0.ToMauiPixel() ?? 0)
         });
         linearLayout.AddView(buttonsLayout);
 
@@ -161,7 +161,7 @@ internal class MaterialScrollPickerFragment(
     {
         return new Space(Context)
         {
-            LayoutParameters = new ViewGroup.LayoutParams(space.ToMauiPixel(), ViewGroup.LayoutParams.WrapContent)
+            LayoutParameters = new ViewGroup.LayoutParams(space.ToMauiPixel() ?? 0, ViewGroup.LayoutParams.WrapContent)
         };
     }
 
@@ -198,7 +198,7 @@ internal class MaterialScrollPickerFragment(
         if (rowsInComponent == 0)
             return null!;
 
-        numberPicker.SelectionDividerHeight = 0.5.ToMauiPixel();
+        numberPicker.SelectionDividerHeight = 0.5.ToMauiPixel() ?? 0;
         numberPicker.MinValue = 0;
         numberPicker.MaxValue = rowsInComponent - 1;
         numberPicker.WrapSelectorWheel = false;

--- a/src/library/DIPS.Mobile.UI/Extensions/Android/DoubleExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/Extensions/Android/DoubleExtensions.cs
@@ -5,5 +5,5 @@ namespace DIPS.Mobile.UI.Extensions.Android;
 
 public static class DoubleExtensions
 {
-    public static int ToMauiPixel(this double value) => (int)TypedValue.ApplyDimension(ComplexUnitType.Dip, (float)value, DUI.GetCurrentMauiContext!.Context!.Resources!.DisplayMetrics);
+    public static int? ToMauiPixel(this double value) => (int?)TypedValue.ApplyDimension(ComplexUnitType.Dip, (float)value, DUI.GetCurrentMauiContext?.Context?.Resources?.DisplayMetrics);
 }

--- a/src/library/DIPS.Mobile.UI/Extensions/Android/ViewExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/Extensions/Android/ViewExtensions.cs
@@ -99,17 +99,27 @@ public static class ViewExtensions
         }
     }
 
-    public static void SetAdditionalHitBoxSize(this AView aView, View view, Thickness additionalHitBoxSize, IMauiContext mauiContext)
+    public static void SetAdditionalHitBoxSize(this AView aView, Thickness additionalHitBoxSize)
     {
+        if(additionalHitBoxSize == Thickness.Zero)
+        {
+            return;
+        }
+        
         var rect = new ARect();
         aView.GetHitRect(rect);
 
-        rect.Top -= additionalHitBoxSize.Top.ToMauiPixel();
-        rect.Left -= additionalHitBoxSize.Left.ToMauiPixel();
-        rect.Bottom += additionalHitBoxSize.Bottom.ToMauiPixel();
-        rect.Right += additionalHitBoxSize.Right.ToMauiPixel();
-
-        if (view.Parent?.ToPlatform(mauiContext) is { } parentView)
+        if(rect.IsEmpty)
+        {
+            return;
+        }
+        
+        rect.Top -= additionalHitBoxSize.Top.ToMauiPixel() ?? 0;
+        rect.Left -= additionalHitBoxSize.Left.ToMauiPixel() ?? 0;
+        rect.Bottom += additionalHitBoxSize.Bottom.ToMauiPixel() ?? 0;
+        rect.Right += additionalHitBoxSize.Right.ToMauiPixel() ?? 0;
+        
+        if (aView.Parent is AView parentView)
         {
             parentView.TouchDelegate = new TouchDelegate(rect, aView);
         }


### PR DESCRIPTION
### Description of Change

From experience, setting Task.Delay inside a mapper function is bad practice, and have been one of the the leading cause of crashes in our library. Instead of setting Task.Delay in the mapper function, we instead override the OnDraw function. When this function is called, the hit rect is initialized and we can set the increased hit box size. This also has the benefit of updating the hit box size when ImageButton/Button's size is changed.

### Todos
- [X] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->