### PR TITLE
[CollectionView][Image] Handle resetting image tint colors on iOS and Android to avoid tint artifacts caused by view recycling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [45.9.2]
+- [CollectionView][Image] Handle resetting image tint colors on iOS and Android to avoid tint artifacts caused by view recycling.
+
 ## [45.9.1]
 - [MultiItemsPicker] Set BindingContext to BottomSheetPickerConfiguration inside MultiItemsPicker
 

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -14,12 +14,27 @@
         <vetleSamples:VetlePageViewModel />
     </dui:ContentPage.BindingContext>
 
-    <Grid RowDefinitions="Auto, Auto, *">
         
         
-        <dui:Button Command="{dui:OpenBottomSheetCommand {x:Type vetleSamples:BottomSheetWithToolbar}}"></dui:Button>
+        <dui:CollectionView ItemsSource="{Binding TestObjects}">
+            
+            <dui:CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid ColumnDefinitions="Auto, 50">
+                        
+                        <dui:Label Text="{Binding Name}"
+                                   FontSize="25"/>
+                        
+                        <dui:Image TintColor="{Binding IconColor}"
+                                    Source="{dui:Icons criticalinfo_fill}"
+                                   Grid.Column="1" />
+                        
+                    </Grid>
+                </DataTemplate>
+            </dui:CollectionView.ItemTemplate>
+            
+        </dui:CollectionView>
         
-    </Grid>
 
 
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePageViewModel.cs
+++ b/src/app/Playground/VetleSamples/VetlePageViewModel.cs
@@ -86,10 +86,6 @@ public class VetlePageViewModel : ViewModel
             IsSavingCompleted = true;
         });
         
-        TestObjects.Add(new TestObject(CheckCommand));
-        TestObjects.Add(new TestObject(CheckCommand));
-        TestObjects.Add(new TestObject(CheckCommand));
-        TestObjects.Add(new TestObject(CheckCommand));
 
         
         GroupedTest = [new(["Test"]), new(TestStrings.ToList())];
@@ -237,7 +233,8 @@ public class VetlePageViewModel : ViewModel
         /*TestStrings.Remove(firstOrDefault);*/
     });
 
-    public List<TestObject> TestObjects { get; } = new List<TestObject>();
+    // Create many
+    public List<TestObject> TestObjects { get; } = [new TestObject(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new(), new()];
     
     public ICommand Navigate { get; }
     public ICommand SaveSuccess { get; }
@@ -502,12 +499,25 @@ class SortOptionComparer : IComparer<string>
 }
 public class TestObject
 {
-    public TestObject(ICommand command)
+    public TestObject()
     {
-        Command = command;
+        
+        var random = new Random().Next(0, 2);
+        if (random == 0)
+        {
+            IconColor = Colors.Red;
+            Name = "Has Color";
+        }
+        else
+        {
+            Name = "No Color";
+        }
+        
     }
-    
-    public ICommand Command { get; }
+
+    public Color? IconColor { get; }
+    public string Name { get; }
+
 
     public bool IsChecked { get; } = true;
 }

--- a/src/library/DIPS.Mobile.UI/Components/Images/Image/Android/ImageHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Images/Image/Android/ImageHandler.cs
@@ -6,7 +6,13 @@ public partial class ImageHandler
 {
     private static partial void TrySetTintColor(ImageHandler handler, Image image)
     {
-        if (image.TintColor == null) return;
-        handler.PlatformView.SetColorFilter(image.TintColor.ToPlatform());
+        if (image.TintColor is null)
+        {
+            handler.PlatformView.ClearColorFilter();
+        }
+        else
+        {
+            handler.PlatformView.SetColorFilter(image.TintColor.ToPlatform());
+        }
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/iOS/IconTintColorHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/iOS/IconTintColorHandler.cs
@@ -80,13 +80,21 @@ internal class IconTintColorHandler : IDisposable
 
     private static void SetUIImageViewTintColor(UIImageView imageView, Color? color)
     {
-        if (imageView.Image is null || color is null)
+        if (imageView.Image is null)
         {
             return;
         }
 
-        imageView.Image = imageView.Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
-        imageView.TintColor = color.ToPlatform();
+        if (color is null)
+        {
+            // Reset to original image colors (no tint)
+            imageView.Image = imageView.Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+        }
+        else
+        {
+            imageView.Image = imageView.Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+            imageView.TintColor = color.ToPlatform();
+        }
     }
 
     public void Dispose()


### PR DESCRIPTION
### Description of Change

This PR addresses issues with image tint colors persisting incorrectly due to view recycling in both iOS and Android UI components.

iOS: Resets the image’s rendering mode to UIImageRenderingMode.AlwaysOriginal and clears TintColor when no tint is specified, preventing leftover tint colors from recycled image views.

Android: Clears the color filter using ClearColorFilter() when no tint color is provided, ensuring recycled views don’t retain previous tint colors.

By properly resetting tint states during view reuse, this update prevents visual artifacts and ensures consistent UI appearance when images are reused in lists or other recycled views.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->