### PR TITLE
[ImageThumbnailView] Fix position of close button on image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [45.9.5]
+- [ImageThumbnailView] Fix position of close button on image
+
 ## [45.9.4]
 - [ItemPickerBottomSheet] Prevent the bindingcontext from being displayed in the bottom sheet in Android
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/Gallery/ImageThumbnailView/ImageThumbnailView.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Gallery/ImageThumbnailView/ImageThumbnailView.cs
@@ -59,9 +59,6 @@ internal class ImageThumbnailView : Grid
             WidthRequest = Sizes.GetSize(SizeName.size_5),
             VerticalOptions = LayoutOptions.Start,
             HorizontalOptions = LayoutOptions.End,
-#if __IOS__
-            Margin = new Thickness(0, Sizes.GetSize(SizeName.content_margin_small), Sizes.GetSize(SizeName.content_margin_small), 0),
-#endif
             Content = new Image
             {
                 TintColor = Colors.GetColor(ColorName.color_icon_default),


### PR DESCRIPTION
Problem: Close button on an image were placed inside of the image instead of on the corner on iOS
Solution: Remove the Margin