### PR TITLE
[MultiItemsPicker] Can now tap outside the `BottomSheet` to close.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [45.9.7]
+- [MultiItemsPicker] Can now tap outside the `BottomSheet` to close.
+- [BottomSheet] `SearchBar` has now `Done` button as default.
+
 ## [45.9.6]
 - [BottomSheet][Android] Focusing any `SearchBar` in `BottomSheet` will now expand the `BottomSheet`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [45.9.7]
 - [MultiItemsPicker] Can now tap outside the `BottomSheet` to close.
-- [BottomSheet] `SearchBar` has now `Done` button as default.
+- [BottomSheet] `SearchBar` has now keyboard `Done` button as default.
 
 ## [45.9.6]
 - [BottomSheet][Android] Focusing any `SearchBar` in `BottomSheet` will now expand the `BottomSheet`.

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/BottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/BottomSheet.cs
@@ -22,7 +22,7 @@ namespace DIPS.Mobile.UI.Components.BottomSheets
 
             BottomSheetHeaderBehavior = new BottomSheetHeaderBehavior();
 
-            SearchBar = new SearchBar { AutomationId = "SearchBar".ToDUIAutomationId<BottomSheet>(), HasCancelButton = false, BackgroundColor = Colors.Transparent};
+            SearchBar = new SearchBar { AutomationId = "SearchBar".ToDUIAutomationId<BottomSheet>(), HasCancelButton = false, BackgroundColor = Colors.Transparent, ReturnKeyType = ReturnType.Done };
             SearchBar.TextChanged += OnSearchTextChanged;
         }
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPickerBottomSheet.cs
@@ -29,7 +29,6 @@ internal class MultiItemsPickerBottomSheet : BottomSheet
 
         this.SetBinding(TitleProperty, static (BottomSheetPickerConfiguration configuration) => configuration.Title, source: m_multiItemsPicker.BottomSheetPickerConfiguration);
         this.SetBinding(HasSearchBarProperty, static (BottomSheetPickerConfiguration bottomSheetPickerConfiguration) => bottomSheetPickerConfiguration.HasSearchBar, source: m_multiItemsPicker.BottomSheetPickerConfiguration);
-        this.SetBinding(IsInteractiveCloseableProperty, static (MultiItemsPicker multiItemsPicker) => multiItemsPicker.HasDoneButton, source: m_multiItemsPicker, converter: new InvertedBoolConverter());
         BottomSheetHeaderBehavior.SetBinding(BottomSheets.Header.BottomSheetHeaderBehavior.IsCloseButtonVisibleProperty, static (MultiItemsPicker multiItemsPicker) => multiItemsPicker.HasDoneButton, source: m_multiItemsPicker, converter: new InvertedBoolConverter());
         
         var collectionView = new CollectionView()


### PR DESCRIPTION
### Description of Change

Additionally, `SearchBar` inside `BottomSheet` now has keyboard `Done` button as default.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->