### PR TITLE
Added `ResetBehaviour` property to `MultiItemsPicker` to enable a button for resetting selected items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [45.5.0]
+- [MultiItemsPicker] Added `ResetBehaviour` property to `MultiItemsPicker` to enable a button for resetting selected items.
+
 ## [45.4.0]
 - [ItemPicker][MultiItemsPicker] Added `FooterTemplate` property to `BottomSheetPickerConfiguration` to allow for setting a footer to item picker bottom sheet.
 

--- a/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
@@ -41,7 +41,6 @@
                         FreeTextPrefix="Free text: "/>
         <dui:Label Text="MultiItemsPicker"
                    Margin="5" />
-        
         <dui:MultiItemsPicker VerticalOptions="Start"
                               Placeholder="{x:Static localizedStrings:LocalizedStrings.To}"
                               HorizontalOptions="Start"
@@ -50,7 +49,11 @@
             <dui:MultiItemsPicker.BottomSheetPickerConfiguration>
                 <dui:BottomSheetPickerConfiguration Title="Select multiple"/>
             </dui:MultiItemsPicker.BottomSheetPickerConfiguration>
+            <dui:MultiItemsPicker.ResetBehaviour>
+                <dui:ResetBehaviour Command="{Binding ClearPeopleCommand, Mode=OneWay}"/>
+            </dui:MultiItemsPicker.ResetBehaviour>
         </dui:MultiItemsPicker>
+        
         <dui:Label Text="SegmentedControl: Mode: Single"
                    Margin="5" />
         

--- a/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamplesViewModel.cs
+++ b/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamplesViewModel.cs
@@ -1,3 +1,4 @@
+using System.Windows.Input;
 using Components.SampleData;
 using DIPS.Mobile.UI.MVVM;
 
@@ -7,6 +8,17 @@ public class ItemPickersSamplesViewModel : ViewModel
 {
     private Person m_selectedPerson;
     private List<Person> m_selectedItems = [SampleDataStorage.People[1]];
+
+    public ItemPickersSamplesViewModel()
+    {
+        ClearPeopleCommand = new Command(ClearPeople);
+    }
+
+    private void ClearPeople()
+    {
+        SelectedItems = [SampleDataStorage.People[1]];
+    }
+
     public IEnumerable<Person> People { get; } = SampleDataStorage.People;
 
     public Person SelectedPerson
@@ -42,4 +54,6 @@ public class ItemPickersSamplesViewModel : ViewModel
 
         return new Person(firstName, lastName, middleName);
     };
+
+    public ICommand ClearPeopleCommand { get; }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPicker.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPicker.Properties.cs
@@ -103,8 +103,9 @@ public partial class MultiItemsPicker
     public ICommand OpenCommand { get; }
 
     /// <summary>
-    /// Defines how the picker should handle resetting its selected items. Setting this property to null will disable
-    /// any reset behaviour.
+    /// Defines how the picker should handle resetting its selected items. Setting it will make a "Reset"-button appear
+    /// in the picker's bottom sheet, which will reset the list. Set the <see cref="ResetBehaviour.Command"/> property
+    /// to override the reset method.
     /// </summary>
     public ResetBehaviour? ResetBehaviour { get; set; }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPicker.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPicker.Properties.cs
@@ -101,4 +101,10 @@ public partial class MultiItemsPicker
     /// Opens the picker.
     /// </summary>
     public ICommand OpenCommand { get; }
+
+    /// <summary>
+    /// Defines how the picker should handle resetting its selected items. Setting this property to null will disable
+    /// any reset behaviour.
+    /// </summary>
+    public ResetBehaviour? ResetBehaviour { get; set; }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPicker.cs
@@ -32,6 +32,8 @@ public partial class MultiItemsPicker : ContentView
         m_currentDeviceOrientation = DeviceDisplay.Current.MainDisplayInfo.Orientation;
     }
 
+    
+    internal Button? ClearButton { get; }
 
     private void MainDisplayInfoChanged(object? sender, DisplayInfoChangedEventArgs e)
     {
@@ -120,6 +122,15 @@ public partial class MultiItemsPicker : ContentView
 
         SelectedItemsCommand?.Execute(SelectedItems);
         DidSelectItem?.Invoke(this, item);
+    }
+
+    public void ClearSelectedItems()
+    {
+        if (SelectedItems is null) return;
+
+        SelectedItems = new List<object>();
+        
+        SelectedItemsCommand?.Execute(SelectedItems);
     }
 
     private void OnSelectedItemsChanged()

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPickerBottomSheet.cs
@@ -48,7 +48,9 @@ internal class MultiItemsPickerBottomSheet : BottomSheet
             
             var button = new Button
             {
-                Style = Styles.GetButtonStyle(ButtonStyle.SecondaryLarge), Text = DUILocalizedStrings.Reset,
+                Style = Styles.GetButtonStyle(ButtonStyle.SecondaryLarge), 
+                Text = DUILocalizedStrings.Reset,
+                VerticalOptions = LayoutOptions.End,
                 Command = new Command(ClearSelectedItems)
             };
             

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/ResetBehaviour.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/ResetBehaviour.cs
@@ -1,0 +1,21 @@
+using System.Windows.Input;
+
+namespace DIPS.Mobile.UI.Components.Pickers.MultiItemsPicker;
+
+public class ResetBehaviour : BindableObject
+{
+    public static readonly BindableProperty CommandProperty = BindableProperty.Create(
+        nameof(Command),
+        typeof(ICommand),
+        typeof(ResetBehaviour));
+
+    /// <summary>
+    /// Custom command when the reset button is pressed. Set this if you need to set a custom value when the list is reset.
+    /// If no command has been set, it will simply clear all selected items.
+    /// </summary>
+    public ICommand? Command
+    {
+        get => (ICommand)GetValue(CommandProperty);
+        set => SetValue(CommandProperty, value);
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.Designer.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.Designer.cs
@@ -380,5 +380,11 @@ namespace DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings {
                 return ResourceManager.GetString("ViewCode", resourceCulture);
             }
         }
+        
+        internal static string Reset {
+            get {
+                return ResourceManager.GetString("Reset", resourceCulture);
+            }
+        }
     }
 }

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.en.resx
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.en.resx
@@ -179,4 +179,7 @@
     <data name="Rotate" xml:space="preserve">
         <value>Rotate</value>
     </data>
+    <data name="Reset" xml:space="preserve">
+        <value>Reset</value>
+    </data>
 </root>

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.resx
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.resx
@@ -186,4 +186,7 @@
     <data name="ViewCode" xml:space="preserve">
         <value />
     </data>
+    <data name="Reset" xml:space="preserve">
+        <value>Tilbakestill</value>
+    </data>
 </root>


### PR DESCRIPTION
### Description of Change
Added a `ResetBehaviour` property to `MultiItemsPicker`. Setting this property will display a "Reset"-button at the bottom of the picker's bottom sheet. This button will by default clear all selected items. The `ResetBehaviour.Command` property can be set to override how the list should be modified when the button is pressed.

### Todos
- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility