### PR TITLE
[Chip][Android] Fixed so that default CornerRadius will be set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [42.2.2] 
+- [Chip][Android] Fixed so that default CornerRadius will be set.
+
 ## [42.2.1] 
 - [SearchPage][ItemPicker] Fixed so that items will get correct default margin and corner radius
 

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -20,59 +20,9 @@
         <vetleSamples:TemplateSelector x:Key="TemplateSelector" />
     </dui:ContentPage.Resources>
 
-    <dui:RefreshView Command="{Binding RefreshCommand}"
-                     IsRefreshing="{Binding IsRefreshing}">
-    <dui:CollectionView2 ItemsSource="{Binding TestStrings}"
-                        x:Name="CollectionView"
-                        IsGrouped="False"
-                        BackgroundColor="Transparent">
-        
-        <!--<dui:CollectionView.ItemsLayout>
-            <LinearItemsLayout Orientation="Horizontal"></LinearItemsLayout>
-        </dui:CollectionView.ItemsLayout>-->
-        
-        <dui:CollectionView2.GroupHeaderTemplate>
-            <DataTemplate>
-                <Grid>
-                    <dui:ListItem Title="he" ></dui:ListItem>
-                </Grid>
-            </DataTemplate>
-        </dui:CollectionView2.GroupHeaderTemplate>
-        
-        <!--<dui:CollectionView.Header>
-            <Button Text="Test!"
-                    BackgroundColor="Red"
-                    Clicked="Button_OnClicked"></Button>
-        </dui:CollectionView.Header>-->
-        
-        <dui:CollectionView2.Header>
-            <Grid>
-            <dui:ListItem Title="Hello" Command="{dui:OpenBottomSheetCommand {x:Type vetleSamples:TestBottomSheetFitToContent}}"></dui:ListItem>
-            </Grid>
-        </dui:CollectionView2.Header>
-        
-        <dui:CollectionView2.Footer>
-            <Grid>
-                
-            <dui:ListItem Title="global footer"></dui:ListItem>
-            </Grid>
-        </dui:CollectionView2.Footer>
-        
-        <dui:CollectionView2.GroupFooterTemplate>
-            <DataTemplate>
-                <Grid>
-                    <dui:ListItem Title="footer"></dui:ListItem>
-                </Grid>
-            </DataTemplate>
-        </dui:CollectionView2.GroupFooterTemplate>
-        
-        <dui:CollectionView2.ItemTemplate>
-            <DataTemplate x:DataType="system:String">
-                <dui:ListItem Title="Hei" />
-            </DataTemplate>
-        </dui:CollectionView2.ItemTemplate>
-
-    </dui:CollectionView2>
-    </dui:RefreshView>
+   <dui:Chip Title="Hello"
+             Margin="{dui:Thickness Top=size_4}"
+             VerticalOptions="Start"
+             HorizontalOptions="Center"/>
 
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml.cs
@@ -201,9 +201,9 @@ public partial class VetlePage
 
     private void Button_OnClicked(object sender, EventArgs e)
     {
-        if (CollectionView.Handler is CollectionViewHandler collectionViewHandler)
+        /*if (CollectionView.Handler is CollectionViewHandler collectionViewHandler)
         {
             
-        }
+        }*/
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Chips/Android/ChipHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/Android/ChipHandler.cs
@@ -65,7 +65,6 @@ public class ChipHandler : ViewHandler<Chip, Google.Android.Material.Chip.Chip>
         platformView.UpdateFont(textStyle: new Label { Style = Styles.GetLabelStyle(LabelStyle.Body200) }, fontManager!);
         platformView.TextAlignment = TextAlignment.Center;
         platformView.SetTextColor(Colors.GetColor(ColorName.color_text_default).ToPlatform());
-        platformView.ChipCornerRadius = Sizes.GetSize(SizeName.radius_small).ToMauiPixel();
         platformView.SetEnsureMinTouchTargetSize(false); //Remove extra margins around the chip, this is added to get more space to hit the chip but its not necessary : https://stackoverflow.com/a/57188310
         platformView.Click += OnChipTapped;
     }
@@ -117,7 +116,7 @@ public class ChipHandler : ViewHandler<Chip, Google.Android.Material.Chip.Chip>
 
     private static void MapCornerRadius(ChipHandler handler, Chip chip)
     {
-        handler.PlatformView.ChipCornerRadius = (float) (handler.VirtualView.CornerRadius*DeviceDisplay.MainDisplayInfo.Density);
+        handler.PlatformView.ChipCornerRadius = handler.VirtualView.CornerRadius.ToMauiPixel();
     }
 
     private static void MapBorderColor(ChipHandler handler, Chip chip)

--- a/src/library/DIPS.Mobile.UI/Components/Chips/Chip.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/Chip.Properties.cs
@@ -38,9 +38,9 @@ public partial class Chip
     /// <summary>
     /// The radius of the corners of the chip.
     /// </summary>
-    public int CornerRadius
+    public double CornerRadius
     {
-        get => (int)GetValue(CornerRadiusProperty);
+        get => (double)GetValue(CornerRadiusProperty);
         set => SetValue(CornerRadiusProperty, value);
     }
     
@@ -115,8 +115,9 @@ public partial class Chip
     
     public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(
         nameof(CornerRadius),
-        typeof(int),
-        typeof(Chip));
+        typeof(double),
+        typeof(Chip),
+        Sizes.GetSize(SizeName.radius_small));
     
     public static readonly BindableProperty IsCloseableProperty = BindableProperty.Create(
         nameof(IsCloseable),


### PR DESCRIPTION
### Description of Change

Don't know when this bug appeared, the mapper will run even though the value is not set. So it was set to zero.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->