### PR TITLE
[SegmentedControl][Android] Fixed bug where setting `HorizontalOptions` had no effect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [45.3.2] 
+- [SegmentedControl][Android] Fixed bug where setting `HorizontalOptions` had no effect.
+
 ## [45.3.1] 
 - [iOS][CollapsibleElement] Fix bug when small list.
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/SegmentedControl/SegmentedControl.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/SegmentedControl/SegmentedControl.cs
@@ -30,13 +30,17 @@ public partial class SegmentedControl : ContentView
         
         BindableLayout.SetItemTemplate(m_horizontalStackLayout, new DataTemplate(CreateSegment));
 
-        Content = new ScrollView
+        var scrollView = new ScrollView
         {
             Content = m_horizontalStackLayout,
             HorizontalScrollBarVisibility = ScrollBarVisibility.Never,
             VerticalScrollBarVisibility = ScrollBarVisibility.Never,
             Orientation = ScrollOrientation.Horizontal
         };
+        
+        scrollView.SetBinding(HorizontalOptionsProperty, static (SegmentedControl segmentedControl) => segmentedControl.HorizontalOptions, source: this);
+        
+        Content = scrollView;
     }
 
     private View CreateSegment()


### PR DESCRIPTION
### Description of Change

On Android it only works if HorizontalOptions is set on ScrollView

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->