### PR TITLE
Added `FooterTemplate` property to `BottomSheetPickerConfiguration` to allow for setting a footer to item picker bottom sheet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [45.4.0]
+- [ItemPicker][MultiItemsPicker] Added `FooterTemplate` property to `BottomSheetPickerConfiguration` to allow for setting a footer to item picker bottom sheet.
+
 ## [45.3.3] 
 - [BottomSheet] Fixed memory leak.
 

--- a/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
@@ -117,6 +117,7 @@
                         <dui:BottomSheetPickerConfiguration.FooterTemplate>
                             <DataTemplate>
                                 <dui:AlertView Style="{dui:Styles Alert=Information}"
+                                               Margin="{dui:Margin Top=size_2, Bottom=size_2, Right=size_3, Left=size_3}"
                                                Title="Here you can write an alert for your user."/>
                             </DataTemplate>
                         </dui:BottomSheetPickerConfiguration.FooterTemplate>

--- a/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
@@ -47,6 +47,9 @@
                               HorizontalOptions="Start"
                               SelectedItems="{Binding SelectedItems, Mode=TwoWay}"
                               ItemsSource="{x:Static sampleData:SampleDataStorage.People}">
+            <dui:MultiItemsPicker.BottomSheetPickerConfiguration>
+                <dui:BottomSheetPickerConfiguration Title="Select multiple"/>
+            </dui:MultiItemsPicker.BottomSheetPickerConfiguration>
         </dui:MultiItemsPicker>
         <dui:Label Text="SegmentedControl: Mode: Single"
                    Margin="5" />

--- a/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
@@ -99,5 +99,30 @@
                 </dui:ItemPicker.BottomSheetPickerConfiguration>
             </dui:ItemPicker>
         </dui:ListItem>
+        
+        <dui:Label Text="Picker in ListItem with bottom sheet footer"
+                   Margin="5" />
+        
+        <dui:ListItem Title="Title"
+                      CornerRadius="{dui:Sizes size_4}"
+                      Margin="{dui:Thickness Left=size_4, Right=size_4}"
+                      BackgroundColor="{dui:Colors color_neutral_05}">
+            
+            <dui:ItemPicker Mode="BottomSheet"
+                            ItemsSource="{Binding People}"
+                            ItemDisplayProperty="DisplayName">
+                <dui:ItemPicker.BottomSheetPickerConfiguration>
+                    <dui:BottomSheetPickerConfiguration Title="Title in bottom sheet "
+                                                        HasSearchBar="False">
+                        <dui:BottomSheetPickerConfiguration.FooterTemplate>
+                            <DataTemplate>
+                                <dui:AlertView Style="{dui:Styles Alert=Information}"
+                                               Title="Here you can write an alert for your user."/>
+                            </DataTemplate>
+                        </dui:BottomSheetPickerConfiguration.FooterTemplate>
+                    </dui:BottomSheetPickerConfiguration>
+                </dui:ItemPicker.BottomSheetPickerConfiguration>
+            </dui:ItemPicker>
+        </dui:ListItem>
     </dui:VerticalStackLayout>
 </dui:ContentPage>

--- a/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
@@ -115,10 +115,10 @@
                     <dui:BottomSheetPickerConfiguration Title="Title in bottom sheet "
                                                         HasSearchBar="False">
                         <dui:BottomSheetPickerConfiguration.FooterTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="pickers:ItemPickersSamplesViewModel">
                                 <dui:AlertView Style="{dui:Styles Alert=Information}"
                                                Margin="{dui:Margin Top=size_2, Bottom=size_2, Right=size_3, Left=size_3}"
-                                               Title="Here you can write an alert for your user."/>
+                                               Title="{Binding AlertText}"/>
                             </DataTemplate>
                         </dui:BottomSheetPickerConfiguration.FooterTemplate>
                     </dui:BottomSheetPickerConfiguration>

--- a/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamplesViewModel.cs
+++ b/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamplesViewModel.cs
@@ -21,6 +21,8 @@ public class ItemPickersSamplesViewModel : ViewModel
         set => RaiseWhenSet(ref m_selectedItems, value);
     }
 
+    public string AlertText => "Here you can write an alert for your user.";
+
     public Func<string, Person> PersonFactory { get; } = fullName =>
     {
         var splitNames = fullName.Split(" ");

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/BottomSheetPickerConfiguration.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/BottomSheetPickerConfiguration.cs
@@ -41,6 +41,8 @@ public class BottomSheetPickerConfiguration : BindableObject
         get => (string)GetValue(TitleProperty);
         set => SetValue(TitleProperty, value);
     }
+    
+    public DataTemplate? FooterTemplate { get; set; }
 
     public ControlTemplate? SelectableItemTemplate { get; set; }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -224,8 +224,10 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
         }
 
         public static ContentControl CreateContentControlForActivityIndicator(CollectionView collectionView,
-            BottomSheetPickerConfiguration? bottomSheetPickerConfiguration)
+            BottomSheetPickerConfiguration bottomSheetPickerConfiguration)
         {
+            collectionView.FooterTemplate = bottomSheetPickerConfiguration.FooterTemplate;
+            
             var contentControl = new ContentControl()
             {
                 BindingContext = bottomSheetPickerConfiguration,

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -67,6 +67,9 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
 
             UI.Effects.Layout.Layout.SetAutoHideLastDivider(m_collectionView, true);
             
+            m_collectionView.SetBinding(StructuredItemsView.FooterProperty, static (ItemPicker itemPicker) => itemPicker.BindingContext, source: m_itemPicker);
+            m_collectionView.FooterTemplate = m_itemPicker.BottomSheetPickerConfiguration.FooterTemplate;
+            
             Content = CreateContentControlForActivityIndicator(m_collectionView,
                 m_itemPicker.BottomSheetPickerConfiguration);
         }
@@ -226,8 +229,6 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
         public static ContentControl CreateContentControlForActivityIndicator(CollectionView collectionView,
             BottomSheetPickerConfiguration bottomSheetPickerConfiguration)
         {
-            collectionView.FooterTemplate = bottomSheetPickerConfiguration.FooterTemplate;
-            
             var contentControl = new ContentControl()
             {
                 BindingContext = bottomSheetPickerConfiguration,

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPickerBottomSheet.cs
@@ -36,6 +36,7 @@ internal class MultiItemsPickerBottomSheet : BottomSheet
 
         Items = new ObservableCollection<SelectableItemViewModel>(m_originalItems);
         
+        this.SetBinding(TitleProperty, static (BottomSheetPickerConfiguration configuration) => configuration.Title, source: multiItemsPicker.BottomSheetPickerConfiguration);
         this.SetBinding(HasSearchBarProperty, static (BottomSheetPickerConfiguration bottomSheetPickerConfiguration) => bottomSheetPickerConfiguration.HasSearchBar, source: m_multiItemsPicker.BottomSheetPickerConfiguration);
 
         var collectionView = new CollectionView()

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPickerBottomSheet.cs
@@ -45,6 +45,12 @@ internal class MultiItemsPickerBottomSheet : BottomSheet
         
         collectionView.SetBinding(ItemsView.ItemsSourceProperty, static (MultiItemsPickerBottomSheet multiItemsPickerBottomSheet) => multiItemsPickerBottomSheet.Items, source: this);
         
+        collectionView.SetBinding(StructuredItemsView.FooterProperty, static (MultiItemsPickerBottomSheet multiItemsPickerBottomSheet) => multiItemsPickerBottomSheet.BindingContext, source: this);
+        collectionView.FooterTemplate = m_multiItemsPicker.BottomSheetPickerConfiguration.FooterTemplate;
+        
+        collectionView.SetBinding(StructuredItemsView.FooterProperty, static (MultiItemsPicker itemPicker) => itemPicker.BindingContext, source: m_multiItemsPicker);
+        collectionView.FooterTemplate = m_multiItemsPicker.BottomSheetPickerConfiguration.FooterTemplate;
+        
         Content = ItemPickerBottomSheet.CreateContentControlForActivityIndicator(collectionView, m_multiItemsPicker.BottomSheetPickerConfiguration);
     }
     

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPickerBottomSheet.cs
@@ -36,7 +36,7 @@ internal class MultiItemsPickerBottomSheet : BottomSheet
 
         Items = new ObservableCollection<SelectableItemViewModel>(m_originalItems);
         
-        this.SetBinding(TitleProperty, static (BottomSheetPickerConfiguration configuration) => configuration.Title, source: multiItemsPicker.BottomSheetPickerConfiguration);
+        this.SetBinding(TitleProperty, static (BottomSheetPickerConfiguration configuration) => configuration.Title, source: m_multiItemsPicker.BottomSheetPickerConfiguration);
         this.SetBinding(HasSearchBarProperty, static (BottomSheetPickerConfiguration bottomSheetPickerConfiguration) => bottomSheetPickerConfiguration.HasSearchBar, source: m_multiItemsPicker.BottomSheetPickerConfiguration);
 
         var collectionView = new CollectionView()


### PR DESCRIPTION
You can now set `FooterTemplate` to `BottomSheetPickerConfiguration` to add footer content to the bottom sheet's internal `CollectionView`.