### PR TITLE
Prevent Touch from loosing scroll capabilities on iOS 18.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## [40.3.6] 
+## [40.3.7]
+- [Touch][iOS] Reinitialize the gesture to prevent it from loosing scroll capabilities on iOS 18.3.x.
+
+## [40.3.6]
 - [Label][Android] Fixed a crash that could occur if `TruncatedText` is set, while `Label` has not enough width for the `TruncatedText` to display.
 
 ## [40.3.5] 

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -18,11 +18,100 @@
         <håvardSamples:HåvardPageViewModel />
     </dui:ContentPage.BindingContext>
 
-    <dui:Button Text="Remove" Command="{Binding Command}" dui:ContextMenuEffect.Mode="LongPressed">
-        <dui:ContextMenuEffect.Menu>
-            <dui:ContextMenu>
-                <dui:ContextMenuItem Title="Test"/>
-            </dui:ContextMenu>
-        </dui:ContextMenuEffect.Menu>
-    </dui:Button>
+    <ScrollView>
+        <VerticalStackLayout>
+            <!-- <dui:NavigationListItem Title="Item" Tapped="ListItem_OnTapped"/> -->
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}" />
+            
+        </VerticalStackLayout>
+    </ScrollView>
 </dui:ContentPage>

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml.cs
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml.cs
@@ -83,6 +83,11 @@ public partial class HåvardPage
         Shell.Current.Items.RemoveAt(0);
         Shell.Current.Items.Add(tabBar);
     }
+
+    private void ListItem_OnTapped(object sender, EventArgs e)
+    {
+        
+    }
 }
 
 public class SecondRootPage : ContentPage

--- a/src/app/Playground/MainPage.xaml
+++ b/src/app/Playground/MainPage.xaml
@@ -8,15 +8,18 @@
                  xmlns:playground="clr-namespace:Playground"
                  x:Class="Playground.MainPage"
                  Title="Welcome to Playground">
-    <VerticalStackLayout>
-        <dui:NavigationListItem Title="Vetle"
-                                Tapped="GoToVetle" />
-        <dui:NavigationListItem Title="Håvard"
-                                 Tapped="GoToHåvard" />
-        <dui:NavigationListItem Title="Sander"
-                                 Tapped="GoToSander" />
-        <dui:NavigationListItem Title="Eirik"
-                            Tapped="GoToEirik" />
-        <dui:Button Text="Tap me" Clicked="TapMe"/>
-    </VerticalStackLayout>
+    <dui:ScrollView>
+        <VerticalStackLayout>
+            <dui:NavigationListItem Title="Vetle"
+                                    Tapped="GoToVetle" />
+            <dui:NavigationListItem Title="Håvard"
+                                    Tapped="GoToHåvard" />
+            <dui:NavigationListItem Title="Sander"
+                                    Tapped="GoToSander" />
+            <dui:NavigationListItem Title="Eirik"
+                                    Tapped="GoToEirik" />
+            <dui:Button Text="Tap me"
+                        Clicked="TapMe" />
+        </VerticalStackLayout>
+    </dui:ScrollView>
 </dui:ContentPage>

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectLongPressGestureRecognizer.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectLongPressGestureRecognizer.cs
@@ -6,7 +6,7 @@ namespace DIPS.Mobile.UI.Effects.Touch.iOS;
 
 internal sealed class TouchEffectLongPressGestureRecognizer : UILongPressGestureRecognizer
 {
-    private readonly UIView m_uiView;
+    private UIView? m_uiView;
     internal UIGestureRecognizerState m_currentState = UIGestureRecognizerState.Possible;
 
     public TouchEffectLongPressGestureRecognizer(UIView uiView, Action<UILongPressGestureRecognizer> onLongPressed) : base(
@@ -43,7 +43,7 @@ internal sealed class TouchEffectLongPressGestureRecognizer : UILongPressGesture
     {
         var touchPoint = GetTouchPoint(touches);
         
-        if (touchPoint == null || !m_uiView.Bounds.Contains(touchPoint.Value))
+        if (m_uiView != null && (touchPoint == null || m_uiView.Bounds.Contains(touchPoint.Value)))
         {
             TouchPlatformEffect.HandleTouch(UIGestureRecognizerState.Cancelled, ref m_currentState, m_uiView);
         }
@@ -51,4 +51,10 @@ internal sealed class TouchEffectLongPressGestureRecognizer : UILongPressGesture
 
     private CGPoint? GetTouchPoint(NSSet touches) =>
         (touches.AnyObject as UITouch)?.LocationInView(m_uiView);
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        m_uiView = null;
+    }
 }

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectTapGestureRecognizer.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectTapGestureRecognizer.cs
@@ -26,7 +26,7 @@ public class TouchEffectTapGestureRecognizer : UIGestureRecognizer
     );
 
 }
-    //Because of an issue where our Delegate do not recieve ShouldRecognizeSimultaneously. Which prevents the user from scrolling if the view is used in a scrolling context. This was introduced in iOS 18.2.x
+    //Because of an issue where our Delegate do not recieve ShouldRecognizeSimultaneously. Which prevents the user from scrolling if the view is used in a scrolling context. This was introduced in iOS 18.3.x
     private void ForceGestureRecognition()
     {
         this.Enabled = false;

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectTapGestureRecognizer.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectTapGestureRecognizer.cs
@@ -7,7 +7,6 @@ namespace DIPS.Mobile.UI.Effects.Touch.iOS;
 
 public class TouchEffectTapGestureRecognizer : UIGestureRecognizer
 {
-    // private readonly UIView m_uiView;
     private readonly Action m_onTap;
 
     internal UIGestureRecognizerState m_currentState = UIGestureRecognizerState.Possible;

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectTapGestureRecognizer.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectTapGestureRecognizer.cs
@@ -7,19 +7,30 @@ namespace DIPS.Mobile.UI.Effects.Touch.iOS;
 
 public class TouchEffectTapGestureRecognizer : UIGestureRecognizer
 {
-    private readonly UIView m_uiView;
+    // private readonly UIView m_uiView;
     private readonly Action m_onTap;
 
     internal UIGestureRecognizerState m_currentState = UIGestureRecognizerState.Possible;
 
     private bool m_isCancelled;
+    private readonly NSObject m_didBecomeActiveObserver;
 
-    public TouchEffectTapGestureRecognizer(UIView uiView, Action onTap)
+    public TouchEffectTapGestureRecognizer(Action onTap)
     {
-        m_uiView = uiView;
         m_onTap = onTap;
 
         Delegate = new TouchEffectGestureRecognizerDelegate();
+        m_didBecomeActiveObserver = NSNotificationCenter.DefaultCenter.AddObserver(
+        UIApplication.DidBecomeActiveNotification,
+        _ => ForceGestureRecognition()
+    );
+
+}
+    //Because of an issue where our Delegate do not recieve ShouldRecognizeSimultaneously. Which prevents the user from scrolling if the view is used in a scrolling context. This was introduced in iOS 18.2.x
+    private void ForceGestureRecognition()
+    {
+        this.Enabled = false;
+        this.Enabled = true;
     }
 
     public override void TouchesBegan(NSSet touches, UIEvent evt)
@@ -28,7 +39,7 @@ public class TouchEffectTapGestureRecognizer : UIGestureRecognizer
         
         m_isCancelled = false;
 
-        TouchPlatformEffect.HandleTouch(UIGestureRecognizerState.Began, ref m_currentState, m_uiView);
+        TouchPlatformEffect.HandleTouch(UIGestureRecognizerState.Began, ref m_currentState, View);
     }
     
     public override void TouchesEnded(NSSet touches, UIEvent evt)
@@ -38,14 +49,14 @@ public class TouchEffectTapGestureRecognizer : UIGestureRecognizer
         if(m_currentState is not UIGestureRecognizerState.Cancelled)
             m_onTap.Invoke();
         
-        TouchPlatformEffect.HandleTouch(UIGestureRecognizerState.Ended, ref m_currentState, m_uiView);
+        TouchPlatformEffect.HandleTouch(UIGestureRecognizerState.Ended, ref m_currentState, View);
     }
 
     public override void TouchesCancelled(NSSet touches, UIEvent evt)
     {
         base.TouchesCancelled(touches, evt);
 
-        TouchPlatformEffect.HandleTouch(UIGestureRecognizerState.Cancelled, ref m_currentState, m_uiView);
+        TouchPlatformEffect.HandleTouch(UIGestureRecognizerState.Cancelled, ref m_currentState, View);
     }
     
     public override void TouchesMoved(NSSet touches, UIEvent evt)
@@ -57,9 +68,9 @@ public class TouchEffectTapGestureRecognizer : UIGestureRecognizer
         
         var touchPoint = GetTouchPoint(touches);
 
-        if (touchPoint == null || !m_uiView.Bounds.Contains(touchPoint.Value))
+        if (touchPoint == null || !View.Bounds.Contains(touchPoint.Value))
         {
-            TouchPlatformEffect.HandleTouch(UIGestureRecognizerState.Cancelled, ref m_currentState, m_uiView);
+            TouchPlatformEffect.HandleTouch(UIGestureRecognizerState.Cancelled, ref m_currentState, View);
             m_isCancelled = true;
         }
         
@@ -67,6 +78,11 @@ public class TouchEffectTapGestureRecognizer : UIGestureRecognizer
     }
     
     private CGPoint? GetTouchPoint(NSSet touches) =>
-        (touches.AnyObject as UITouch)?.LocationInView(m_uiView);
-    
+        (touches.AnyObject as UITouch)?.LocationInView(View);
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        NSNotificationCenter.DefaultCenter.RemoveObserver(m_didBecomeActiveObserver);
+    }
 }

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
@@ -26,7 +26,7 @@ public partial class TouchPlatformEffect
 
         if (m_touchMode is Touch.TouchMode.Tap or Touch.TouchMode.Both && m_isEnabled)
         {
-            m_tapGestureRecognizer = new TouchEffectTapGestureRecognizer(OnTap);
+            m_tapGestureRecognizer = new TouchEffectTapGestureRecognizer(Control, OnTap);
             Control.AddGestureRecognizer(m_tapGestureRecognizer);
         }
 
@@ -75,8 +75,9 @@ public partial class TouchPlatformEffect
     }
 
     internal static void HandleTouch(UIGestureRecognizerState state, ref UIGestureRecognizerState currentState,
-        UIView uiView)
+        UIView? uiView)
     {
+        if (uiView is null) return;
         switch (state)
         {
             case UIGestureRecognizerState.Began:

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
@@ -26,7 +26,7 @@ public partial class TouchPlatformEffect
 
         if (m_touchMode is Touch.TouchMode.Tap or Touch.TouchMode.Both && m_isEnabled)
         {
-            m_tapGestureRecognizer = new TouchEffectTapGestureRecognizer(Control, OnTap);
+            m_tapGestureRecognizer = new TouchEffectTapGestureRecognizer(OnTap);
             Control.AddGestureRecognizer(m_tapGestureRecognizer);
         }
 
@@ -70,6 +70,8 @@ public partial class TouchPlatformEffect
             if(Control.GestureRecognizers != null && m_longPressGestureRecognizer is not null)
                 Control.RemoveGestureRecognizer(m_longPressGestureRecognizer!);
         }
+
+        m_tapGestureRecognizer?.Dispose();
     }
 
     internal static void HandleTouch(UIGestureRecognizerState state, ref UIGestureRecognizerState currentState,


### PR DESCRIPTION
### Description of Change

- [Touch][iOS] Reinitialize the gesture to prevent it from loosing scroll capabilities on iOS 18.3.x.

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->