### PR TITLE
[SearchPage] Fixed an issue where consumer could not modify `AutoHideLastDivider` property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [42.2.6] 
+- [SearchPage] Fixed an issue where consumer could not modify `AutoHideLastDivider` property.
+
 ## [42.2.5] 
 - [CollectionView][Android] Fixed issue where headers/footers would get same padding as elements in list.
 - [CollectionView] CornerRadius will now get updated to the next item if an item is added to CollectionView using ObservableCollection.

--- a/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Searching/SearchPage.Properties.cs
@@ -132,10 +132,24 @@ namespace DIPS.Mobile.UI.Components.Searching
         /// </summary>
         public bool AutoHideLastDivider
         {
-            set => UI.Effects.Layout.Layout.SetAutoHideLastDivider(m_resultCollectionView, value);
+            get => (bool)GetValue(AutoHideLastDividerProperty);
+            set => SetValue(AutoHideLastDividerProperty, value);
         }
 
         public SearchBar SearchBar { get; }
+        
+        public static readonly BindableProperty AutoHideLastDividerProperty = BindableProperty.Create(
+            nameof(AutoHideLastDivider),
+            typeof(bool),
+            typeof(SearchPage),
+            defaultBindingMode: BindingMode.OneTime,
+            propertyChanged: (bindable, _, newValue) =>
+            {
+                if (newValue is bool boolean && bindable is SearchPage searchPage)
+                {
+                    UI.Effects.Layout.Layout.SetAutoHideLastDivider(searchPage.m_resultCollectionView, boolean);
+                }
+            });
         
         public static readonly BindableProperty CancelCommandProperty = BindableProperty.Create(
             nameof(CancelCommand),


### PR DESCRIPTION
### Description of Change

Changed to bindable property

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->