### PR TITLE
[Editor][iOS] Fixed an issue where the top of the page would sometimes scroll down if `dui:Editor` resides in a ScrollView/CollectionView.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [40.3.8] 
-- [Editor][iOS] Fixed an issue where the top of the page would sometimes scroll down if `Editor` resides in a ScrollView/CollectionView.
+- [dui:Editor][iOS] Fixed an issue where the top of the page would sometimes scroll down if `dui:Editor` resides in a ScrollView/CollectionView.
 
 ## [40.3.7]
 - [Touch][iOS] Reinitialize the gesture to prevent it from loosing scroll capabilities on iOS 18.3.x.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [40.3.8] 
+- [Editor][iOS] Fixed an issue where the top of the page would sometimes scroll down if `Editor` resides in a ScrollView/CollectionView.
+
 ## [40.3.7]
 - [Touch][iOS] Reinitialize the gesture to prevent it from loosing scroll capabilities on iOS 18.3.x.
 

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -15,18 +15,22 @@
     <dui:ContentPage.BindingContext>
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
-    
+
     <dui:ContentPage.Resources>
         <vetleSamples:TemplateSelector x:Key="TemplateSelector" />
     </dui:ContentPage.Resources>
 
-    <Grid ColumnDefinitions="100, *">
-    
-        <dui:Label Text="Testtttttt"
-                   MaxLines="1"
-                   LineBreakMode="TailTruncation"
-                   TruncatedText="... lol"/>     
-             
+    <dui:ScrollView>
 
-    </Grid>
+        <Grid RowDefinitions="Auto, Auto">
+
+            <dui:MultiLineInputField />
+            
+            <dui:Editor Grid.Row="1"
+                        ShouldUseDefaultPadding="False"/>
+
+        </Grid>
+
+    </dui:ScrollView>
+
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml.cs
@@ -14,10 +14,20 @@ public partial class VetlePage
         InitializeComponent();
         TestCommand = new Command(SwitchRoot);
 
-        
+        _ = FuckThisShitUp();
     }
-    
-    
+
+    private async Task FuckThisShitUp()
+    {
+        var thread = new Thread (() => {
+            while (true) {
+                Thread.Sleep (5000);
+                GC.Collect();
+            }
+        }) { IsBackground = true };
+        thread.Start();
+    }
+
 
     protected override void OnBindingContextChanged()
     {

--- a/src/library/DIPS.Mobile.UI/Components/TextFields/Editor/iOS/EditorHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/TextFields/Editor/iOS/EditorHandler.cs
@@ -19,7 +19,7 @@ public partial class EditorHandler
             return;
 
         handler.PlatformView.TextContainer.LineFragmentPadding = 0;
-        handler.PlatformView.TextContainerInset = UIEdgeInsets.Zero;
+        handler.PlatformView.TextContainerInset = new UIEdgeInsets(1f, 0f, 1f, 0f);
     }
 
 


### PR DESCRIPTION
### Description of Change

Default padding of a UITextView container is 8,0,8,0. When we made this component, we set this to UIEdgeInsets.Zero to make sure the text is not padded. So a Label and a Editor will always be placed at the same place. However, in later maui versions, this does not work correctly. It seems as though if an Editor have just enough space to display, the auto scroll functions in MAUI goes crazy and tries to make sure all the text is visible to the user. If we set the padding of UITextView to 1,0,1,0, this works correctly. 

I couldn't see that the 1,0,1,0 padding had any effect on how the Editor is displayed in MultiLineInputField and also dui:Editor.

This can also be reproduced by setting HeightRequest to a Editor from MAUI to a number where the text is slightly clipped, or just enough space for the text to be displayed.



### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->