### PR TITLE
[Label] Fixed a crash that could occur if `TruncatedText` is set, while `Label` has not enough width for the `TruncatedText` to display.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [40.3.6] 
+- [Label][Android] Fixed a crash that could occur if `TruncatedText` is set, while `Label` has not enough width for the `TruncatedText` to display.
+
 ## [40.3.5] 
 - [Button] Try-catched an unreproducible crash that happened in `ButtonHandler`.
 

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -20,10 +20,12 @@
         <vetleSamples:TemplateSelector x:Key="TemplateSelector" />
     </dui:ContentPage.Resources>
 
-    <Grid>
+    <Grid ColumnDefinitions="100, *">
     
-        <dui:Button Text="Test"
-                    Style="{dui:Styles Button=SecondarySmall}" />     
+        <dui:Label Text="Testtttttt"
+                   MaxLines="1"
+                   LineBreakMode="TailTruncation"
+                   TruncatedText="... lol"/>     
              
 
     </Grid>

--- a/src/library/DIPS.Mobile.UI/Components/Labels/Android/MauiTextView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Labels/Android/MauiTextView.cs
@@ -65,7 +65,7 @@ public class MauiTextView : Microsoft.Maui.Platform.MauiTextView
 
         if (!string.IsNullOrEmpty(modifiedOriginalText))
         {
-            while (true)
+            while (modifiedOriginalText.Length > 0)
             {
                 modifiedOriginalText = modifiedOriginalText.Substring(0, modifiedOriginalText.Length - 1);
 

--- a/src/library/DIPS.Mobile.UI/Components/Labels/iOS/MauiLabel.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Labels/iOS/MauiLabel.cs
@@ -82,7 +82,7 @@ public class MauiLabel : Microsoft.Maui.Platform.MauiLabel
     private void RemoveTextUntilNotTruncated()
     {
         var modifiedOriginalText = GetTextFromLabel();
-        while (true)
+        while (modifiedOriginalText.Length > 0)
         {
             modifiedOriginalText = modifiedOriginalText.Substring(0, modifiedOriginalText.Length - 1);
 


### PR DESCRIPTION
### Description of Change

Instead of `while(true)` I changed it to `while (modifiedOriginalText.Length > 0)`, to make sure substring will not take in a negative value. This happens if the TruncatedText has no space to display.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->