### PR TITLE
[ListItem][iOS] Fixed a bug where setting `FormattedText` sometimes did not wrap on a new line.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [44.1.2] 
+- [ListItem][iOS] Fixed a bug where setting `FormattedText` sometimes did not wrap on a new line.
+
 ## [44.1.1] 
 - [CollectionView][Android] Fixed a bug where CornerRadius and padding were not set on last element if group footer was not set.
 - [AmplitudeView] Added ElapsedMilliseconds to Controller.

--- a/src/app/Playground/VetleSamples/TextHighlighter.cs
+++ b/src/app/Playground/VetleSamples/TextHighlighter.cs
@@ -1,0 +1,78 @@
+using System.Globalization;
+using DIPS.Mobile.UI.Resources.Colors;
+using Colors = Microsoft.Maui.Graphics.Colors;
+
+namespace Arena.Mobile.Domains.MunicipalCare.Shared.Converters;
+
+[AcceptEmptyServiceProvider]
+public class TextHighlighter : IMultiValueConverter, IMarkupExtension
+{
+    public string FontFamily { get; set; } = "UI";
+    public Color TextColor { get; set; } = DIPS.Mobile.UI.Resources.Colors.Colors.GetColor(ColorName.color_neutral_90);
+    public double FontSize { get; set; } = 16;
+    public bool ShouldAddEllipsisAtStart { get; set; } = true;
+    
+    public object? Convert(object[]? values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values![0] is not string text)
+            return new FormattedString();
+
+        if (values[1] is not string searchText)
+            return new FormattedString();
+
+        var formattedString = new FormattedString();
+
+        var firstHighlightedTextIsAdded = false;
+        
+        var words = text.Replace("\n", " ").Split(" ");
+        foreach (var word in words)
+        {
+            if (string.IsNullOrWhiteSpace(word))
+                continue;
+            
+            if (word.Contains(searchText, StringComparison.CurrentCultureIgnoreCase))
+            {
+                // The first highlighted text should be at the start of the text
+                if (formattedString.Spans.Count > 0 && !firstHighlightedTextIsAdded && ShouldAddEllipsisAtStart)
+                {
+                    formattedString.Spans.Clear();
+                    firstHighlightedTextIsAdded = true;
+                    
+                    formattedString.Spans.Add(AddSpan("... "));
+                }
+                
+                var startIndexOfMatchedWord = word.ToLower().IndexOf(searchText.ToLower(), StringComparison.Ordinal);
+                if(startIndexOfMatchedWord == -1)
+                    continue;
+                
+                var charactersBeforeMatch = word[..startIndexOfMatchedWord];
+                var charactersAfterMatch = word[(startIndexOfMatchedWord + searchText.Length)..] + " ";
+                var matchedCharacters = word.Substring(startIndexOfMatchedWord, searchText.Length);
+                
+                if(charactersBeforeMatch.Length > 0)
+                    formattedString.Spans.Add(AddSpan(charactersBeforeMatch));
+                formattedString.Spans.Add(AddSpan(matchedCharacters, true));
+                formattedString.Spans.Add(AddSpan(charactersAfterMatch));
+                
+            }
+            else
+            {
+                formattedString.Spans.Add(AddSpan(word + " "));
+            }
+        }
+
+        return formattedString;
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+
+    private Span AddSpan(string text, bool match = false)
+    {
+        return new Span { Text = text, BackgroundColor = match ? Colors.Yellow : Colors.Transparent, TextColor = TextColor, FontSize = FontSize, FontFamily = FontFamily };
+    }
+
+    public object ProvideValue(IServiceProvider serviceProvider) => this;
+}

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -6,6 +6,7 @@
                  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                  xmlns:vetleSamples="clr-namespace:Playground.VetleSamples"
                  xmlns:dui="http://dips.com/mobile.ui"
+                 xmlns:converters="clr-namespace:Arena.Mobile.Domains.MunicipalCare.Shared.Converters"
                  x:Class="Playground.VetleSamples.VetlePage"
                  x:Name="This"
                  BackgroundColor="{dui:Colors color_system_white}"
@@ -15,15 +16,66 @@
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
 
-    <Grid RowDefinitions="Auto, Auto">
-        <dui:AmplitudeView Grid.Row="0"
-                           Controller="{Binding Controller, Mode=OneTime}"
-                           HeightRequest="75"
-                           x:Name="VoiceVisualizer" />
 
-        <dui:Button Text="Pause"
-                    Grid.Row="1"
-                    Command="{Binding CancelCommand}" />
-    </Grid>
+    <!--<dui:VerticalStackLayout>-->
+        <Grid ColumnDefinitions="Auto, *, Auto"
+              RowDefinitions="Auto, Auto"
+              Margin="{dui:Thickness Left=size_3, Right=size_3}"
+              BackgroundColor="Red"
+              dui:Layout.AutoCornerRadius="True"
+              Padding="{dui:Thickness Left=content_margin_small, Top=content_margin_medium, Right=content_margin_small, Bottom=content_margin_medium}">
+            <Image Source="{dui:Icons alert_line}"
+                   Margin="{dui:Thickness Right=size_2}" />
+
+            <Grid Grid.Column="1"
+                  RowDefinitions="*, Auto"
+                  VerticalOptions="Center">
+                <dui:Label FormattedText="Tjeneste med tilleggsspørsmål og egenskaper"
+                           FontSize="16"
+                           VerticalTextAlignment="Center">
+                </dui:Label>
+            </Grid>
+
+            <Image Source="{dui:Icons check_line}"
+                   Grid.Column="2"
+                   Margin="{dui:Thickness Left=size_2}" />
+
+        </Grid>
+        
+        <!--<dui:ListItem Icon="{dui:Icons alert_line}"
+                      Margin="{dui:Thickness Left=size_3, Right=size_3}"
+                      >
+            <dui:ListItem.TitleOptions>
+                <dui:TitleOptions FormattedText="Tjeneste med tilleggsspørsmål og egenskaper"
+                                  Width="*" />
+            </dui:ListItem.TitleOptions>
+            
+            <dui:ListItem.InLineContentOptions>
+                <dui:InLineContentOptions Width="Auto" />
+            </dui:ListItem.InLineContentOptions>
+            
+            <dui:Image Source="{dui:Icons check_line}" />
+            
+        </dui:ListItem>-->
+        
+    <!--</dui:VerticalStackLayout>-->
+
+    <!--<dui:ListItem VerticalOptions="Start"
+                      BackgroundColor="Red"
+                      Icon="{dui:Icons alert_line}">
+            
+            <dui:ListItem.InLineContentOptions>
+                <dui:InLineContentOptions Width="Auto" />
+            </dui:ListItem.InLineContentOptions>
+            
+            <dui:ListItem.TitleOptions>
+                <dui:TitleOptions Width="*" FormattedText="{Binding Subtitle}" />
+                    
+            </dui:ListItem.TitleOptions>
+            
+            <dui:Image Source="{dui:Icons check_line}" />
+            
+        </dui:ListItem>-->
+
 
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePageViewModel.cs
+++ b/src/app/Playground/VetleSamples/VetlePageViewModel.cs
@@ -33,7 +33,7 @@ public class VetlePageViewModel : ViewModel
     private List<string> m_testStrings = [];
     private ObservableCollection<GroupedTest> m_groupedTest = [];
     private bool m_isRefreshing;
-    private string m_subtitle = "Hello";
+    private string m_subtitle = "Tjeneste med tilleggsspørsmål og egenskaper";
 
     public VetlePageViewModel()
     {
@@ -98,7 +98,7 @@ public class VetlePageViewModel : ViewModel
     
     private void Disable()
     {
-        Subtitle = string.Empty;
+        /*Subtitle = string.Empty;*/
     }
 
     public bool Disabled
@@ -183,7 +183,7 @@ public class VetlePageViewModel : ViewModel
     [
         "Lokalisasjon påkrevd - Kodeverk og egendefinert",
         "Lokalisasjon - Fritekst",
-        "526321",
+        "tjeneste med tilleggsspørsmål og egenskaper",
         "271351",
         "912512",
         "ABC",

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/ListItem.cs
@@ -48,7 +48,7 @@ public partial class ListItem : Grid
         ];
         
         RowDefinitions = [
-            new RowDefinition(GridLength.Star), 
+            new RowDefinition(GridLength.Auto), 
             new RowDefinition(GridLength.Auto)
         ];
 


### PR DESCRIPTION
### Description of Change

Was reproduced by creating a ListItem from scratch, noticed that setting RowDefinitions="*", made the bug appear.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->