### PR TITLE
Convert SizeResources to use double instead of int as value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [42.0.0]
-- Convert SizeResources to use double instead of int as valu.
+- Convert SizeResources to use double instead of int as value.
 
 ## [41.0.0]
 - [ContextMenu] `SetContextMenuItemClickedCallback` is renamed to `ItemsShouldSendGlobalClicks`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [42.0.0]
+- Convert SizeResources to use double instead of int as valu.
+
 ## [41.0.0]
 - [ContextMenu] `SetContextMenuItemClickedCallback` is renamed to `ItemsShouldSendGlobalClicks`.
 - [ContextMenu] `ItemsShouldSendGlobalClicks` now sends a `GlobalContextMenuClickMetadata`.

--- a/src/app/Components/ResourcesSamples/Sizes/SizesAsFontSize.xaml.cs
+++ b/src/app/Components/ResourcesSamples/Sizes/SizesAsFontSize.xaml.cs
@@ -15,12 +15,12 @@ public partial class SizesAsFontSize
 
 public class SizeResource
 {
-    public SizeResource(string key, int value)
+    public SizeResource(string key, double value)
     {
         Key = key;
         Value = value;
     }
         
     public string Key { get; }
-    public int Value { get; }
+    public double Value { get; }
 }

--- a/src/app/Components/ResourcesSamples/Sizes/SizesAsVisualBoxes.xaml.cs
+++ b/src/app/Components/ResourcesSamples/Sizes/SizesAsVisualBoxes.xaml.cs
@@ -4,8 +4,8 @@ namespace Components.ResourcesSamples.Sizes;
 
 public partial class SizesAsVisualBoxes
 {
-    private Dictionary<string, int> m_sizes;
-    private Dictionary<string, int> m_allSizes;
+    private Dictionary<string, double> m_sizes;
+    private Dictionary<string, double> m_allSizes;
     public SizesAsVisualBoxes()
     {
         InitializeComponent();
@@ -18,7 +18,7 @@ public partial class SizesAsVisualBoxes
         m_allSizes = Sizes;
     }
     
-    public Dictionary<string, int> Sizes
+    public Dictionary<string, double> Sizes
     {
         get => m_sizes;
         private set

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -23,7 +23,9 @@
     <dui:ScrollView>
 
         <Grid RowDefinitions="Auto, Auto">
-
+            
+            <dui:Button CornerRadius="{dui:Sizes size_2}"></dui:Button>
+            
             <dui:MultiLineInputField />
             
             <dui:Editor Grid.Row="1"

--- a/src/library/DIPS.Mobile.UI/API/Camera/Gallery/GalleryThumbnails.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Gallery/GalleryThumbnails.cs
@@ -33,7 +33,7 @@ public partial class GalleryThumbnails : Grid
             ImageSource = Icons.GetIcon(IconName.camera),
             ImageTintColor = Colors.GetColor(ColorName.color_neutral_80),
             Style = Styles.GetButtonStyle(ButtonStyle.GhostIconButtonLarge),
-            CornerRadius = Sizes.GetSize(SizeName.size_2),
+            CornerRadius = (int)Sizes.GetSize(SizeName.size_2),
             BackgroundColor = Colors.GetColor(ColorName.color_neutral_30),
             WidthRequest = Sizes.GetSize(SizeName.size_15),
             HeightRequest = Sizes.GetSize(SizeName.size_15),

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/Android/MaterialScrollPickerFragment.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/Android/MaterialScrollPickerFragment.cs
@@ -35,7 +35,7 @@ internal class MaterialScrollPickerFragment(
             Orientation = Orientation.Vertical
         };
         
-        linearLayout.SetPadding(0, 0, 0, Sizes.GetSize(SizeName.size_2));
+        linearLayout.SetPadding(0, 0, 0, (int)Sizes.GetSize(SizeName.size_2));
 
         var title = CreateTitle();
         var numberPickersLayout = CreateNumberPickersLayout(out var numberPickers);
@@ -45,12 +45,12 @@ internal class MaterialScrollPickerFragment(
             linearLayout.AddView(title);
         linearLayout.AddView(new Space(Context)
         {
-            LayoutParameters = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, 20.0.ToMauiPixel() ?? 0)
+            LayoutParameters = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, 20.0.ToMauiPixel())
         });
         linearLayout.AddView(numberPickersLayout);
         linearLayout.AddView(new Space(Context)
         {
-            LayoutParameters = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, 20.0.ToMauiPixel() ?? 0)
+            LayoutParameters = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, 20.0.ToMauiPixel())
         });
         linearLayout.AddView(buttonsLayout);
 
@@ -161,7 +161,7 @@ internal class MaterialScrollPickerFragment(
     {
         return new Space(Context)
         {
-            LayoutParameters = new ViewGroup.LayoutParams(space.ToMauiPixel() ?? 0, ViewGroup.LayoutParams.WrapContent)
+            LayoutParameters = new ViewGroup.LayoutParams(space.ToMauiPixel(), ViewGroup.LayoutParams.WrapContent)
         };
     }
 
@@ -198,7 +198,7 @@ internal class MaterialScrollPickerFragment(
         if (rowsInComponent == 0)
             return null!;
 
-        numberPicker.SelectionDividerHeight = 0.5.ToMauiPixel() ?? 0;
+        numberPicker.SelectionDividerHeight = 0.5.ToMauiPixel();
         numberPicker.MinValue = 0;
         numberPicker.MaxValue = rowsInComponent - 1;
         numberPicker.WrapSelectorWheel = false;

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/iOS/ScrollPickerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/iOS/ScrollPickerHandler.cs
@@ -260,7 +260,7 @@ internal class ScrollPickerViewController : UIViewController
     
     public override void ViewDidLoad()
     {
-        View = new UIStackView { Axis = UILayoutConstraintAxis.Vertical, Spacing = Sizes.GetSize(SizeName.size_1) };
+        View = new UIStackView { Axis = UILayoutConstraintAxis.Vertical, Spacing = (int)Sizes.GetSize(SizeName.size_1) };
         View.AddSubview(m_uiPicker);
         if(m_clearButton is not null)
             View.AddSubview(m_clearButton);

--- a/src/library/DIPS.Mobile.UI/Extensions/Android/DoubleExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/Extensions/Android/DoubleExtensions.cs
@@ -5,5 +5,5 @@ namespace DIPS.Mobile.UI.Extensions.Android;
 
 public static class DoubleExtensions
 {
-    public static int? ToMauiPixel(this double value) => (int?)TypedValue.ApplyDimension(ComplexUnitType.Dip, (float)value, DUI.GetCurrentMauiContext?.Context?.Resources?.DisplayMetrics);
+    public static int ToMauiPixel(this double value) => (int)TypedValue.ApplyDimension(ComplexUnitType.Dip, (float)value, DUI.GetCurrentMauiContext?.Context?.Resources?.DisplayMetrics);
 }

--- a/src/library/DIPS.Mobile.UI/Extensions/Android/ViewExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/Extensions/Android/ViewExtensions.cs
@@ -114,10 +114,10 @@ public static class ViewExtensions
             return;
         }
         
-        rect.Top -= additionalHitBoxSize.Top.ToMauiPixel() ?? 0;
-        rect.Left -= additionalHitBoxSize.Left.ToMauiPixel() ?? 0;
-        rect.Bottom += additionalHitBoxSize.Bottom.ToMauiPixel() ?? 0;
-        rect.Right += additionalHitBoxSize.Right.ToMauiPixel() ?? 0;
+        rect.Top -= additionalHitBoxSize.Top.ToMauiPixel();
+        rect.Left -= additionalHitBoxSize.Left.ToMauiPixel();
+        rect.Bottom += additionalHitBoxSize.Bottom.ToMauiPixel();
+        rect.Right += additionalHitBoxSize.Right.ToMauiPixel();
         
         if (aView.Parent is AView parentView)
         {

--- a/src/library/DIPS.Mobile.UI/Resources/Sizes/SizeResources.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Sizes/SizeResources.cs
@@ -6,7 +6,7 @@ generated 8/30/2023 10:47:37 AM from DIPS.Mobile.DesignTokens
         namespace DIPS.Mobile.UI.Resources.Sizes;
         internal static class SizeResources
         {
-            public static Dictionary<string, int> Sizes { get; } = new()
+            public static Dictionary<string, double> Sizes { get; } = new()
             {
                 ["none"] = -1,
                 ["size_0"] = 0,

--- a/src/library/DIPS.Mobile.UI/Resources/Sizes/Sizes.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Sizes/Sizes.cs
@@ -6,7 +6,7 @@ public static class Sizes
     /// Get the size by <see cref="SizeName"/>
     /// </summary>
     /// <param name="sizeName">The size name to get</param>
-    public static int GetSize(SizeName sizeName)
+    public static double GetSize(SizeName sizeName)
     {
         return SizesExtension.GetSize(sizeName);
     }

--- a/src/library/DIPS.Mobile.UI/Resources/Sizes/SizesExtension.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Sizes/SizesExtension.cs
@@ -12,7 +12,7 @@ namespace DIPS.Mobile.UI.Resources.Sizes
         /// <remarks>This is automatically detected if the extension is used on a <see cref="BindableProperty"/></remarks>
         public SizeDatatype Datatype { get; set; }
 
-        public static int GetSize(string sizeName)
+        public static double GetSize(string sizeName)
         {
             if (!SizeResources.Sizes.TryGetValue(sizeName, out var value))
             {
@@ -22,7 +22,7 @@ namespace DIPS.Mobile.UI.Resources.Sizes
             return value;
         }
 
-        public static int GetSize(SizeName sizeName)
+        public static double GetSize(SizeName sizeName)
         {
             return GetSize(sizeName.ToString());
         }


### PR DESCRIPTION
### Description of Change

This can be a breaking change in apps that consumes this library, if sizes has been used in C# and some properties expects an int.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->