### PR TITLE
[Touch][iOS] Fixed a bug where disabling an element right after touch effect fires, makes the element stay at clicked opacity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [43.0.1] 
+- [Touch][iOS] Fixed a bug where disabling an element right after touch effect fires, makes the element stay at clicked opacity.
+
 ## [43.0.0] 
 - [Button][Android] Fixed an issue where padding were not added to icon in a button.
 - [Touch] Support to also use `IsEnabled` property on the Element.

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -21,7 +21,8 @@
     </dui:ContentPage.Resources>
 
     <dui:VerticalStackLayout Spacing="20">
-        <dui:Button Text="Open BottomSheet"
+        <dui:ListItem Title="Open BottomSheet"
+                    Tapped="Button_OnClicked"
                     Command="{dui:OpenBottomSheetCommand {x:Type vetleSamples:BottomSheetWithToolbar}}"/>
     
         <Grid ColumnDefinitions="*, Auto"

--- a/src/app/Playground/VetleSamples/VetlePage.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows.Input;
 using DIPS.Mobile.UI.Components.Alerting.Dialog;
 using DIPS.Mobile.UI.Components.BottomSheets;
+using DIPS.Mobile.UI.Components.ListItems;
 using DIPS.Mobile.UI.Components.Lists;
 using DIPS.Mobile.UI.Resources.Icons;
 using Playground.HåvardSamples;
@@ -76,7 +77,7 @@ public partial class VetlePage
 
     private void SwitchRoot()
     {
-       
+        
 
     }
 
@@ -201,14 +202,14 @@ public partial class VetlePage
 
     private void Button_OnClicked(object sender, EventArgs e)
     {
-        /*if (CollectionView.Handler is CollectionViewHandler collectionViewHandler)
-        {
-            
-        }*/
+        if (sender is ListItem button)
+            button.IsEnabled = !button.IsEnabled;
     }
 
     private void ListItem_OnTapped(object sender, EventArgs e)
     {
         /*CollectionView.ReloadData();*/
     }
+
+    
 }

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/Android/TouchPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/Android/TouchPlatformEffect.cs
@@ -71,7 +71,7 @@ public partial class TouchPlatformEffect
         Touch.GetCommand(Element)?.Execute(Touch.GetCommandParameter(Element));
     }
 
-    private partial void Dispose()
+    private partial void Dispose(bool isDetaching)
     {
         if (m_touchMode is Touch.TouchMode.Tap or Touch.TouchMode.Both)
         {

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/Touch.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/Touch.Properties.cs
@@ -34,6 +34,5 @@ public partial class Touch
     public static readonly BindableProperty IsEnabledProperty = BindableProperty.CreateAttached("IsEnabled",
         typeof(bool),
         typeof(Touch),
-        true,
-        propertyChanged: OnTouchPropertiesChanged);
+        true);
 }

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/TouchPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/TouchPlatformEffect.cs
@@ -12,9 +12,9 @@ public partial class TouchPlatformEffect : PlatformEffect
         
         element.PropertyChanged += ElementOnPropertyChanged;
 
-        var isEnabled = Touch.GetIsEnabled(Element);
+        var isEnabled = Touch.GetIsEnabled(Element) && element.IsEnabled;
         
-        if (element.IsEnabled && isEnabled)
+        if (isEnabled)
             Init();
     }
     
@@ -28,15 +28,17 @@ public partial class TouchPlatformEffect : PlatformEffect
         if(sender is not VisualElement element)
             return;
 
-        if (element.IsEnabled)
+        var isEnabled = element.IsEnabled && Touch.GetIsEnabled(element);
+        
+        if (isEnabled)
             Init();
         else
-            Dispose();
+            Remove(false);
     }
 
     protected override void OnDetached()
     {
-        Dispose();
+        Remove(true);
         
         if (Element is not VisualElement element)
             return;
@@ -44,5 +46,5 @@ public partial class TouchPlatformEffect : PlatformEffect
         element.PropertyChanged -= ElementOnPropertyChanged;
     }
     
-    private partial void Dispose();
+    private partial void Remove(bool isDetaching);
 }

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/TouchPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/TouchPlatformEffect.cs
@@ -33,12 +33,12 @@ public partial class TouchPlatformEffect : PlatformEffect
         if (isEnabled)
             Init();
         else
-            Remove(false);
+            Dispose(false);
     }
 
     protected override void OnDetached()
     {
-        Remove(true);
+        Dispose(true);
         
         if (Element is not VisualElement element)
             return;
@@ -46,5 +46,5 @@ public partial class TouchPlatformEffect : PlatformEffect
         element.PropertyChanged -= ElementOnPropertyChanged;
     }
     
-    private partial void Remove(bool isDetaching);
+    private partial void Dispose(bool isDetaching);
 }

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/dotnet/TouchPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/dotnet/TouchPlatformEffect.cs
@@ -4,5 +4,5 @@ namespace DIPS.Mobile.UI.Effects.Touch;
 public partial class TouchPlatformEffect
 {
     private partial void Init(){}
-    private partial void Dispose(){}
+    private partial void Dispose(bool isDetaching){}
 }

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
@@ -51,11 +51,11 @@ public partial class TouchPlatformEffect
             Touch.GetCommand(Element)?.Execute(Touch.GetCommandParameter(Element));
     }
 
-    private partial void Remove(bool isDetaching)
+    private partial void Dispose(bool isDetaching)
     {
         if(Control is null)
             return;
-
+        
         // If the Control was set to disabled after being pressed, we need to animate it back to the original state
         if (!isDetaching)
         {

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
@@ -51,10 +51,16 @@ public partial class TouchPlatformEffect
             Touch.GetCommand(Element)?.Execute(Touch.GetCommandParameter(Element));
     }
 
-    private partial void Dispose()
+    private partial void Remove(bool isDetaching)
     {
         if(Control is null)
             return;
+
+        // If the Control was set to disabled after being pressed, we need to animate it back to the original state
+        if (!isDetaching)
+        {
+            AnimateToOriginal(Control, 1);
+        }
         
         if (m_touchMode is Touch.TouchMode.Tap or Touch.TouchMode.Both)
         {


### PR DESCRIPTION
### Description of Change

This is a regression bug from last PR, because now we listen to `IsEnabled` property changes on the Element, and then remove gestures when it's disabled. We need to also animate it to original opacity if this is the case.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->