### PR TITLE
[ContextMenu] Changes to SetContextMenuItemClickedCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [41.0.0]
+- [ContextMenu] `SetContextMenuItemClickedCallback` is renamed to `HandleContextMenuLogging`.
+- [ContextMenu] `HandleContextMenuLogging` now sends a `ContextMenuLoggingMetadata`.
+- [ContextMenu] Added `ItemsShouldLogWhenClicked` which controls if all Context Menu item will send a logging callback. Default false.
+- [ContextMenu] Added `Mode` getter to know which mode a menu has.
+- [ContextMenuItem] Added `ShouldLogWhenClicked? which controls if it will send a logging callback. Default false.
+
 ## [40.3.9]
 - [Entry][iOS] Added 'Done' toolbar item. 
 - [Entry][iOS] Attempt to avoid seemingly random crash.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## [41.0.0]
-- [ContextMenu] `SetContextMenuItemClickedCallback` is renamed to `HandleContextMenuLogging`.
-- [ContextMenu] `HandleContextMenuLogging` now sends a `ContextMenuLoggingMetadata`.
-- [ContextMenu] Added `ItemsShouldLogWhenClicked` which controls if all Context Menu item will send a logging callback. Default false.
+- [ContextMenu] `SetContextMenuItemClickedCallback` is renamed to `ItemsShouldSendGlobalClicks`.
+- [ContextMenu] `ItemsShouldSendGlobalClicks` now sends a `GlobalContextMenuClickMetadata`.
 - [ContextMenu] Added `Mode` getter to know which mode a menu has.
-- [ContextMenuItem] Added `ShouldLogWhenClicked? which controls if it will send a logging callback. Default false.
+- [ContextMenuItem] Added `ShouldSendGlobalClick` which controls if all Context Menu item will send a logging callback. Default false.
 
 ## [40.3.9]
 - [Entry][iOS] Added 'Done' toolbar item. 

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -29,7 +29,7 @@
                          dui:Touch.Command="{Binding Command}"
                          dui:ContextMenuEffect.Mode="LongPressed">
                 <dui:ContextMenuEffect.Menu>
-                    <dui:ContextMenu ItemsShouldLogWhenClicked="True" >
+                    <dui:ContextMenu ItemsShouldSendGlobalClicks="True" >
                         <dui:ContextMenuItem Title="Tap me"
                                              Command="{Binding Command}" />
                     </dui:ContextMenu>
@@ -42,7 +42,7 @@
                          dui:Touch.Command="{Binding Command}"
                          dui:ContextMenuEffect.Mode="Pressed">
                 <dui:ContextMenuEffect.Menu>
-                    <dui:ContextMenu ItemsShouldLogWhenClicked="True" >
+                    <dui:ContextMenu ItemsShouldSendGlobalClicks="True" >
                         <dui:ContextMenuItem Title="Tap me"
                                              Command="{Binding Command}" />
                     </dui:ContextMenu>

--- a/src/app/Playground/HåvardSamples/HåvardPage.xaml
+++ b/src/app/Playground/HåvardSamples/HåvardPage.xaml
@@ -21,6 +21,33 @@
     <ScrollView>
         <VerticalStackLayout>
             <!-- <dui:NavigationListItem Title="Item" Tapped="ListItem_OnTapped"/> -->
+
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}"
+                         dui:ContextMenuEffect.Mode="LongPressed">
+                <dui:ContextMenuEffect.Menu>
+                    <dui:ContextMenu ItemsShouldLogWhenClicked="True" >
+                        <dui:ContextMenuItem Title="Tap me"
+                                             Command="{Binding Command}" />
+                    </dui:ContextMenu>
+                </dui:ContextMenuEffect.Menu>
+            </ContentView>
+            <ContentView HeightRequest="50"
+                         WidthRequest="100"
+                         Background="Red"
+                         Padding="12"
+                         dui:Touch.Command="{Binding Command}"
+                         dui:ContextMenuEffect.Mode="Pressed">
+                <dui:ContextMenuEffect.Menu>
+                    <dui:ContextMenu ItemsShouldLogWhenClicked="True" >
+                        <dui:ContextMenuItem Title="Tap me"
+                                             Command="{Binding Command}" />
+                    </dui:ContextMenu>
+                </dui:ContextMenuEffect.Menu>
+                </ContentView>
             <ContentView HeightRequest="50"
                          WidthRequest="100"
                          Background="Red"
@@ -96,22 +123,7 @@
                          Background="Red"
                          Padding="12"
                          dui:Touch.Command="{Binding Command}" />
-            <ContentView HeightRequest="50"
-                         WidthRequest="100"
-                         Background="Red"
-                         Padding="12"
-                         dui:Touch.Command="{Binding Command}" />
-            <ContentView HeightRequest="50"
-                         WidthRequest="100"
-                         Background="Red"
-                         Padding="12"
-                         dui:Touch.Command="{Binding Command}" />
-            <ContentView HeightRequest="50"
-                         WidthRequest="100"
-                         Background="Red"
-                         Padding="12"
-                         dui:Touch.Command="{Binding Command}" />
-            
+
         </VerticalStackLayout>
     </ScrollView>
 </dui:ContentPage>

--- a/src/app/Playground/MauiProgram.cs
+++ b/src/app/Playground/MauiProgram.cs
@@ -14,7 +14,7 @@ public static class MauiProgram
             .UseMauiApp<App>()
             .UseDIPSUI(options =>
             {
-                options.HandleContextMenuLogging(OnContextMenuItemClicked);
+                options.HandleContextMenuGlobalClicks(OnContextMenuItemClicked);
                 /*options.EnableAutomaticMemoryLeakResolving();*/
             });
         
@@ -33,7 +33,7 @@ public static class MauiProgram
         return builder.Build();
     }
 
-    private static void OnContextMenuItemClicked(ContextMenuLoggingMetadata metadata)
+    private static void OnContextMenuItemClicked(GlobalContextMenuClickMetadata metadata)
     {
         Console.WriteLine($@"Clicked context menu item with title {metadata.ContextMenuItem.Title}!, menu: {metadata.ContextMenu.Mode}");
     }

--- a/src/app/Playground/MauiProgram.cs
+++ b/src/app/Playground/MauiProgram.cs
@@ -14,7 +14,7 @@ public static class MauiProgram
             .UseMauiApp<App>()
             .UseDIPSUI(options =>
             {
-                options.SetContextMenuItemClickedCallback(OnContextMenuItemClicked);
+                options.HandleContextMenuLogging(OnContextMenuItemClicked);
                 /*options.EnableAutomaticMemoryLeakResolving();*/
             });
         
@@ -33,8 +33,8 @@ public static class MauiProgram
         return builder.Build();
     }
 
-    private static void OnContextMenuItemClicked(ContextMenuItem obj)
+    private static void OnContextMenuItemClicked(ContextMenuLoggingMetadata metadata)
     {
-        Console.WriteLine($@"Clicked context menu item with title {obj.Title}!");
+        Console.WriteLine($@"Clicked context menu item with title {metadata.ContextMenuItem.Title}!, menu: {metadata.ContextMenu.Mode}");
     }
 }

--- a/src/library/DIPS.Mobile.UI/API/Builder/DIPSUIOptions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Builder/DIPSUIOptions.cs
@@ -6,9 +6,9 @@ namespace DIPS.Mobile.UI.API.Builder;
 
 internal class DIPSUIOptions : IDIPSUIOptions
 {
-    public IDIPSUIOptions SetContextMenuItemClickedCallback(Action<ContextMenuItem> callback)
+    public IDIPSUIOptions HandleContextMenuLogging(Action<ContextMenuLoggingMetadata> callback)
     {
-        ContextMenuEffect.SetContextMenuItemClickedCallback(callback);
+        ContextMenuEffect.SetContextMenuItemLoggingCallback(callback);
 
         return this;
     }

--- a/src/library/DIPS.Mobile.UI/API/Builder/DIPSUIOptions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Builder/DIPSUIOptions.cs
@@ -6,7 +6,7 @@ namespace DIPS.Mobile.UI.API.Builder;
 
 internal class DIPSUIOptions : IDIPSUIOptions
 {
-    public IDIPSUIOptions HandleContextMenuLogging(Action<ContextMenuLoggingMetadata> callback)
+    public IDIPSUIOptions HandleContextMenuGlobalClicks(Action<GlobalContextMenuClickMetadata> callback)
     {
         ContextMenuEffect.SetContextMenuItemLoggingCallback(callback);
 

--- a/src/library/DIPS.Mobile.UI/API/Builder/IDIPSUIOptions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Builder/IDIPSUIOptions.cs
@@ -10,7 +10,7 @@ public interface IDIPSUIOptions
     /// </summary>
     /// <param name="callback">The method to invoke, receiving the <see cref="ContextMenuItem"/> that was tapped.</param>
     /// <returns></returns>
-    IDIPSUIOptions HandleContextMenuLogging(Action<ContextMenuLoggingMetadata> callback);
+    IDIPSUIOptions HandleContextMenuGlobalClicks(Action<GlobalContextMenuClickMetadata> callback);
 
     /// <summary>
     ///     Sets whether DIPS.Mobile.UI should try and auto-resolve memory leaks that occur during page navigation and closing of bottomsheets.

--- a/src/library/DIPS.Mobile.UI/API/Builder/IDIPSUIOptions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Builder/IDIPSUIOptions.cs
@@ -10,7 +10,7 @@ public interface IDIPSUIOptions
     /// </summary>
     /// <param name="callback">The method to invoke, receiving the <see cref="ContextMenuItem"/> that was tapped.</param>
     /// <returns></returns>
-    IDIPSUIOptions SetContextMenuItemClickedCallback(Action<ContextMenuItem> callback);
+    IDIPSUIOptions HandleContextMenuLogging(Action<ContextMenuLoggingMetadata> callback);
 
     /// <summary>
     ///     Sets whether DIPS.Mobile.UI should try and auto-resolve memory leaks that occur during page navigation and closing of bottomsheets.

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/Android/ContextMenuPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/Android/ContextMenuPlatformEffect.cs
@@ -28,6 +28,7 @@ public partial class ContextMenuPlatformEffect
         }
 
         m_contextMenu.BindingContext = Element.BindingContext;
+        m_contextMenu.Mode = m_mode;
         m_contextMenuBehaviour = new ContextMenuHandler(m_contextMenu, Control);
 
         if (m_mode == ContextMenuEffect.ContextMenuMode.Pressed)

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.Properties.cs
@@ -5,6 +5,11 @@ namespace DIPS.Mobile.UI.Components.ContextMenus;
 public partial class ContextMenu : IContextMenu
 {
     public event Action? ItemsSourceUpdated;
+
+    public static readonly BindableProperty ItemsShouldLogWhenClickedProperty = BindableProperty.Create(
+        nameof(ItemsShouldLogWhenClicked),
+        typeof(bool),
+        typeof(ContextMenu), defaultValue:false);
     
     /// <see cref="Title"/>
     public static readonly BindableProperty TitleProperty = BindableProperty.Create(
@@ -57,6 +62,16 @@ public partial class ContextMenu : IContextMenu
         set => SetValue(ItemClickedCommandProperty, value);
     }
     
+    /// <summary>
+    /// Determines if all items in the menu should log when they are clicked.
+    /// </summary>
+    /// <remarks>Default value : false</remarks>
+    public bool ItemsShouldLogWhenClicked
+    {
+        get => (bool)GetValue(ItemsShouldLogWhenClickedProperty);
+        set => SetValue(ItemsShouldLogWhenClickedProperty, value);
+    }
+    
 
     /// <summary>
     /// <see cref="ContextMenuHorizontalOptions"/>
@@ -74,9 +89,15 @@ public partial class ContextMenu : IContextMenu
         get => (ContextMenuHorizontalOptions)GetValue(ContextMenuHorizontalOptionsProperty);
         set => SetValue(ContextMenuHorizontalOptionsProperty, value);
     }
+    
+    /// <summary>
+    /// Get the mode of the context menu.
+    /// </summary>
+    /// <remarks>This is non-settable on this class. <a href="https://github.com/DIPSAS/DIPS.Mobile.UI/wiki/Context-Menus#modes"> See documentation on how to set it.</a></remarks>
+    public ContextMenuEffect.ContextMenuMode Mode { get; internal set; }
 
     /// <summary>
-    /// 
+    /// Event that gets raised when a <see cref="ContextMenuItem"/> was clicked by the user.
     /// </summary>
     public event EventHandler? DidClickItem;
 

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.Properties.cs
@@ -6,8 +6,8 @@ public partial class ContextMenu : IContextMenu
 {
     public event Action? ItemsSourceUpdated;
 
-    public static readonly BindableProperty ItemsShouldLogWhenClickedProperty = BindableProperty.Create(
-        nameof(ItemsShouldLogWhenClicked),
+    public static readonly BindableProperty ItemsShouldSendGlobalClicksProperty = BindableProperty.Create(
+        nameof(ItemsShouldSendGlobalClicks),
         typeof(bool),
         typeof(ContextMenu), defaultValue:false);
     
@@ -66,10 +66,10 @@ public partial class ContextMenu : IContextMenu
     /// Determines if all items in the menu should log when they are clicked.
     /// </summary>
     /// <remarks>Default value : false</remarks>
-    public bool ItemsShouldLogWhenClicked
+    public bool ItemsShouldSendGlobalClicks
     {
-        get => (bool)GetValue(ItemsShouldLogWhenClickedProperty);
-        set => SetValue(ItemsShouldLogWhenClickedProperty, value);
+        get => (bool)GetValue(ItemsShouldSendGlobalClicksProperty);
+        set => SetValue(ItemsShouldSendGlobalClicksProperty, value);
     }
     
 

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuEffect.cs
@@ -22,11 +22,11 @@ public class ContextMenuEffect : RoutingEffect
         null,
         propertyChanged:OnHasMenuChanged);
 
-    internal static Action<ContextMenuLoggingMetadata>? ContextMenuItemLoggingCallback { get; private set; }
+    internal static Action<GlobalContextMenuClickMetadata>? ContextMenuItemGlobalClicksCallBack { get; private set; }
 
-    internal static void SetContextMenuItemLoggingCallback(Action<ContextMenuLoggingMetadata> callback)
+    internal static void SetContextMenuItemLoggingCallback(Action<GlobalContextMenuClickMetadata> callback)
     {
-        ContextMenuItemLoggingCallback = callback;
+        ContextMenuItemGlobalClicksCallBack = callback;
     }
 
     public static ContextMenuMode GetMode(BindableObject view)

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuEffect.cs
@@ -22,11 +22,11 @@ public class ContextMenuEffect : RoutingEffect
         null,
         propertyChanged:OnHasMenuChanged);
 
-    internal static Action<ContextMenuItem>? ContextMenuItemClickedCallback { get; private set; }
+    internal static Action<ContextMenuLoggingMetadata>? ContextMenuItemLoggingCallback { get; private set; }
 
-    internal static void SetContextMenuItemClickedCallback(Action<ContextMenuItem> callback)
+    internal static void SetContextMenuItemLoggingCallback(Action<ContextMenuLoggingMetadata> callback)
     {
-        ContextMenuItemClickedCallback = callback;
+        ContextMenuItemLoggingCallback = callback;
     }
 
     public static ContextMenuMode GetMode(BindableObject view)

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.Properties.cs
@@ -6,8 +6,8 @@ namespace DIPS.Mobile.UI.Components.ContextMenus;
 
 public partial class ContextMenuItem
 {
-    public static readonly BindableProperty ShouldLogWhenClickedProperty = BindableProperty.Create(
-        nameof(ShouldLogWhenClicked),
+    public static readonly BindableProperty ShouldSendGlobalClickProperty = BindableProperty.Create(
+        nameof(ShouldSendGlobalClick),
         typeof(bool),
         typeof(ContextMenuItem), defaultValue: false);
 
@@ -153,13 +153,13 @@ public partial class ContextMenuItem
     }
 
     /// <summary>
-    /// Determines if the context menu item should invoke <see cref="DIPSUIOptions.HandleContextMenuLogging"/>
+    /// Determines if the context menu item should invoke <see cref="DIPSUIOptions.HandleContextMenuGlobalClicks"/>
     /// </summary>
-    /// <remarks>Default value : false. If this is left false, but the parent <see cref="ContextMenu.ItemsShouldLogWhenClicked"/> is true, it will log. If this is set to true but parent <see cref="ContextMenu.ItemsShouldLogWhenClicked"/> is set to false, it will log.</remarks>
-    public bool ShouldLogWhenClicked
+    /// <remarks>Default value : false. If this is left false, but the parent <see cref="ContextMenu.ItemsShouldSendGlobalClicks"/> is true, it will log. If this is set to true but parent <see cref="ContextMenu.ItemsShouldSendGlobalClicks"/> is set to false, it will log.</remarks>
+    public bool ShouldSendGlobalClick
     {
-        get => (bool)GetValue(ShouldLogWhenClickedProperty);
-        set => SetValue(ShouldLogWhenClickedProperty, value);
+        get => (bool)GetValue(ShouldSendGlobalClickProperty);
+        set => SetValue(ShouldSendGlobalClickProperty, value);
     }
 }
 

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.Properties.cs
@@ -1,16 +1,21 @@
 using System.ComponentModel;
 using System.Windows.Input;
+using DIPS.Mobile.UI.API.Builder;
 
 namespace DIPS.Mobile.UI.Components.ContextMenus;
 
 public partial class ContextMenuItem
 {
-    
+    public static readonly BindableProperty ShouldLogWhenClickedProperty = BindableProperty.Create(
+        nameof(ShouldLogWhenClicked),
+        typeof(bool),
+        typeof(ContextMenuItem), defaultValue: false);
+
     public static readonly BindableProperty IsCheckedProperty = BindableProperty.Create(
         nameof(IsChecked),
         typeof(bool),
         typeof(ContextMenuItem));
-    
+
     /// <summary>
     /// <see cref="Command"/>
     /// </summary>
@@ -26,12 +31,12 @@ public partial class ContextMenuItem
         nameof(CommandParameter),
         typeof(object),
         typeof(ContextMenuItem));
-    
+
     public static readonly BindableProperty IconProperty = BindableProperty.Create(
         nameof(Icon),
         typeof(ImageSource),
         typeof(ContextMenuItem));
-    
+
     public static readonly BindableProperty IsVisibleProperty = BindableProperty.Create(
         nameof(IsVisible),
         typeof(bool),
@@ -51,7 +56,7 @@ public partial class ContextMenuItem
         get => (bool)GetValue(IsDestructiveProperty);
         set => SetValue(IsDestructiveProperty, value);
     }
-    
+
     /// <summary>
     /// The command to run when the item was clicked
     /// </summary>
@@ -78,7 +83,7 @@ public partial class ContextMenuItem
         get => (bool)GetValue(IsVisibleProperty);
         set => SetValue(IsVisibleProperty, value);
     }
-    
+
     /// <summary>
     /// The clicked event when the item was clicked
     /// </summary>
@@ -88,7 +93,7 @@ public partial class ContextMenuItem
         nameof(Title),
         typeof(string),
         typeof(ContextMenuItem));
-    
+
     /// <summary>
     /// The title of the context menu item
     /// </summary>
@@ -102,7 +107,7 @@ public partial class ContextMenuItem
         nameof(IsCheckable),
         typeof(bool),
         typeof(ContextMenuItem));
-    
+
     /// <summary>
     /// Determines if the native check mark should be added to the item when its tapped
     /// </summary>
@@ -120,7 +125,7 @@ public partial class ContextMenuItem
         get => (bool)GetValue(IsCheckedProperty);
         set => SetValue(IsCheckedProperty, value);
     }
-    
+
     /// <summary>
     /// The parent of the context menu item
     /// </summary>
@@ -131,12 +136,12 @@ public partial class ContextMenuItem
     /// </summary>
     // ReSharper disable once InconsistentNaming
     public iOSContextMenuItemOptions iOSOptions { get; set; } = new();
-    
+
     /// <summary>
     /// <see cref="AndroidContextMenuItemOptions"/>
     /// </summary>
     public AndroidContextMenuItemOptions AndroidOptions { get; set; } = new();
-    
+
     /// <summary>
     /// The icon to be used as a image with the context menu item
     /// </summary>
@@ -145,6 +150,16 @@ public partial class ContextMenuItem
     {
         get => (ImageSource)GetValue(IconProperty);
         set => SetValue(IconProperty, value);
+    }
+
+    /// <summary>
+    /// Determines if the context menu item should invoke <see cref="DIPSUIOptions.HandleContextMenuLogging"/>
+    /// </summary>
+    /// <remarks>Default value : false. If this is left false, but the parent <see cref="ContextMenu.ItemsShouldLogWhenClicked"/> is true, it will log. If this is set to true but parent <see cref="ContextMenu.ItemsShouldLogWhenClicked"/> is set to false, it will log.</remarks>
+    public bool ShouldLogWhenClicked
+    {
+        get => (bool)GetValue(ShouldLogWhenClickedProperty);
+        set => SetValue(ShouldLogWhenClickedProperty, value);
     }
 }
 

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
@@ -12,14 +12,14 @@ public partial class ContextMenuItem : Element, IContextMenuItem
         DidClick?.Invoke(this, EventArgs.Empty);
         
         var contextMenuLoggingMetadata = new GlobalContextMenuClickMetadata(this, contextMenu);
-        var didLog = false;
+        var didSendGlobalClick = false;
         if (contextMenu.ItemsShouldSendGlobalClicks) //If consumer wants to send clicks globally for all items
         {
             ContextMenuEffect.ContextMenuItemGlobalClicksCallBack?.Invoke(contextMenuLoggingMetadata);
-            didLog = true;
+            didSendGlobalClick = true;
         }
         
-        if (ShouldSendGlobalClick && !didLog) //If consumer wants a single item to log, no matter what parent says
+        if (ShouldSendGlobalClick && !didSendGlobalClick) //If consumer wants a single item to log, no matter what parent says
         {
             ContextMenuEffect.ContextMenuItemGlobalClicksCallBack?.Invoke(contextMenuLoggingMetadata);    
         }

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
@@ -8,9 +8,22 @@ public partial class ContextMenuItem : Element, IContextMenuItem
     internal void SendClicked(ContextMenu contextMenu)
     {
         contextMenu.SendClicked(this);
-        ContextMenuEffect.ContextMenuItemClickedCallback?.Invoke(this);
         Command?.Execute(CommandParameter);
         DidClick?.Invoke(this, EventArgs.Empty);
+        
+        // var mode = (ContextMenuEffect.ContextMenuMode)contextMenu.GetValue(ContextMenuEffect.ModeProperty);
+        var contextMenuLoggingMetadata = new ContextMenuLoggingMetadata(this, contextMenu);
+        var didLog = false;
+        if (contextMenu.ItemsShouldLogWhenClicked) //If consumer wants to log for all items
+        {
+            ContextMenuEffect.ContextMenuItemLoggingCallback?.Invoke(contextMenuLoggingMetadata);
+            didLog = true;
+        }
+        
+        if (ShouldLogWhenClicked && !didLog) //If consumer wants a single item to log, no matter what parent says
+        {
+            ContextMenuEffect.ContextMenuItemLoggingCallback?.Invoke(contextMenuLoggingMetadata);    
+        }
     }
 
     public void Dispose()

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
@@ -11,18 +11,17 @@ public partial class ContextMenuItem : Element, IContextMenuItem
         Command?.Execute(CommandParameter);
         DidClick?.Invoke(this, EventArgs.Empty);
         
-        // var mode = (ContextMenuEffect.ContextMenuMode)contextMenu.GetValue(ContextMenuEffect.ModeProperty);
-        var contextMenuLoggingMetadata = new ContextMenuLoggingMetadata(this, contextMenu);
+        var contextMenuLoggingMetadata = new GlobalContextMenuClickMetadata(this, contextMenu);
         var didLog = false;
-        if (contextMenu.ItemsShouldLogWhenClicked) //If consumer wants to log for all items
+        if (contextMenu.ItemsShouldSendGlobalClicks) //If consumer wants to send clicks globally for all items
         {
-            ContextMenuEffect.ContextMenuItemLoggingCallback?.Invoke(contextMenuLoggingMetadata);
+            ContextMenuEffect.ContextMenuItemGlobalClicksCallBack?.Invoke(contextMenuLoggingMetadata);
             didLog = true;
         }
         
-        if (ShouldLogWhenClicked && !didLog) //If consumer wants a single item to log, no matter what parent says
+        if (ShouldSendGlobalClick && !didLog) //If consumer wants a single item to log, no matter what parent says
         {
-            ContextMenuEffect.ContextMenuItemLoggingCallback?.Invoke(contextMenuLoggingMetadata);    
+            ContextMenuEffect.ContextMenuItemGlobalClicksCallBack?.Invoke(contextMenuLoggingMetadata);    
         }
     }
 

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuLoggingMetadata.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuLoggingMetadata.cs
@@ -1,0 +1,3 @@
+namespace DIPS.Mobile.UI.Components.ContextMenus;
+
+public record ContextMenuLoggingMetadata(ContextMenuItem ContextMenuItem, ContextMenu ContextMenu);

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuLoggingMetadata.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuLoggingMetadata.cs
@@ -1,3 +1,0 @@
-namespace DIPS.Mobile.UI.Components.ContextMenus;
-
-public record ContextMenuLoggingMetadata(ContextMenuItem ContextMenuItem, ContextMenu ContextMenu);

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/GlobalContextMenuClickMetadata.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/GlobalContextMenuClickMetadata.cs
@@ -1,0 +1,3 @@
+namespace DIPS.Mobile.UI.Components.ContextMenus;
+
+public record GlobalContextMenuClickMetadata(ContextMenuItem ContextMenuItem, ContextMenu ContextMenu);

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.cs
@@ -21,9 +21,10 @@ public partial class ContextMenuPlatformEffect
             return;
         
         m_contextMenu.BindingContext = Element.BindingContext;
-
+        
         m_mode = ContextMenuEffect.GetMode(Element);
-
+        m_contextMenu.Mode = m_mode;
+        
         if (m_mode == ContextMenuEffect.ContextMenuMode.Pressed)
         {
             SetupPressedMode(m_contextMenu);


### PR DESCRIPTION
### Description of Change

SetContextMenuItemClickedCallback is now named ItemsShouldSendGlobalClicks.
The old implementation were too eager, and we want to opt in this feature by the consumer.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->