### PR TITLE
[BottomSheet][Android] Focusing `SearchBar` will now expand the `BottomSheet`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [45.9.0]
+- [BottomSheet][Android] Focusing `SearchBar` will now expand the `BottomSheet`.
+
 ## [45.8.3]
 - [ListItem][CollectionView][iOS] ListItem's divider in a CollectionView will now no longer have weird positioning.
 

--- a/src/app/Playground/VetleSamples/BottomSheetWithToolbar.xaml
+++ b/src/app/Playground/VetleSamples/BottomSheetWithToolbar.xaml
@@ -11,6 +11,7 @@
                  Padding="{dui:Thickness Left=size_1, Top=size_1}"
                  Title="Hello yes"
                  IsInteractiveCloseable="False"
+                 HasSearchBar="True"
                  OnBackButtonPressedCommand="{Binding CloseCommand}">
 
     <dui:BottomSheet.BindingContext>
@@ -28,6 +29,7 @@
     
     
     <VerticalStackLayout>
+        <dui:Editor />
         <dui:Button Text="Hello" HorizontalOptions="Start"
                     Command="{Binding TestCommand}" />
         <dui:Button Text="Enabled" HorizontalOptions="Start"

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -16,13 +16,9 @@
 
     <Grid RowDefinitions="Auto, Auto, *">
         
-        <dui:SingleLineInputField Text="{Binding TestString}"
-                                  HeaderText="Hello"/>
         
-        <dui:MultiLineInputField Text="{Binding TestString}"
-                                 HeaderText="Hello"
-                                 Grid.Row="1"/>
-<dui:SearchBar ></dui:SearchBar>        
+        <dui:Button Command="{dui:OpenBottomSheetCommand {x:Type vetleSamples:BottomSheetWithToolbar}}"></dui:Button>
+        
     </Grid>
 
 


### PR DESCRIPTION
### Description of Change

For better consistency with iOS

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->