### PR TITLE
[BottomSheet][Android] Focusing any `SearchBar` in `BottomSheet` will now expand the `BottomSheet`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [45.9.6]
+- [BottomSheet][Android] Focusing any `SearchBar` in `BottomSheet` will now expand the `BottomSheet`.
+
 ## [45.9.5]
 - [ImageThumbnailView] Fix position of close button on image
 

--- a/src/app/Playground/VetleSamples/BottomSheetWithToolbar.xaml
+++ b/src/app/Playground/VetleSamples/BottomSheetWithToolbar.xaml
@@ -29,11 +29,7 @@
     
     
     <VerticalStackLayout>
-        <dui:Editor />
-        <dui:Button Text="Hello" HorizontalOptions="Start"
-                    Command="{Binding TestCommand}" />
-        <dui:Button Text="Enabled" HorizontalOptions="Start"
-                    Command="{Binding TestCommand2}" />
+        <dui:SearchBar />
     </VerticalStackLayout>
 
     

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -16,24 +16,7 @@
 
         
         
-        <dui:CollectionView ItemsSource="{Binding TestObjects}">
-            
-            <dui:CollectionView.ItemTemplate>
-                <DataTemplate>
-                    <Grid ColumnDefinitions="Auto, 50">
-                        
-                        <dui:Label Text="{Binding Name}"
-                                   FontSize="25"/>
-                        
-                        <dui:Image TintColor="{Binding IconColor}"
-                                    Source="{dui:Icons criticalinfo_fill}"
-                                   Grid.Column="1" />
-                        
-                    </Grid>
-                </DataTemplate>
-            </dui:CollectionView.ItemTemplate>
-            
-        </dui:CollectionView>
+        <dui:Button Command="{dui:OpenBottomSheetCommand {x:Type vetleSamples:BottomSheetWithToolbar}}"></dui:Button>
         
 
 

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/Android/BottomSheetHandler.cs
@@ -18,7 +18,10 @@ using RelativeLayout = Android.Widget.RelativeLayout;
 using ADrawableCompat = AndroidX.Core.Graphics.Drawable.DrawableCompat;
 using Paint = Android.Graphics.Paint;
 using System.ComponentModel;
+using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.Components.BottomSheets.Header;
+using SearchBar = DIPS.Mobile.UI.Components.Searching.SearchBar;
+using View = Microsoft.Maui.Controls.View;
 
 namespace DIPS.Mobile.UI.Components.BottomSheets;
 
@@ -34,7 +37,8 @@ public partial class BottomSheetHandler : ContentViewHandler
     private static AView? s_mEmptyNonFitToContentView;
     private AView? m_searchBarView;
     private BottomSheetHeader m_bottomSheetHeader;
-    private bool m_setPositioningToLargeUsingSearchBar;
+    private List<WeakReference<SearchBar>> m_weakSearchBars = [];
+    private WeakReference<AView>? m_weakCurrentFocusedSearchBar;
 
     public AView OnBeforeOpening(IMauiContext mauiContext, Context context, AView bottomSheetAndroidView,
         RelativeLayout rootLayout, LinearLayout bottomSheetLayout)
@@ -84,6 +88,7 @@ public partial class BottomSheetHandler : ContentViewHandler
         m_searchBarView = m_bottomSheet.SearchBar.ToPlatform(mauiContext);
         bottomSheetLayout.AddView(m_searchBarView);
         ToggleSearchBar();
+        FindAndSetupSearchBars();
 
         bottomSheetLayout.AddView(bottomSheetAndroidView);
 
@@ -110,31 +115,47 @@ public partial class BottomSheetHandler : ContentViewHandler
             new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, (int)Context.ToPixels(BottomSheet.BottomBarHeight));
             
         rootLayout.AddView(m_bottomBar);
-
+        
         return m_linearLayout = rootLayout;
     }
 
+    private void FindAndSetupSearchBars()
+    {
+        m_weakSearchBars = m_bottomSheet.FindAllChildrenOfType<SearchBar>().Select(sb => new WeakReference<SearchBar>(sb)).ToList();
+
+        foreach (var weakSearchBar in m_weakSearchBars)
+        {
+            if (!weakSearchBar.TryGetTarget(out var searchBar))
+                continue;
+
+            searchBar.Focused += SearchBarOnFocused;
+            searchBar.Unfocused += SearchBarOnUnfocused;
+        }
+        
+        // Also, setup the internal search bar in BottomSheet
+        if (m_bottomSheet.SearchBar is { } searchBarInternal)
+        {
+            searchBarInternal.Focused += SearchBarOnFocused;
+            searchBarInternal.Unfocused += SearchBarOnUnfocused;
+        }
+        
+    }
+
+
     private void ToggleSearchBar()
     {
-        if (m_searchBarView == null) return;
-        if (m_bottomSheet.HasSearchBar)
-        {
-            m_searchBarView.Visibility = ViewStates.Visible;
-            m_bottomSheet.SearchBar.Focused += SearchBarOnFocused;
-            m_bottomSheet.SearchBar.Unfocused += SearchBarOnUnfocused;
-        }
-        else
-        {
-            m_searchBarView.Visibility = ViewStates.Gone;
-        }
+        if (m_searchBarView == null) 
+            return;
+        
+        m_searchBarView.Visibility = m_bottomSheet.HasSearchBar ? ViewStates.Visible : ViewStates.Gone;
     }
 
     private void SearchBarOnUnfocused(object? sender, EventArgs e)
     {
-        if (m_setPositioningToLargeUsingSearchBar)
+        if (m_weakCurrentFocusedSearchBar is not null)
             m_bottomSheet.Positioning = Positioning.Medium;
-        
-        m_setPositioningToLargeUsingSearchBar = false;
+
+        m_weakCurrentFocusedSearchBar = null;
     }
 
     private void SearchBarOnFocused(object? sender, EventArgs e)
@@ -142,8 +163,8 @@ public partial class BottomSheetHandler : ContentViewHandler
         if(m_bottomSheet.Positioning is Positioning.Large)
             return;
         
+        m_weakCurrentFocusedSearchBar = new WeakReference<AView>(((sender as View)!).ToPlatform(DUI.GetCurrentMauiContext!));
         m_bottomSheet.Positioning = Positioning.Large;
-        m_setPositioningToLargeUsingSearchBar = true;
     }
 
     private void ToggleFitToContent(BottomSheet bottomSheet)
@@ -175,7 +196,10 @@ public partial class BottomSheetHandler : ContentViewHandler
         else if (bottomSheet.Positioning == Positioning.Medium)
         {
             bottomSheet.BottomSheetDialog.Behavior.State = BottomSheetBehavior.StateHalfExpanded;
-            handler.m_searchBarView?.ClearFocus();
+            if (handler.m_weakCurrentFocusedSearchBar?.TryGetTarget(out var searchBarNativeView) ?? false)
+            {
+                searchBarNativeView.ClearFocus();
+            }
         }
     }
 
@@ -209,9 +233,22 @@ public partial class BottomSheetHandler : ContentViewHandler
         
         s_mEmptyNonFitToContentView?.RemoveFromParent();
         m_bottomSheetHeader.DisconnectHandlers();
+
+        foreach (var weakSearchBar in m_weakSearchBars)
+        {
+            if (!weakSearchBar.TryGetTarget(out var searchBar))
+                continue;
+
+            searchBar.Focused -= SearchBarOnFocused;
+            searchBar.Unfocused -= SearchBarOnUnfocused;
+        }
         
-        m_bottomSheet.SearchBar.Focused -= SearchBarOnFocused;
-        m_bottomSheet.SearchBar.Unfocused -= SearchBarOnUnfocused;
+        // Also, dispose the internal search bar in BottomSheet
+        if (m_bottomSheet.SearchBar is { } searchBarInternal)
+        {
+            searchBarInternal.Focused -= SearchBarOnFocused;
+            searchBarInternal.Unfocused -= SearchBarOnUnfocused;
+        }
     }
     
     /// <summary>

--- a/src/library/DIPS.Mobile.UI/Extensions/ViewExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/Extensions/ViewExtensions.cs
@@ -96,6 +96,9 @@ public static class ViewExtensions
         return default;
     }
     
+    /// <summary>
+    /// Finds all children of a specific type in the visual tree of the given view.
+    /// </summary>
     public static List<T> FindAllChildrenOfType<T>(this View? view)
     {
         var results = new List<T>();

--- a/src/library/DIPS.Mobile.UI/Extensions/ViewExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/Extensions/ViewExtensions.cs
@@ -96,6 +96,37 @@ public static class ViewExtensions
         return default;
     }
     
+    public static List<T> FindAllChildrenOfType<T>(this View? view)
+    {
+        var results = new List<T>();
+
+        if (view is null)
+            return results;
+
+        var queue = new Queue<View>();
+        queue.Enqueue(view);
+
+        while (queue.Count > 0)
+        {
+            var currentView = queue.Dequeue();
+
+            if (currentView is T matchView)
+                results.Add(matchView);
+
+            if (currentView is IVisualTreeElement visualTreeElement)
+            {
+                foreach (var child in visualTreeElement.GetVisualChildren())
+                {
+                    if (child is View childView)
+                        queue.Enqueue(childView);
+                }
+            }
+        }
+
+        return results;
+    }
+
+    
     public static IEnumerable<Element> GetParentsPath(this Element self)
     {
         var current = self;


### PR DESCRIPTION
### Description of Change

In previous related PR, we only made sure to expand the BottomSheet if the searchbar that is internal in the BottomSheet was focused. Now we expand it if any searchbar inside bottomsheet is focused.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->