### PR TITLE
[ItemPicker] Fixed an issue where keyboard would close if searching with free-text enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [44.9.1] 
-- [ItemPicker] Fixed an issue where keyboard would close if searching with free-text enabled.g
+- [ItemPicker] Fixed an issue where keyboard would close if searching with free-text enabled.
 
 ## [44.9.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [44.9.1] 
-- [ItemPicker] Fixed an issue where keyboard would close if searching with free-text enabled.
+- [ItemPicker] Fixed an issue where keyboard would close if searching with free-text enabled.g
 
 ## [44.9.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [44.9.1] 
+- [ItemPicker] Fixed an issue where keyboard would close if searching with free-text enabled.
+
 ## [44.9.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -188,14 +188,17 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             }
             else
             {
-                var filteredItems = m_originalItems.Where(p => p.DisplayName.ToLower().Contains(filterText.ToLower()))
+                var filteredItems = m_originalItems
+                    .Where(p => p.DisplayName.ToLower().Contains(filterText.ToLower()))
                     .ToList();
                 Items.Clear();
 
+                var itemsToAdd = new List<SelectableItemViewModel>(filteredItems);
+                
                 var couldCreateFreeTextItem = true;
                 foreach (var item in filteredItems)
                 {
-                    Items.Add(item);
+                    itemsToAdd.Add(item);
                     if (item.DisplayName.Equals(filterText))
                     {
                         couldCreateFreeTextItem = false;
@@ -210,7 +213,12 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                         m_itemPicker.FreeTextPrefix + filterText,
                         freeTextItem.Equals(m_itemPicker.SelectedItem), freeTextItem);
                 
-                    Items.Insert(0, m_freeTextItem);
+                    itemsToAdd.Insert(0, m_freeTextItem);
+                }
+                
+                foreach (var item in itemsToAdd)
+                {
+                    Items.Add(item);
                 }
             }
         }


### PR DESCRIPTION
### Description of Change

It was because the item was at first index after all has been added. Now we add em all in one swoop

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->