### PR TITLE
[ItemPickerBottomSheet]Fix duplicates when filtering in itempicker bottomsheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 - Fix duplicates when filtering in ItemPicker BottomSheet
 
 ## [45.8.1]
-- Fix duplicates when filtering in ItemPicker BottomSheet
 - [ListItem][CollectionView][iOS] ListItem's divider in a CollectionView will now no longer expand its height.
 
 ## [45.8.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [45.8.1]
+- Fix duplicates when filtering in ItemPicker BottomSheet
+
 ## [45.8.0]
 - Imported new colors.
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -201,7 +201,6 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                 var couldCreateFreeTextItem = true;
                 foreach (var item in filteredItems)
                 {
-                    itemsToAdd.Add(item);
                     if (item.DisplayName.Equals(filterText))
                     {
                         couldCreateFreeTextItem = false;


### PR DESCRIPTION
Problem: When searching in the item picker for bottom sheet, the result items are duplicated

Resolution: The matching items were added twice to the filteredItems, so removed one of the add lines