### PR TITLE
Added possibility for adding a "Done" button to MultiItemsPicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [45.7.0]
+- [MultiItemsPicker] Added property `HasDoneButton` for displaying a done button in the bottom sheet
+- [BottomSheet] Added property `IsCloseButtonVisible` for controlling whether the close button should be visible in the header
+
 ## [45.6.1]
 - [SearchBar][iOS] Keep cancel button enabled when losing focus on search bar.
 

--- a/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
@@ -44,6 +44,7 @@
         <dui:MultiItemsPicker VerticalOptions="Start"
                               Placeholder="{x:Static localizedStrings:LocalizedStrings.To}"
                               HorizontalOptions="Start"
+                              HasDoneButton="True"
                               SelectedItems="{Binding SelectedItems, Mode=TwoWay}"
                               ItemsSource="{x:Static sampleData:SampleDataStorage.People}">
             <dui:MultiItemsPicker.BottomSheetPickerConfiguration>

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/BottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/BottomSheet.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using DIPS.Mobile.UI.Components.BottomSheets.Header;
 using DIPS.Mobile.UI.Internal;
 using Colors = Microsoft.Maui.Graphics.Colors;
 using SearchBar = DIPS.Mobile.UI.Components.Searching.SearchBar;
@@ -18,6 +19,8 @@ namespace DIPS.Mobile.UI.Components.BottomSheets
             this.SetAppThemeColor(BackgroundColorProperty, BackgroundColorName);
 
             BottombarButtons = new ObservableCollection<Button>();
+
+            BottomSheetHeaderBehavior = new BottomSheetHeaderBehavior();
 
             SearchBar = new SearchBar { AutomationId = "SearchBar".ToDUIAutomationId<BottomSheet>(), HasCancelButton = false, BackgroundColor = Colors.Transparent};
             SearchBar.TextChanged += OnSearchTextChanged;

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/Header/BottomSheetHeader.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/Header/BottomSheetHeader.cs
@@ -65,6 +65,8 @@ internal class BottomSheetHeader : Grid
         
         SemanticProperties.SetDescription(closeButton, DUILocalizedStrings.Close);
         
+        closeButton.SetBinding(IsVisibleProperty, static (BottomSheetHeaderBehavior headerBehavior) => headerBehavior.IsBackButtonVisible, source: m_bottomSheet.BottomSheetHeaderBehavior);
+        
         this.Add(closeButton, 1);
     }
 

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/Header/BottomSheetHeaderBehavior.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/Header/BottomSheetHeaderBehavior.cs
@@ -42,10 +42,22 @@ public class BottomSheetHeaderBehavior : BindableObject
         set => SetValue(CloseButtonCommandProperty, value);
     }
 
+    /// <summary>
+    /// Whether the back button should be visible in the header.
+    /// </summary>
     public bool IsBackButtonVisible
     {
         get => (bool)GetValue(IsBackButtonVisibleProperty);
         set => SetValue(IsBackButtonVisibleProperty, value);
+    }
+    
+    /// <summary>
+    /// Whether the close button should be visible in the header.
+    /// </summary>
+    public bool IsCloseButtonVisible
+    {
+        get => (bool)GetValue(IsCloseButtonVisibleProperty);
+        set => SetValue(IsCloseButtonVisibleProperty, value);
     }
 
     /// <summary>
@@ -77,6 +89,12 @@ public class BottomSheetHeaderBehavior : BindableObject
         nameof(IsBackButtonVisible),
         typeof(bool),
         typeof(BottomSheetHeaderBehavior));
+
+    public static readonly BindableProperty IsCloseButtonVisibleProperty = BindableProperty.Create(
+        nameof(IsCloseButtonVisible),
+        typeof(bool),
+        typeof(BottomSheetHeaderBehavior),
+        true);
     
     public static readonly BindableProperty IsTitleAndBackButtonContainerEnabledProperty = BindableProperty.Create(
         nameof(IsTitleAndBackButtonContainerEnabled),

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPicker.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPicker.Properties.cs
@@ -96,6 +96,22 @@ public partial class MultiItemsPicker
         get => (string)GetValue(PlaceholderProperty);
         set => SetValue(PlaceholderProperty, value);
     }
+
+    public static readonly BindableProperty HasDoneButtonBindableProperty = BindableProperty.Create(
+        nameof(HasDoneButton),
+        typeof(bool),
+        typeof(MultiItemsPicker));
+
+    /// <summary>
+    /// Whether the bottom sheet should have a "Done" button, which will close the bottom sheet when tapped. Setting
+    /// this to true will also disallow people from closing the bottom sheet by dragging it down or tapping outside it,
+    /// and also hide the close button in the header.
+    /// </summary>
+    public bool HasDoneButton
+    {
+        get => (bool)GetValue(HasDoneButtonBindableProperty);
+        set => SetValue(HasDoneButtonBindableProperty, value);
+    }
     
     /// <summary>
     /// Opens the picker.

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPickerBottomSheet.cs
@@ -1,9 +1,12 @@
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using DIPS.Mobile.UI.Components.BottomSheets;
 using DIPS.Mobile.UI.Components.ListItems;
 using DIPS.Mobile.UI.Components.ListItems.Extensions;
 using DIPS.Mobile.UI.Components.Pickers.ItemPicker;
+using DIPS.Mobile.UI.Converters.ValueConverters;
 using DIPS.Mobile.UI.Effects.Touch;
+using DIPS.Mobile.UI.MVVM.Commands;
 using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
 using DIPS.Mobile.UI.Resources.Styles;
 using DIPS.Mobile.UI.Resources.Styles.Button;
@@ -26,7 +29,8 @@ internal class MultiItemsPickerBottomSheet : BottomSheet
 
         this.SetBinding(TitleProperty, static (BottomSheetPickerConfiguration configuration) => configuration.Title, source: m_multiItemsPicker.BottomSheetPickerConfiguration);
         this.SetBinding(HasSearchBarProperty, static (BottomSheetPickerConfiguration bottomSheetPickerConfiguration) => bottomSheetPickerConfiguration.HasSearchBar, source: m_multiItemsPicker.BottomSheetPickerConfiguration);
-
+        this.SetBinding(IsInteractiveCloseableProperty, static (MultiItemsPicker multiItemsPicker) => multiItemsPicker.HasDoneButton, source: m_multiItemsPicker, converter: new InvertedBoolConverter());
+        
         var collectionView = new CollectionView()
         {
             ItemTemplate = new DataTemplate(LoadTemplate), Margin = Sizes.GetSize(SizeName.content_margin_small)
@@ -42,20 +46,32 @@ internal class MultiItemsPickerBottomSheet : BottomSheet
         
         Content = ItemPickerBottomSheet.CreateContentControlForActivityIndicator(collectionView, m_multiItemsPicker.BottomSheetPickerConfiguration);
 
-        if (m_multiItemsPicker.ResetBehaviour is not null)
+        AddBottomBarButtons();
+    }
+
+    private void AddBottomBarButtons()
+    {
+        TryAddResetButton();
+
+        AddDoneButton();
+    }
+
+    private void TryAddResetButton()
+    {
+        if (m_multiItemsPicker.ResetBehaviour is null) return;
+
+        m_multiItemsPicker.ResetBehaviour.SetBinding(BindingContextProperty, static (MultiItemsPicker picker) => picker.BindingContext, source: m_multiItemsPicker);
+            
+        var button = new Button
         {
-            m_multiItemsPicker.ResetBehaviour.SetBinding(BindingContextProperty, static (MultiItemsPicker picker) => picker.BindingContext, source: m_multiItemsPicker);
+            Style = Styles.GetButtonStyle(ButtonStyle.SecondaryLarge), 
+            Text = DUILocalizedStrings.Reset,
+            VerticalOptions = LayoutOptions.End,
+            HorizontalOptions = LayoutOptions.Center,
+            Command = new Command(ClearSelectedItems)
+        };
             
-            var button = new Button
-            {
-                Style = Styles.GetButtonStyle(ButtonStyle.SecondaryLarge), 
-                Text = DUILocalizedStrings.Reset,
-                VerticalOptions = LayoutOptions.End,
-                Command = new Command(ClearSelectedItems)
-            };
-            
-            BottombarButtons.Add(button);
-        }
+        BottombarButtons.Add(button);
     }
 
     private void LoadItemsFromPicker(MultiItemsPicker multiItemsPicker)
@@ -78,6 +94,22 @@ internal class MultiItemsPickerBottomSheet : BottomSheet
         }
 
         Items = new ObservableCollection<SelectableItemViewModel>(m_originalItems);
+    }
+
+    private void AddDoneButton()
+    {
+        if (!m_multiItemsPicker.HasDoneButton) return;
+        
+        var doneButton = new Button
+        {
+            Style = Styles.GetButtonStyle(ButtonStyle.PrimaryLarge),
+            Text = DUILocalizedStrings.Done,
+            VerticalOptions = LayoutOptions.End,
+            HorizontalOptions = LayoutOptions.Center,
+            Command = new AsyncCommand(() => Close())
+        };
+        
+        BottombarButtons.Add(doneButton);
     }
 
     private void ClearSelectedItems()


### PR DESCRIPTION
### Description of Change
Added `HasDoneButton` property to `MultiItemsPicker` to display a "Done" button and disable closing the bottom sheet otherwise. Also added `IsCloseButtonVisible` property to `BottomSheetHeaderBehavior` to control visibility of close button.

### Todos
- [ ] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->