### PR TITLE
[CollectionView][iOS] Fixed regression bug where `AutoCornerRadius` did not work.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [42.2.4] 
+- [CollectionView][iOS] Fixed regression bug where `AutoCornerRadius` did not work.
+
 ## [42.2.3] 
 - [CollectionView][iOS] Fixed poor performance.
 

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/iOS/CollectionViewHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/iOS/CollectionViewHandler.cs
@@ -109,6 +109,8 @@ internal class ReordableItemsViewController(ReorderableItemsView reorderableItem
 
     internal static void TrySetCornerRadiusOnCell(UICollectionView collectionView, NSIndexPath indexPath, UICollectionViewCell cell, CollectionView mauiCollectionView)
     {
+        var viewThatReceivedMarginUnderCell = cell.Subviews[1].Subviews[0];
+        
         if(mauiCollectionView.LastItemCornerRadius.IsEmpty() && mauiCollectionView.FirstItemCornerRadius.IsEmpty() && !mauiCollectionView.AutoCornerRadius)
         {
             return;
@@ -134,14 +136,14 @@ internal class ReordableItemsViewController(ReorderableItemsView reorderableItem
 
         if (!cornerRadius.IsEmpty())
         {
-            SetViewCornerRadius(cell, cornerRadius);
+            SetViewCornerRadius(viewThatReceivedMarginUnderCell, cornerRadius);
         }
         else
         {
             // Reset the corner radius for all other cells, because of virtualization
-            cell.ClipsToBounds = false;
-            cell.Layer.CornerRadius = 0;
-            cell.Layer.MaskedCorners = 0;
+            viewThatReceivedMarginUnderCell.ClipsToBounds = false;
+            viewThatReceivedMarginUnderCell.Layer.CornerRadius = 0;
+            viewThatReceivedMarginUnderCell.Layer.MaskedCorners = 0;
         }
     }
 


### PR DESCRIPTION
### Description of Change

When we refactored how the padding worked in CollectionView, we needed to set corner radius on a element that actually received margin. With the other method, the cell itself got margin.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->