### PR TITLE
[ListItem] Fixed a regression bug where consumers could not fill out title without setting `InlineContent`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [44.0.1] 
+- [ListItem] Fixed a regression bug where consumers could not fill out title without setting `InlineContent`.
+
 ## [44.0.0] 
 - [BreakingChange][ListItem] Removed `ContextMenu` property.
 - [BreakingChange][ListItem] Removed Horizontal -and Vertical Text alignment properties on `TitleOptions` and `SubtitleOptions`, they never worked anyway.

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -16,25 +16,17 @@
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
 
-    <dui:CollectionView ItemsSource="{Binding TestObject2s}">
+    <dui:ListItem VerticalOptions="Start"
+                  Title="Long title that goes over two lines yes yyesy e ys y sey seyseyeyse">
         
-        <dui:CollectionView.ItemTemplate>
-            <DataTemplate x:DataType="{x:Type vetleSamples:TestObject2}">
-                <dui:ListItem Title="{Binding Name}"
-                              Icon="{Binding Icon}"
-                              Command="{Binding Navigate, Source={RelativeSource AncestorType={x:Type vetleSamples:VetlePageViewModel}}}"/>
-            </DataTemplate>
-        </dui:CollectionView.ItemTemplate>
+        <dui:ListItem.TitleOptions>
+            <dui:TitleOptions Width="*" />
+        </dui:ListItem.TitleOptions>
         
-    </dui:CollectionView>
-    <!--<dui:VerticalStackLayout BindableLayout.ItemsSource="{Binding TestStrings}">
+        <dui:ListItem.InLineContentOptions>
+            <dui:InLineContentOptions Width="Auto" />
+        </dui:ListItem.InLineContentOptions>
         
-       <BindableLayout.ItemTemplate>
-           <DataTemplate x:DataType="{x:Type x:String}">
-               <dui:ListItem Title="{Binding .}" />
-           </DataTemplate>
-       </BindableLayout.ItemTemplate>
-        
-    </dui:VerticalStackLayout>-->
+    </dui:ListItem>
 
 </dui:ContentPage>

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.Properties.cs
@@ -320,7 +320,14 @@ public partial class ListItem
         typeof(ListItem),
         propertyChanged: (bindable, _, newValue) =>
         {
-            if (bindable is ListItem { InLineContent: not null } listItem)
+            if (bindable is not ListItem listItem)
+                return;
+
+            if (listItem.InLineContent is null)
+            {
+                listItem.ColumnDefinitions[2].Width = listItem.InLineContentOptions?.Width ?? listItem.ColumnDefinitions[2].Width;   
+            }
+            else
             {
                 Bind<InLineContentOptions>(newValue, listItem);
             }

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
@@ -25,7 +25,7 @@ public partial class ListItem : Grid
     private IView m_oldInLineContent;
     private IView? m_oldUnderlyingContent;
 
-    public readonly Grid TitleAndSubtitleContainer = new()
+    private readonly Grid m_titleAndSubtitleContainer = new()
     {
         AutomationId = "TitleAndSubtitleContainer".ToDUIAutomationId<ListItem>(),
         VerticalOptions = LayoutOptions.Center,
@@ -54,7 +54,7 @@ public partial class ListItem : Grid
 
         BackgroundColor = DIPS.Mobile.UI.Resources.Colors.Colors.GetColor(ColorName.color_surface_default);
         
-        this.Add(TitleAndSubtitleContainer, 1);
+        this.Add(m_titleAndSubtitleContainer, 1);
     }
 
     private void AddTitle()
@@ -65,7 +65,7 @@ public partial class ListItem : Grid
         TitleLabel = new Label { AutomationId = "TitleLabel".ToDUIAutomationId<ListItem>() };
         TitleLabel.SetBinding(Label.TextProperty, static (ListItem listItem) => listItem.Title, source: this);
         
-        TitleAndSubtitleContainer.Add(TitleLabel);
+        m_titleAndSubtitleContainer.Add(TitleLabel);
 
         SetDefaultValuesOrBindToOptions(TitleOptions, () =>
         {
@@ -81,7 +81,7 @@ public partial class ListItem : Grid
         SubtitleLabel = new Label { AutomationId = "SubtitleLabel".ToDUIAutomationId<ListItem>() };
         SubtitleLabel.SetBinding(Label.TextProperty, static(ListItem listItem) => listItem.Subtitle, source: this);
         
-        TitleAndSubtitleContainer.Add(SubtitleLabel, 0, 1);
+        m_titleAndSubtitleContainer.Add(SubtitleLabel, 0, 1);
 
         SetDefaultValuesOrBindToOptions(SubtitleOptions, () =>
         {

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/InLineContent/InLineContentOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/InLineContent/InLineContentOptions.cs
@@ -19,7 +19,7 @@ public partial class InLineContentOptions : ListItemOptions
             Grid.SetRowSpan(inLineContent, 2);
         }
     }
-
+    
     protected override void DoBind(ListItem listItem)
     { 
         listItem.ColumnDefinitions[2].Width = Width;


### PR DESCRIPTION
### Description of Change

Made a change in last PR where InlineContentOptions is only set if InlineContent is set, but consumers uses InlineContentOptions without setting InlineContent sometimes to make sure the title is filled out.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->