### PR TITLE
[Button] Try-catched an unreproducible crash that happened in `ButtonHandler`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [40.3.5] 
+- [Button] Try-catched an unreproducible crash that happened in `ButtonHandler`.
+
 ## [40.3.4] 
 - [ImageButton][Button][Android] Fixed a rare crash when setting `AdditionalHitBoxSize`.
 

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -22,16 +22,8 @@
 
     <Grid>
     
-    
-        <dui:ImageButton Source="{dui:Icons arrow_back_line}"
-                         AdditionalHitBoxSize="100"
-                         VerticalOptions="Start"/>
-        
-        <!--<dui:Button Text="Test"
-                    Style="{dui:Styles Button=SecondarySmall}"
-                    IsEnabled="{Binding IsEnabled}"
-                    AdditionalHitBoxSize="{dui:Sizes size_2}" />   -->  
-        
+        <dui:Button Text="Test"
+                    Style="{dui:Styles Button=SecondarySmall}" />     
              
 
     </Grid>

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/Android/ButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/Android/ButtonHandler.cs
@@ -1,5 +1,6 @@
 using Android.Graphics.Drawables;
 using DIPS.Mobile.UI.Extensions.Android;
+using DIPS.Mobile.UI.Internal.Logging;
 using Google.Android.Material.Button;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Platform;
@@ -40,12 +41,18 @@ public partial class ButtonHandler : Microsoft.Maui.Handlers.ButtonHandler
 
     private void UpdateForegroundRipple()
     {
-        var rippleColor = Resources.Colors.Colors.GetColor(ColorName.color_neutral_90);
-        var ripple = new RippleDrawable(new Color(rippleColor.Red, rippleColor.Green, rippleColor.Blue, 0.1f).ToDefaultColorStateList(),
-            null,
-            PlatformView.Background);
-        
-        PlatformView.Foreground = ripple;
+        try
+        {
+            var rippleColor = Resources.Colors.Colors.GetColor(ColorName.color_neutral_90);
+            var ripple = new RippleDrawable(new Color(rippleColor.Red, rippleColor.Green, rippleColor.Blue, 0.1f).ToDefaultColorStateList(),
+                null,
+                PlatformView.Background);
+            PlatformView.Foreground = ripple;
+        }
+        catch (Exception e)
+        {
+            DUILogService.LogError<ButtonHandler>("Failed to set ripple effect on button: " + e.Message);
+        }
     }
     
     private static void OverrideMapBackgroundColor(ButtonHandler handler, Button button)


### PR DESCRIPTION
### Description of Change

For some reason, our QA got a crash when setting the foreground ripple on Button. The crash bug are not reproducible, however, I have try-catched and logged where the crash occurs, so that the app should no longer crash if the crash bug should resurface. 

### Todos
- [X] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->