### PR TITLE
[ItemPicker] Added `FreeTextItemFactory` and `FreeTextPrefix` properties to support custom text item in bottom sheet mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## [44.7.0]
+## [44.8.0]
 - [ItemPicker] Added `FreeTextItemFactory` and `FreeTextPrefix` properties to support custom text item in bottom sheet mode
+
+## [44.7.0]
+- Resources was updated from DIPS.Mobile.DesignTokens
 
 ## [44.6.0] 
 - Added `AutoScrollingTextView`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## [44.7.0] 
-- Resources was updated from DIPS.Mobile.DesignTokens
+## [44.7.0]
+- [ItemPicker] Added `FreeTextItemFactory` and `FreeTextPrefix` properties to support custom text item in bottom sheet mode
 
 ## [44.6.0] 
 - Added `AutoScrollingTextView`.

--- a/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
@@ -30,6 +30,15 @@
                         Mode="BottomSheet"
                         SelectedItem="{Binding SelectedPerson}"
                         ItemsSource="{Binding People}" />
+        <dui:Label Text="ItemPicker, Mode: Bottom Sheet w/ Free Text"
+                   Margin="5" />
+        <dui:ItemPicker VerticalOptions="Start"
+                        HorizontalOptions="Start"
+                        Mode="BottomSheet"
+                        SelectedItem="{Binding SelectedPerson}"
+                        ItemsSource="{Binding People}" 
+                        FreeTextItemFactory="{Binding PersonFactory}"
+                        FreeTextPrefix="Free text: "/>
         <dui:Label Text="MultiItemsPicker"
                    Margin="5" />
         

--- a/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamplesViewModel.cs
+++ b/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamplesViewModel.cs
@@ -20,4 +20,24 @@ public class ItemPickersSamplesViewModel : ViewModel
         get => m_selectedItems;
         set => RaiseWhenSet(ref m_selectedItems, value);
     }
+
+    public Func<string, Person> PersonFactory { get; } = fullName =>
+    {
+        var splitNames = fullName.Split(" ");
+        var firstName = splitNames[0];
+
+        var middleName = string.Empty;
+        var lastName = string.Empty;
+        if (splitNames.Length == 2)
+        {
+            lastName = splitNames[1];
+        }
+        else if (splitNames.Length > 2)
+        {
+            middleName = splitNames[1];
+            lastName = splitNames[2];
+        }
+
+        return new Person(firstName, lastName, middleName);
+    };
 }

--- a/src/app/Playground/EirikSamples/EirikPage.xaml
+++ b/src/app/Playground/EirikSamples/EirikPage.xaml
@@ -10,37 +10,12 @@
     <dui:ContentPage.BindingContext>
         <eirikSamples:EirikPageViewModel />
     </dui:ContentPage.BindingContext>
-    <dui:VerticalStackLayout>
-        <dui:CollectionView ItemsSource="{Binding List}"
-                            IsGrouped="True">
-            <dui:CollectionView.GroupHeaderTemplate>
-                <DataTemplate x:DataType="{x:Type eirikSamples:GroupedStrings}">
-                    <dui:Label Text="{Binding GroupTitle}"/>
-                </DataTemplate>
-            </dui:CollectionView.GroupHeaderTemplate>
-            <dui:CollectionView.ItemTemplate>
-                <DataTemplate x:DataType="{x:Type x:String}">
-                    <dui:ListItem Title="{Binding .}"
-                                  HasBottomDivider="True"
-                                  HasTopDivider="True"
-                                  BindingContextChanged="ListItemOnBindingContextChanged">
-                        <dui:ContextMenuEffect.Menu>
-                            <dui:ContextMenu BindingContextChanged="ContextMenu_OnBindingContextChanged">
-                                <dui:ContextMenuItem Title="Show system message"
-                                                     Command="{Binding BindingContext.ShowSystemMessageCommand, Source={x:Reference This}}"
-                                                     CommandParameter="{Binding .}"/>
-                                <dui:ContextMenuItem Title="Remove"
-                                                     Command="{Binding BindingContext.RemoveFromListCommand, Source={x:Reference This}}"
-                                                     CommandParameter="{Binding .}"/>
-                            </dui:ContextMenu>
-                        </dui:ContextMenuEffect.Menu>
-                    </dui:ListItem>
-                </DataTemplate>
-            </dui:CollectionView.ItemTemplate>
-        </dui:CollectionView>
-        <dui:Button Text="Add to list"
-                    Command="{Binding AddToListCommand}"/>
-        <dui:Button Text="Navigate"
-                    Command="{Binding NavigateCommand}"/>
-    </dui:VerticalStackLayout>
+    <dui:ItemPicker Mode="BottomSheet"
+                    ItemsSource="{Binding Items}"
+                    FreeTextItemFactory="{Binding FreeTextItemFactory}"
+                    FreeTextPrefix="Fritekst: ">
+        <dui:ItemPicker.BottomSheetPickerConfiguration>
+            <dui:BottomSheetPickerConfiguration HasSearchBar="True"/>
+        </dui:ItemPicker.BottomSheetPickerConfiguration>
+    </dui:ItemPicker>
 </dui:ContentPage>

--- a/src/app/Playground/EirikSamples/EirikPageViewModel.cs
+++ b/src/app/Playground/EirikSamples/EirikPageViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Windows.Input;
+using DIPS.Mobile.UI.Components.Alerting.Dialog;
 using DIPS.Mobile.UI.Components.Alerting.SystemMessage;
 using DIPS.Mobile.UI.Components.Pickers.DatePicker.HorizontalInLine;
 using DIPS.Mobile.UI.Components.Slidable;
@@ -19,6 +20,7 @@ public class EirikPageViewModel : ViewModel
 
     private SliderConfig m_config = new(-3, 0);
     private SlidableProperties m_properties = new(0);
+    private bool m_toggleView;
 
     public EirikPageViewModel()
     {
@@ -26,6 +28,14 @@ public class EirikPageViewModel : ViewModel
         ShowSystemMessageCommand = new Command<string>(ShowSystemMessage);
         RemoveFromListCommand = new Command<string>(RemoveFromList);
         NavigateCommand = new Command(Navigate);
+
+        DoSomethingCommand = new Command(DoSomething);
+    }
+
+    private async void DoSomething()
+    {
+        await DialogService.ShowMessage(options => options.SetActionTitle("Yep!").SetTitle("Something was done."));
+        ToggleView = !ToggleView;
     }
 
     private void Navigate()
@@ -34,6 +44,16 @@ public class EirikPageViewModel : ViewModel
     }
 
     public ICommand NavigateCommand { get; }
+
+    public List<string> Items { get; } = ["One", "Two", "Three", "Four"];
+    
+    public Func<string, string> FreeTextItemFactory { get; } = text => text;
+
+    public bool ToggleView
+    {
+        get => m_toggleView;
+        private set => RaiseWhenSet(ref m_toggleView, value);
+    }
 
     private void RemoveFromList(string obj)
     {
@@ -55,6 +75,7 @@ public class EirikPageViewModel : ViewModel
     public ICommand AddToListCommand { get; }
     public ICommand ShowSystemMessageCommand { get; }
     public ICommand RemoveFromListCommand { get; }
+    public ICommand DoSomethingCommand { get; }
 
     private void AddToList()
     {

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Properties.cs
@@ -95,6 +95,28 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
         }
 
         /// <summary>
+        /// Factory for creating an Item containing free text. Set this property to enable free text. When free text is
+        /// enabled, people will be able to add what they enter into the search bar as a custom selection.
+        /// </summary>
+        /// <remarks>
+        /// Free text is only available in <see cref="PickerMode.BottomSheet"/>, and with <see cref="BottomSheetPickerConfiguration.HasSearchBar"/> enabled.
+        /// </remarks>
+        public Func<string, object>? FreeTextItemFactory
+        {
+            get => (Func<string, object>)GetValue(FreeTextItemFactoryProperty);
+            set => SetValue(FreeTextItemFactoryProperty, value);
+        }
+        
+        /// <summary>
+        /// Prefix that will be added before a free text item as it appears in the bottom sheet.
+        /// </summary>
+        public string FreeTextPrefix
+        {
+            get => (string)GetValue(FreeTextPrefixProperty);
+            set => SetValue(FreeTextPrefixProperty, value);
+        }
+        
+        /// <summary>
         /// Opens the picker.
         /// </summary>
         /// <remarks>This will not work if <see cref="Mode"/> is <see cref="PickerMode.ContextMenu"/></remarks>
@@ -122,6 +144,17 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             nameof(ShouldAutoFocusSearchBar),
             typeof(bool),
             typeof(ItemPicker));
+
+        public static readonly BindableProperty FreeTextItemFactoryProperty = BindableProperty.Create(
+            nameof(FreeTextItemFactory),
+            typeof(Func<string, object>),
+            typeof(ItemPicker));
+
+        public static readonly BindableProperty FreeTextPrefixProperty = BindableProperty.Create(
+            nameof(FreeTextPrefix),
+            typeof(string),
+            typeof(ItemPicker),
+            defaultValue: string.Empty);
     }
 
     public enum PickerMode

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.cs
@@ -18,7 +18,7 @@ public partial class ItemPicker : ContentView
         m_chip.SetBinding(MaximumHeightRequestProperty, static (Chip chip) => chip.MaximumHeightRequest, source: this);
         MaximumWidthRequest = 200;
     }
-
+    
     protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
         base.OnHandlerChanging(args);

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -45,7 +45,7 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             if (m_itemPicker.FreeTextItemFactory is not null && m_itemPicker.SelectedItem is not null && !selectedItemIsInItemsSource)
             {
                 var displayString = m_itemPicker.SelectedItem.GetPropertyValue(m_itemPicker.ItemDisplayProperty)!;
-                var freeTextItem = m_itemPicker.FreeTextItemFactory(displayString);
+                var freeTextItem = m_itemPicker.SelectedItem;
                 m_freeTextItem = new SelectableItemViewModel(itemPicker.FreeTextPrefix + displayString, true, freeTextItem);
                 itemsToInsert.Insert(0, m_freeTextItem);
             }


### PR DESCRIPTION
### Description of Change
Item pickers will now support people selecting a custom item, using text from the search bar. The `FreeItemTextFactory` property must be set for this to be enabled, as well as `Mode=BottomSheet` and `BottomSheetConfiguration.HasSearch=true`. The factory must be a `Func<string, object>` delegate that returns an object of the same type as `ItemsSource` and `SelectedItem`. The string parameter is the user's text input.

Additionally, a prefix can be shown for the item in the bottom sheet, by setting the `FreeTextPrefix`. The format of the resulting text will be `<FreeTextPrefix><UserInput>`. 