### PR TITLE
[iOS] Fixed freeze when showing barcode result.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [45.7.4]
+- [iOS] Fixed freeze when showing barcode result.
+
 ## [45.7.3]
 - [Searchbar][Android] `AndroidBusyBackgroundColor` will now show if `IsBusy` is set to false.
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScanResultView.xaml
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScanResultView.xaml
@@ -41,6 +41,7 @@
         </listitemsExtensions:NavigationListItem>
         <lists:CollectionView Grid.Row="2"
                               VerticalScrollBarVisibility="Never"
+                              HasAdditionalSpaceAtTheEnd="False"
                               ItemsSource="{Binding BarcodeScanResult.Observations}"
                               Header="."
                               IsVisible="{Binding BarcodeScanResult.HasMultipleObservations}"

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScanResultView.xaml
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScanResultView.xaml
@@ -39,6 +39,7 @@
                                                 Tapped="OnAndroidFormatTapped"
                                                 Subtitle="{Binding BarcodeScanResult.Barcode.Format}">
         </listitemsExtensions:NavigationListItem>
+        <!-- TODO: Figure out why HasAdditionalSpaceAtTheEnd set to true freezes the app -->
         <lists:CollectionView Grid.Row="2"
                               VerticalScrollBarVisibility="Never"
                               HasAdditionalSpaceAtTheEnd="False"


### PR DESCRIPTION
### Description of Change

Somehow, turning off additional space fixes the freeze. The additional spacing functions correctly everywhere else. This is a quick fix to make it not freeze. We should look into why it happens at a later time

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->