### PR TITLE
[ContextMenu][iOS] ContextMenu's with mode `Pressed` will now rebuild the menu when one of the items' properties changes. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [44.1.3] 
-- Test
+- [ContextMenu][iOS] 
 
 ## [44.1.2] 
 - [ListItem][iOS] Fixed a bug where setting `FormattedText` sometimes did not wrap on a new line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [44.1.3] 
+- Test
+
 ## [44.1.2] 
 - [ListItem][iOS] Fixed a bug where setting `FormattedText` sometimes did not wrap on a new line.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [44.1.3] 
-- [ContextMenu][iOS] 
+- [ContextMenu][iOS] ContextMenu's with mode `Pressed` will now rebuild the menu when one of the items' properties changes. 
 
 ## [44.1.2] 
 - [ListItem][iOS] Fixed a bug where setting `FormattedText` sometimes did not wrap on a new line.

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -15,67 +15,37 @@
     <dui:ContentPage.BindingContext>
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
-
-
-    <!--<dui:VerticalStackLayout>-->
-        <Grid ColumnDefinitions="Auto, *, Auto"
-              RowDefinitions="Auto, Auto"
-              Margin="{dui:Thickness Left=size_3, Right=size_3}"
-              BackgroundColor="Red"
-              dui:Layout.AutoCornerRadius="True"
-              Padding="{dui:Thickness Left=content_margin_small, Top=content_margin_medium, Right=content_margin_small, Bottom=content_margin_medium}">
-            <Image Source="{dui:Icons alert_line}"
-                   Margin="{dui:Thickness Right=size_2}" />
-
-            <Grid Grid.Column="1"
-                  RowDefinitions="*, Auto"
-                  VerticalOptions="Center">
-                <dui:Label FormattedText="Tjeneste med tilleggsspørsmål og egenskaper"
-                           FontSize="16"
-                           VerticalTextAlignment="Center">
-                </dui:Label>
-            </Grid>
-
-            <Image Source="{dui:Icons check_line}"
-                   Grid.Column="2"
-                   Margin="{dui:Thickness Left=size_2}" />
-
-        </Grid>
-        
-        <!--<dui:ListItem Icon="{dui:Icons alert_line}"
-                      Margin="{dui:Thickness Left=size_3, Right=size_3}"
-                      >
-            <dui:ListItem.TitleOptions>
-                <dui:TitleOptions FormattedText="Tjeneste med tilleggsspørsmål og egenskaper"
-                                  Width="*" />
-            </dui:ListItem.TitleOptions>
-            
-            <dui:ListItem.InLineContentOptions>
-                <dui:InLineContentOptions Width="Auto" />
-            </dui:ListItem.InLineContentOptions>
-            
-            <dui:Image Source="{dui:Icons check_line}" />
-            
-        </dui:ListItem>-->
-        
-    <!--</dui:VerticalStackLayout>-->
-
-    <!--<dui:ListItem VerticalOptions="Start"
-                      BackgroundColor="Red"
-                      Icon="{dui:Icons alert_line}">
-            
-            <dui:ListItem.InLineContentOptions>
-                <dui:InLineContentOptions Width="Auto" />
-            </dui:ListItem.InLineContentOptions>
-            
-            <dui:ListItem.TitleOptions>
-                <dui:TitleOptions Width="*" FormattedText="{Binding Subtitle}" />
+    
+    <dui:VerticalStackLayout>
+    <dui:Button Text="Hello"
+                dui:ContextMenuEffect.Mode="Pressed">
+        <dui:ContextMenuEffect.Menu>
+            <dui:ContextMenu>
+                <dui:ContextMenuGroup Title="Hello" IsVisible="{Binding IsVisible}" >
                     
-            </dui:ListItem.TitleOptions>
-            
-            <dui:Image Source="{dui:Icons check_line}" />
-            
-        </dui:ListItem>-->
+                    <dui:ContextMenuItem Title="Hello"
+                                         />
+                    
+                    <dui:ContextMenuItem Title="yo"
+                    />
+                </dui:ContextMenuGroup>
+                <dui:ContextMenuGroup Title="Hello" IsVisible="{Binding IsVisible}" >
+                    
+                    <dui:ContextMenuItem Title="Hello"
+                    />
+                    
+                    <dui:ContextMenuItem Title="yo"
+                    />
+                </dui:ContextMenuGroup>
+            </dui:ContextMenu>
+        </dui:ContextMenuEffect.Menu>
+    </dui:Button>
+        
+        <dui:Button Text="IsVisible"
+                    Command="{Binding DisableCommand}"></dui:Button>
+        
+    </dui:VerticalStackLayout>
+    
 
 
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -29,6 +29,7 @@
                     <dui:ContextMenuItem Title="yo"
                     />
                 </dui:ContextMenuGroup>
+                <dui:ContextMenuSeparatorItem />
                 <dui:ContextMenuGroup Title="Hello" IsVisible="{Binding IsVisible}" >
                     
                     <dui:ContextMenuItem Title="Hello"

--- a/src/app/Playground/VetleSamples/VetlePageViewModel.cs
+++ b/src/app/Playground/VetleSamples/VetlePageViewModel.cs
@@ -34,6 +34,7 @@ public class VetlePageViewModel : ViewModel
     private ObservableCollection<GroupedTest> m_groupedTest = [];
     private bool m_isRefreshing;
     private string m_subtitle = "Tjeneste med tilleggsspørsmål og egenskaper";
+    private bool m_isVisible;
 
     public VetlePageViewModel()
     {
@@ -98,7 +99,7 @@ public class VetlePageViewModel : ViewModel
     
     private void Disable()
     {
-        /*Subtitle = string.Empty;*/
+        IsVisible = !IsVisible;
     }
 
     public bool Disabled
@@ -358,6 +359,12 @@ public class VetlePageViewModel : ViewModel
     }
 
     public Controller Controller { get; } = new();
+
+    public bool IsVisible
+    {
+        get => m_isVisible;
+        set => RaiseWhenSet(ref m_isVisible, value);
+    }
 
     public void OnDateChanged()
     {

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.Properties.cs
@@ -5,7 +5,9 @@ namespace DIPS.Mobile.UI.Components.ContextMenus;
 public partial class ContextMenu : IContextMenu
 {
     public event Action? ItemsSourceUpdated;
+#if __IOS__
     internal event Action? ItemPropertiesUpdated;
+#endif
 
     public static readonly BindableProperty ItemsShouldSendGlobalClicksProperty = BindableProperty.Create(
         nameof(ItemsShouldSendGlobalClicks),

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.Properties.cs
@@ -5,6 +5,7 @@ namespace DIPS.Mobile.UI.Components.ContextMenus;
 public partial class ContextMenu : IContextMenu
 {
     public event Action? ItemsSourceUpdated;
+    internal event Action? ItemsPropertiesUpdated;
 
     public static readonly BindableProperty ItemsShouldSendGlobalClicksProperty = BindableProperty.Create(
         nameof(ItemsShouldSendGlobalClicks),

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.Properties.cs
@@ -5,7 +5,7 @@ namespace DIPS.Mobile.UI.Components.ContextMenus;
 public partial class ContextMenu : IContextMenu
 {
     public event Action? ItemsSourceUpdated;
-    internal event Action? ItemsPropertiesUpdated;
+    internal event Action? ItemPropertiesUpdated;
 
     public static readonly BindableProperty ItemsShouldSendGlobalClicksProperty = BindableProperty.Create(
         nameof(ItemsShouldSendGlobalClicks),

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.cs
@@ -73,6 +73,6 @@ public partial class ContextMenu : Button
 
     internal void SendItemPropertiesUpdated()
     {
-        ItemsPropertiesUpdated?.Invoke();
+        ItemPropertiesUpdated?.Invoke();
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.cs
@@ -71,8 +71,10 @@ public partial class ContextMenu : Button
         ItemsSourceUpdated?.Invoke();
     }
 
+#if __IOS__
     internal void SendItemPropertiesUpdated()
     {
         ItemPropertiesUpdated?.Invoke();
     }
+#endif
 }

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.cs
@@ -19,6 +19,7 @@ public partial class ContextMenu : Button
         {
             foreach (var c in ItemsSource)
             {
+                (c as ContextMenuItem)!.ContextMenu = this;
                 (c as Element)!.BindingContext = BindingContext;
             }
         }
@@ -68,5 +69,10 @@ public partial class ContextMenu : Button
     public void SendItemsSourceUpdated()
     {
         ItemsSourceUpdated?.Invoke();
+    }
+
+    internal void SendItemPropertiesUpdated()
+    {
+        ItemsPropertiesUpdated?.Invoke();
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenu.cs
@@ -19,7 +19,7 @@ public partial class ContextMenu : Button
         {
             foreach (var c in ItemsSource)
             {
-                (c as ContextMenuItem)!.ContextMenu = this;
+                c.ContextMenu = this;
                 (c as Element)!.BindingContext = BindingContext;
             }
         }

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuGroup.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuGroup.cs
@@ -19,6 +19,7 @@ public partial class ContextMenuGroup : ContextMenuItem
         {
             foreach (var c in ItemsSource)
             {
+                c.ContextMenu = ContextMenu;
                 c.BindingContext = BindingContext;
             }
         }

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.Properties.cs
@@ -161,6 +161,11 @@ public partial class ContextMenuItem
         get => (bool)GetValue(ShouldSendGlobalClickProperty);
         set => SetValue(ShouldSendGlobalClickProperty, value);
     }
+    
+    /// <summary>
+    /// The ContextMenu that the item is in
+    /// </summary>
+    internal ContextMenu? ContextMenu { get; set; }
 }
 
 /// <summary>

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.Properties.cs
@@ -165,7 +165,7 @@ public partial class ContextMenuItem
     /// <summary>
     /// The ContextMenu that the item is in
     /// </summary>
-    internal ContextMenu? ContextMenu { get; set; }
+    public ContextMenu? ContextMenu { get; set; }
 }
 
 /// <summary>

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
@@ -25,6 +25,20 @@ public partial class ContextMenuItem : Element, IContextMenuItem
         }
     }
 
+    protected override void OnPropertyChanged(string propertyName = null)
+    {
+        base.OnPropertyChanged(propertyName);
+        
+        if(propertyName == IsVisibleProperty.PropertyName || 
+           propertyName == IconProperty.PropertyName ||
+           propertyName == TitleProperty.PropertyName ||
+           propertyName == IsCheckedProperty.PropertyName || 
+           propertyName == IsDestructiveProperty.PropertyName)
+        {
+            ContextMenu?.SendItemPropertiesUpdated();
+        }
+    }
+
     public void Dispose()
     {
         DidClick = null;

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
@@ -25,6 +25,7 @@ public partial class ContextMenuItem : Element, IContextMenuItem
         }
     }
 
+#if __IOS__
     protected override void OnPropertyChanged(string propertyName = null)
     {
         base.OnPropertyChanged(propertyName);
@@ -38,6 +39,7 @@ public partial class ContextMenuItem : Element, IContextMenuItem
             ContextMenu?.SendItemPropertiesUpdated();
         }
     }
+#endif
 
     public void Dispose()
     {

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuSeparatorItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuSeparatorItem.cs
@@ -14,6 +14,23 @@ public class ContextMenuSeparatorItem : Element, IContextMenuItem
         set => SetValue(IsVisibleProperty, value);
     }
 
+    /// <summary>
+    /// The ContextMenu that the item is in
+    /// </summary>
+    public ContextMenu? ContextMenu { get; set; }
+
+#if __IOS__
+    protected override void OnPropertyChanged(string propertyName = null)
+    {
+        base.OnPropertyChanged(propertyName);
+        
+        if(propertyName == IsVisibleProperty.PropertyName) 
+        {
+            ContextMenu?.SendItemPropertiesUpdated();
+        }
+    }
+#endif
+    
     public void Dispose()
     {
         

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/IContextMenuItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/IContextMenuItem.cs
@@ -3,4 +3,5 @@ namespace DIPS.Mobile.UI.Components.ContextMenus;
 public interface IContextMenuItem : IDisposable
 {
     bool IsVisible { get; }
+    ContextMenu? ContextMenu { get; set; }
 }

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.Pressed.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.Pressed.cs
@@ -15,7 +15,7 @@ public partial class ContextMenuPlatformEffect
     private void SetupPressedMode(ContextMenu contextMenu)
     {
         contextMenu.ItemsSourceUpdated += RebuildMenu;
-        contextMenu.ItemsPropertiesUpdated += RebuildMenu;
+        contextMenu.ItemPropertiesUpdated += RebuildMenu;
         
         if (Control is not UIButton uiButton)
         {
@@ -98,7 +98,7 @@ public partial class ContextMenuPlatformEffect
         m_uiButtonToRemove?.RemoveFromSuperview();
         
         m_contextMenu.ItemsSourceUpdated -= RebuildMenu;
-        m_contextMenu.ItemsPropertiesUpdated -= RebuildMenu;
+        m_contextMenu.ItemPropertiesUpdated -= RebuildMenu;
         
         if(Element is not null)
             Element.PropertyChanged -= ElementOnPropertyChanged;

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.Pressed.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.Pressed.cs
@@ -15,6 +15,7 @@ public partial class ContextMenuPlatformEffect
     private void SetupPressedMode(ContextMenu contextMenu)
     {
         contextMenu.ItemsSourceUpdated += RebuildMenu;
+        contextMenu.ItemsPropertiesUpdated += RebuildMenu;
         
         if (Control is not UIButton uiButton)
         {
@@ -97,6 +98,7 @@ public partial class ContextMenuPlatformEffect
         m_uiButtonToRemove?.RemoveFromSuperview();
         
         m_contextMenu.ItemsSourceUpdated -= RebuildMenu;
+        m_contextMenu.ItemsPropertiesUpdated -= RebuildMenu;
         
         if(Element is not null)
             Element.PropertyChanged -= ElementOnPropertyChanged;


### PR DESCRIPTION
### Description of Change

For a long time we have had a bug where the Menu would not change even though the binding has changed itself. This is because we set the menu of the button only at the start, or if the ItemsSource changes. This is not reproducible on `LongPressed` mode, because the menu is built when the animation starts. 

Now we check in PropertyChanged if any properties of `ContextMenuItem` changes, if so, rebuild the menu.

### Todos
- [ ] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->