### PR TITLE
[ListItem][CollectionView][iOS] ListItem's divider in a CollectionView will now no longer have weird positioning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [45.8.2]
+- [ListItem][CollectionView][iOS] ListItem's divider in a CollectionView will now no longer have weird positioning.
+
 ## [45.8.1]
 - [ListItem][CollectionView][iOS] ListItem's divider in a CollectionView will now no longer expand its height.
 

--- a/src/app/Playground/VetleSamples/CollectionViewTests/GroupedCollectionView.xaml
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/GroupedCollectionView.xaml
@@ -53,7 +53,7 @@
                 <Grid RowDefinitions="Auto, Auto">
                     <dui:ListItem Title="{Binding .}"
                                   Command="{Binding Source={RelativeSource AncestorType={x:Type collectionViewTests:GroupedCollectionViewModel}}, Path=AddItemAtMiddleInSectionCommand}"
-                                  HasTopDivider="True">
+                                  HasBottomDivider="True">
                         
                         
                         

--- a/src/app/Playground/VetleSamples/CollectionViewTests/GroupedCollectionViewModel.cs
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/GroupedCollectionViewModel.cs
@@ -20,7 +20,7 @@ public class GroupedCollectionViewModel : ViewModel
     
     public ICommand AddItemAtEndInSectionCommand => new Command(() =>
     {
-        GroupedTest[0].Add("Test7");
+        GroupedTest[0].Add($"Test {GroupedTest[0].Count}");
     });
     
     public ICommand AddItemAtStartInSectionCommand => new Command(() =>

--- a/src/app/Playground/VetleSamples/CollectionViewTests/RegularCollectionView.xaml
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/RegularCollectionView.xaml
@@ -10,7 +10,7 @@
         <collectionViewTests:RegularCollectionViewModel />
     </ContentPage.BindingContext>
     
-    <dui:CollectionView ItemsSource="{Binding TestStrings}"
+    <dui:CollectionView ItemsSource="{Binding TestItems}"
                         x:Name="CollectionView"
                         HasAdditionalSpaceAtTheEnd="True"
                         BackgroundColor="Transparent"
@@ -36,19 +36,12 @@
             <DataTemplate>
                 
                     <Grid RowDefinitions="Auto, Auto">
-                        <dui:ListItem Title="{Binding .}">
+                        <dui:ListItem Title="{Binding Name}"
+                                      HasBottomDivider="True">
                             
-                            <dui:ListItem.UnderlyingContent>
-                                <Grid Padding="8">
-                                    <dui:Label Text="{Binding .}"
-                                               TextColor="{dui:Colors color_neutral_60}" />
-                                    
-                                    <dui:Divider VerticalOptions="End" />
-                                </Grid>
-                            </dui:ListItem.UnderlyingContent>
+                           
                             
                         </dui:ListItem>
-                        <dui:Divider VerticalOptions="End" />
                     </Grid>
             </DataTemplate>
         </dui:CollectionView.ItemTemplate>

--- a/src/app/Playground/VetleSamples/CollectionViewTests/RegularCollectionView2.xaml
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/RegularCollectionView2.xaml
@@ -52,17 +52,17 @@
         
         <dui:CollectionView2.ItemTemplate>
             <DataTemplate>
-                <Grid RowDefinitions="Auto, Auto">
+                <Grid RowDefinitions="Auto">
                     <dui:ListItem Title="{Binding .}">
                         
-                        <dui:ListItem.UnderlyingContent>
+                        <!--<dui:ListItem.UnderlyingContent>
                             <Grid Padding="8">
                                 <dui:Label Text="{Binding .}"
                                            TextColor="{dui:Colors color_neutral_60}" />
                                 
                                 <dui:Divider VerticalOptions="End" />
                             </Grid>
-                        </dui:ListItem.UnderlyingContent>
+                        </dui:ListItem.UnderlyingContent>-->
                         
                     </dui:ListItem>
                     <dui:Divider VerticalOptions="End" />

--- a/src/library/DIPS.Mobile.UI/API/Builder/AppHostBuilderExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Builder/AppHostBuilderExtensions.cs
@@ -2,6 +2,7 @@ using DIPS.Mobile.UI.API.Camera.Preview;
 using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.Components.BottomSheets;
 using DIPS.Mobile.UI.Components.ContextMenus;
+using DIPS.Mobile.UI.Components.Dividers;
 using DIPS.Mobile.UI.Components.Images.NativeIcon;
 using DIPS.Mobile.UI.Components.Navigation.FloatingNavigationButton;
 using DIPS.Mobile.UI.Components.Pickers.ScrollPicker;
@@ -63,6 +64,7 @@ public static partial class AppHostBuilderExtensions
             handlers.AddHandler<ScrollPicker, ScrollPickerHandler>();
             handlers.AddHandler<Components.Shell.Shell, ShellRenderer>();
             handlers.AddHandler<PreviewView, PreviewViewHandler>();
+            handlers.AddHandler<Divider, DividerHandler>();
             
             AddPlatformHandlers(handlers);
         });

--- a/src/library/DIPS.Mobile.UI/Components/Dividers/Android/DividerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Dividers/Android/DividerHandler.cs
@@ -1,0 +1,6 @@
+namespace DIPS.Mobile.UI.Components.Dividers;
+
+internal partial class DividerHandler
+{
+    
+}

--- a/src/library/DIPS.Mobile.UI/Components/Dividers/Divider.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Dividers/Divider.cs
@@ -1,17 +1,17 @@
-using System.Collections;
 using DIPS.Mobile.UI.Internal;
-using Microsoft.Maui.Controls.Shapes;
 
 namespace DIPS.Mobile.UI.Components.Dividers;
 
-public class Divider : ContentView
+public class Divider : BoxView
 {
+    internal static string s_automationId = "Divider".ToDUIAutomationId<Divider>();
+    
     public Divider()
     {
         this.SetAppThemeColor(BackgroundColorProperty, ColorName.color_stroke_default);
 
-        var line = new Line{ AutomationId = "Line".ToDUIAutomationId<Divider>()};
-        line.SetBinding(BackgroundProperty, static (Divider divider) => divider.BackgroundColor, source: this);
-        Content = line;
+        HeightRequest = 1;
+
+        AutomationId = s_automationId;
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Dividers/DividerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Dividers/DividerHandler.cs
@@ -1,0 +1,8 @@
+using Microsoft.Maui.Controls.Handlers;
+
+namespace DIPS.Mobile.UI.Components.Dividers;
+
+internal partial class DividerHandler : BoxViewHandler
+{
+    
+}

--- a/src/library/DIPS.Mobile.UI/Components/Dividers/dotnet/DividerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Dividers/dotnet/DividerHandler.cs
@@ -1,0 +1,6 @@
+namespace DIPS.Mobile.UI.Components.Dividers;
+
+internal partial class DividerHandler
+{
+    
+}

--- a/src/library/DIPS.Mobile.UI/Components/Dividers/iOS/DividerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Dividers/iOS/DividerHandler.cs
@@ -1,0 +1,27 @@
+using Microsoft.Maui.Platform;
+
+namespace DIPS.Mobile.UI.Components.Dividers;
+
+internal partial class DividerHandler
+{
+    protected override MauiShapeView CreatePlatformView()
+    {
+        return new DividerShapeView { WeakVirtualView = new WeakReference<Divider>((Divider)VirtualView) };
+    }
+}
+
+internal class DividerShapeView : MauiShapeView
+{
+    public WeakReference<Divider>? WeakVirtualView { private get; init; }
+    
+    public Divider? VirtualView
+    {
+        get
+        {
+            if (WeakVirtualView?.TryGetTarget(out var target) ?? false)
+                return target;
+
+            return null;
+        }
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/iOS/CollectionViewHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/iOS/CollectionViewHandler.cs
@@ -108,10 +108,10 @@ internal class ReordeableItemsViewController(ReorderableItemsView reorderableIte
         Divider? divider = null;
         cell.BreadthFirstSearchChildrenUntilMatch(view =>
         {
-            if (view is not ContentView { CrossPlatformLayout: Divider crossPlatformLayout })
+            if (view is not DividerShapeView dividerShapeView)
                 return false;
 
-            divider = crossPlatformLayout;
+            divider = dividerShapeView.VirtualView;
             return true;
         });
 
@@ -121,14 +121,14 @@ internal class ReordeableItemsViewController(ReorderableItemsView reorderableIte
         if (IsLastItemInSection(collectionView, indexPath))
         {
             if(currentDividerSetToInvisibleInSection.TryGetValue(indexPath.Section, out var value))
-                value.IsVisible = true;
-            divider.IsVisible = false;
+                value.Opacity = 1;
+            divider.Opacity = 0;
             currentDividerSetToInvisibleInSection[indexPath.Section] = divider;
         }
         else
         {
             // Reset the divider for all other cells, because of virtualization
-            divider.IsVisible = true;
+            divider.Opacity = 1;
         }
     }
 


### PR DESCRIPTION
### Description of Change

First of all, Divider is refactored so that it is more lightweight. A BoxView is all you really need. But the real fix was setting Opacity to 0/1 instead of IsVisible to false/true, avoiding some layout calculations, which messed up the divider in a list.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->