### PR TITLE
Added IncludeInheritance property to TypeToObjectConverter to allow to check for sub-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [43.3.0]
+- Added `IncludeInheritance` property to `TypeToObjectConverter` to allow to check for sub-types
+
 ## [43.2.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/src/library/DIPS.Mobile.UI/Converters/ValueConverters/TypeToObjectConverter.cs
+++ b/src/library/DIPS.Mobile.UI/Converters/ValueConverters/TypeToObjectConverter.cs
@@ -24,6 +24,11 @@ namespace DIPS.Mobile.UI.Converters.ValueConverters
         /// The type to check against, use {x:Type namespace:MyType}
         /// </summary>
         public Type? Type { get; set; }
+        
+        /// <summary>
+        /// Determines if the expression should be regarded as 'true' as long as the value is an instance of a sub-type of <see cref="Type"/>
+        /// </summary>
+        public bool IncludeInheritance { get; set; }
 
         /// <inheritdoc/>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
@@ -36,6 +41,12 @@ namespace DIPS.Mobile.UI.Converters.ValueConverters
                 throw new XamlParseException($"{nameof(TrueObject)} can not be null").WithXmlLineInfo(m_serviceProvider);
             if (FalseObject == null)
                 throw new XamlParseException($"{nameof(FalseObject)} can not be null").WithXmlLineInfo(m_serviceProvider);
+
+            if (IncludeInheritance)
+            {
+                return Type.IsInstanceOfType(value) ? TrueObject : FalseObject;
+            }
+            
             return (value.GetType() == Type) ? TrueObject : FalseObject;
         }
         /// <inheritdoc/>

--- a/src/tests/unittests/Converters/ValueConverters/TypeToObjectConverterTests.cs
+++ b/src/tests/unittests/Converters/ValueConverters/TypeToObjectConverterTests.cs
@@ -65,5 +65,47 @@ namespace DIPS.Mobile.UI.UnitTests.Converters.ValueConverters
 
             actualOutput.Should().Be(ExpectedFalseObject);
         }
+        
+        [Fact]
+        public void Convert_ValueIsOfSubTypeWhenDisallowSubTypes_FalseObjectAsOutput()
+        {
+            m_typeToObjectConverter.TrueObject = ExpectedTrueObject;
+            m_typeToObjectConverter.FalseObject = ExpectedFalseObject;
+            m_typeToObjectConverter.Type = typeof(MyTestTypeA);
+
+            var actualOutput = m_typeToObjectConverter.Convert<string>(new MyTestTypeB());
+
+            actualOutput.Should().Be(ExpectedFalseObject);
+        }
+        
+        [Fact]
+        public void Convert_ValueIsOfSubTypeWhenAllowSubTypes_TrueObjectAsOutput()
+        {
+            m_typeToObjectConverter.TrueObject = ExpectedTrueObject;
+            m_typeToObjectConverter.FalseObject = ExpectedFalseObject;
+            m_typeToObjectConverter.Type = typeof(MyTestTypeA);
+            m_typeToObjectConverter.IncludeInheritance = true;
+
+            var actualOutput = m_typeToObjectConverter.Convert<string>(new MyTestTypeB());
+
+            actualOutput.Should().Be(ExpectedTrueObject);
+        }
+        
+        [Fact]
+        public void Convert_ValueIsNotOfSubTypeWhenAllowSubTypes_FalseObjectAsOutput()
+        {
+            m_typeToObjectConverter.TrueObject = ExpectedTrueObject;
+            m_typeToObjectConverter.FalseObject = ExpectedFalseObject;
+            m_typeToObjectConverter.Type = typeof(MyTestTypeA);
+            m_typeToObjectConverter.IncludeInheritance = true;
+
+            var actualOutput = m_typeToObjectConverter.Convert<string>("This is a string");
+
+            actualOutput.Should().Be(ExpectedFalseObject);
+        }
+
+        private class MyTestTypeA;
+
+        private class MyTestTypeB : MyTestTypeA;
     }
 }


### PR DESCRIPTION
### Description of Change
Added IncludeInheritance property to TypeToObjectConverter to allow for checks against sub-types. Introduced this property as to not break the existing behaviour.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->