### PR TITLE
[SearchBar][iOS] Keep cancel button enabled when losing focus on search bar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [45.6.1]
+- [SearchBar][iOS] Keep cancel button enabled when losing focus on search bar.
+
 ## [45.6.0]
 - [SearchBar][iOS] Setting cancel button visibility in runtime will now animate.
 

--- a/src/app/Playground/MauiProgram.cs
+++ b/src/app/Playground/MauiProgram.cs
@@ -16,6 +16,7 @@ public static class MauiProgram
             {
                 options.HandleContextMenuGlobalClicks(OnContextMenuItemClicked);
                 /*options.EnableAutomaticMemoryLeakResolving();*/
+                options.EnableCustomHideSoftInputOnTapped();
             });
         
         builder.ConfigureFonts(fonts =>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -14,16 +14,17 @@
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
 
-    <Grid RowDefinitions="Auto, Auto, *">
+    <Grid RowDefinitions="Auto, Auto, *"
+          >
         
         <dui:SearchBar HasCancelButton="True"
-                       IsVisible="False"
-                       CancelButtonTextColor="Green"
+                       CancelButtonTextColor="{dui:Colors color_primary_90}"
+                       CancelCommand="{Binding CancelCommand}"
                        x:Name="SearchBar"/>
              
         <dui:Button Text="Lol"
                     Grid.Row="1"
-                    Clicked="Button_OnClicked"></dui:Button>
+                    ></dui:Button>
         
     </Grid>
 

--- a/src/library/DIPS.Mobile.UI/Components/Searching/iOS/SearchBarHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Searching/iOS/SearchBarHandler.cs
@@ -155,6 +155,8 @@ internal partial class SearchBarHandler : ViewHandler<SearchBar, DuiSearchBar>
         base.ConnectHandler(platformView);
 
         platformView.SearchBarStyle = UISearchBarStyle.Minimal;
+        
+        VirtualView.Unfocused += VirtualViewOnUnfocused;
 
         if (platformView.SearchTextField.LeftView is UIImageView uiImageView) //Magnifier icon on the left
         {
@@ -162,6 +164,15 @@ internal partial class SearchBarHandler : ViewHandler<SearchBar, DuiSearchBar>
         }
 
         SubscribeToEvents();
+    }
+
+    private async void VirtualViewOnUnfocused(object? sender, EventArgs e)
+    {
+        var cancelButton = PlatformView.FindChildView<UIButton>();
+        if (cancelButton is null)
+            return;
+        await Task.Delay(1);
+        cancelButton.Enabled = true;
     }
 
     private void SubscribeToEvents()

--- a/src/library/DIPS.Mobile.UI/Components/Searching/iOS/SearchBarHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Searching/iOS/SearchBarHandler.cs
@@ -220,6 +220,8 @@ internal partial class SearchBarHandler : ViewHandler<SearchBar, DuiSearchBar>
             clearButton.TouchUpInside -= OnClearButtonClicked;
         }
 
+        VirtualView.Unfocused -= VirtualViewOnUnfocused;
+        
         InternalSearchBar.Focused -= OnInternalSearchBarFocused;
         InternalSearchBar.Unfocused -= OnInternalSearchBarUnFocused;
     }


### PR DESCRIPTION
### Description of Change

iOS default sets the cancel button to disabled if search bar loses focus. We do not want this to happen.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->