### PR TITLE
Add `Counter` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [47.5.0]
+- Added `Counter` component
+
 ## [47.4.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/src/app/Components/ComponentsSamples/Counters/CountersSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Counters/CountersSamples.xaml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:dui="http://dips.com/mobile.ui"
+             xmlns:counters="clr-namespace:DIPS.Mobile.UI.Components.Counters;assembly=DIPS.Mobile.UI"
+             xmlns:counters1="clr-namespace:Components.ComponentsSamples.Counters"
+             x:Class="Components.ComponentsSamples.Counters.CountersSamples"
+             x:DataType="counters1:CountersSamplesViewModel">
+    <dui:ContentPage.BindingContext>
+        <counters1:CountersSamplesViewModel/>
+    </dui:ContentPage.BindingContext>
+    <dui:ScrollView>
+        <dui:VerticalStackLayout>
+            <dui:ListItem Title="Counter">
+                <counters:Counter Value="{Binding Value}"
+                                  SecondaryValue="{Binding SecondaryValue}"
+                                  Mode="{Binding Mode}"
+                                  IsUrgent="{Binding IsUrgent}"
+                                  IsSecondaryUrgent="{Binding IsSecondaryUrgent}"/>
+            </dui:ListItem>
+            <!-- <dui:ListItem Title="Standard counter"> -->
+            <!--     <counters:Counter Value="5"/> -->
+            <!-- </dui:ListItem> -->
+            <!-- <dui:ListItem Title="Urgent counter"> -->
+            <!--     <counters:Counter Value="5" -->
+            <!--                       IsUrgent="True"/> -->
+            <!-- </dui:ListItem> -->
+            <!-- <dui:ListItem Title="Double counter"> -->
+            <!--     <counters:Counter Value="5" -->
+            <!--                       SecondaryValue="10" -->
+            <!--                       Mode="Double"/> -->
+            <!-- </dui:ListItem> -->
+            <!-- <dui:ListItem Title="Double counter"> -->
+            <!--     <counters:Counter Value="5" -->
+            <!--                       Mode="Double"/> -->
+            <!-- </dui:ListItem> -->
+            <!-- <dui:ListItem Title="Double urgent counter"> -->
+            <!--     <counters:Counter Value="5" -->
+            <!--                       SecondaryValue="10" -->
+            <!--                       IsSecondaryUrgent="True" -->
+            <!--                       Mode="Double"/> -->
+            <!-- </dui:ListItem> -->
+            <dui:ListItem Title="Value">
+                <dui:Entry Text="{Binding Value}"
+                           Keyboard="Numeric"
+                           HasBorder="True"/>
+            </dui:ListItem>
+            <dui:ListItem Title="Secondary Value">
+                <dui:Entry Text="{Binding SecondaryValue}"
+                           Keyboard="Numeric"
+                           HasBorder="True"/>
+            </dui:ListItem>
+            <dui:ListItem Title="Mode">
+                <dui:ItemPicker Mode="ContextMenu"
+                                SelectedItem="{Binding Mode}"
+                                ItemsSource="{Binding Modes}">
+                </dui:ItemPicker>
+            </dui:ListItem>
+            <dui:ListItem Title="Is Urgent">
+                <dui:Switch IsToggled="{Binding IsUrgent}"/>
+            </dui:ListItem>
+            <dui:ListItem Title="Is Secondary Urgent">
+                <dui:Switch IsToggled="{Binding IsSecondaryUrgent}"/>
+            </dui:ListItem>
+        </dui:VerticalStackLayout>
+    </dui:ScrollView>
+</dui:ContentPage>

--- a/src/app/Components/ComponentsSamples/Counters/CountersSamples.xaml.cs
+++ b/src/app/Components/ComponentsSamples/Counters/CountersSamples.xaml.cs
@@ -1,0 +1,9 @@
+namespace Components.ComponentsSamples.Counters;
+
+public partial class CountersSamples
+{
+    public CountersSamples()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/app/Components/ComponentsSamples/Counters/CountersSamplesViewModel.cs
+++ b/src/app/Components/ComponentsSamples/Counters/CountersSamplesViewModel.cs
@@ -1,0 +1,50 @@
+using DIPS.Mobile.UI.Components.Counters;
+using DIPS.Mobile.UI.MVVM;
+
+namespace Components.ComponentsSamples.Counters;
+
+public class CountersSamplesViewModel : ViewModel
+{
+    private int m_value = 5;
+    private int m_secondaryValue;
+    private CounterDisplayMode m_mode = CounterDisplayMode.Single;
+    private bool m_isUrgent;
+    private bool m_isSecondaryUrgent;
+
+    public List<CounterDisplayMode> Modes { get; } =
+    [
+        CounterDisplayMode.Single,
+        CounterDisplayMode.Double,
+        CounterDisplayMode.Auto
+    ];
+    
+    public int Value
+    {
+        get => m_value;
+        set => RaiseWhenSet(ref m_value, value);
+    }
+
+    public int SecondaryValue
+    {
+        get => m_secondaryValue;
+        set => RaiseWhenSet(ref m_secondaryValue, value);
+    }
+
+    public bool IsUrgent
+    {
+        get => m_isUrgent;
+        set => RaiseWhenSet(ref m_isUrgent, value);
+    }
+
+    public bool IsSecondaryUrgent
+    {
+        get => m_isSecondaryUrgent;
+        set => RaiseWhenSet(ref m_isSecondaryUrgent, value);
+    }
+
+    public CounterDisplayMode Mode
+    {
+        get => m_mode;
+        set => RaiseWhenSet(ref m_mode, value);
+    }
+}

--- a/src/app/Components/REGISTER_YOUR_SAMPLES_HERE.cs
+++ b/src/app/Components/REGISTER_YOUR_SAMPLES_HERE.cs
@@ -5,6 +5,7 @@ using Components.ComponentsSamples.BottomSheets;
 using Components.ComponentsSamples.Buttons;
 using Components.ComponentsSamples.Chips;
 using Components.ComponentsSamples.ContextMenus;
+using Components.ComponentsSamples.Counters;
 using Components.ComponentsSamples.ImageCapturing;
 using Components.ComponentsSamples.Labels;
 using Components.ComponentsSamples.ListItems;
@@ -61,6 +62,7 @@ public static class REGISTER_YOUR_SAMPLES_HERE
             new(SampleType.Components, "Amplitude View", () => new AmplitudeViewSamples()),
             new(SampleType.Components, "Text", () => new TextSamples()),
             new(SampleType.Components, "Tag", () => new TagsSamples()),
+            new(SampleType.Components, "Counters", () => new CountersSamples()),
 
             
 

--- a/src/library/DIPS.Mobile.UI/AssemblyInfo.cs
+++ b/src/library/DIPS.Mobile.UI/AssemblyInfo.cs
@@ -91,6 +91,7 @@ using Microsoft.Maui.Controls.Internals;
 [assembly: XmlnsDefinition("http://dips.com/mobile.ui","DIPS.Mobile.UI.Components.Text.AutoScrollingTextView")]
 [assembly: XmlnsDefinition("http://dips.com/mobile.ui","DIPS.Mobile.UI.Effects.Animation.Effects")]
 [assembly: XmlnsDefinition("http://dips.com/mobile.ui","DIPS.Mobile.UI.Components.Tag")]
+[assembly: XmlnsDefinition("http://dips.com/mobile.ui","DIPS.Mobile.UI.Components.Counters")]
 
 
 

--- a/src/library/DIPS.Mobile.UI/Components/Counters/Counter.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Counters/Counter.Properties.cs
@@ -29,12 +29,6 @@ public partial class Counter
         defaultBindingMode: BindingMode.OneWay,
         propertyChanged: (bindable, _, _) => ((Counter)bindable).OnIsSecondaryUrgentChanged());
 
-    public bool IsSecondaryUrgent
-    {
-        get => (bool)GetValue(IsSecondaryUrgentProperty);
-        set => SetValue(IsSecondaryUrgentProperty, value);
-    }
-
     public static readonly BindableProperty ModeProperty = BindableProperty.Create(
         nameof(Mode),
         typeof(CounterDisplayMode),
@@ -42,27 +36,50 @@ public partial class Counter
         defaultBindingMode: BindingMode.OneWay,
         propertyChanged: (bindable, _, _) => ((Counter)bindable).OnModeChanged());
 
+    /// <summary>
+    /// The mode determining how the primary and secondary counter should be displayed.
+    /// </summary>
     public CounterDisplayMode Mode
     {
         get => (CounterDisplayMode)GetValue(ModeProperty);
         set => SetValue(ModeProperty, value);
     }
     
+    /// <summary>
+    /// Whether the primary value should have an urgent style.
+    /// </summary>
     public bool IsUrgent
     {
         get => (bool)GetValue(IsUrgentProperty);
         set => SetValue(IsUrgentProperty, value);
     }
     
+    /// <summary>
+    /// Whether the secondary value should have an urgent style.
+    /// </summary>
+    public bool IsSecondaryUrgent
+    {
+        get => (bool)GetValue(IsSecondaryUrgentProperty);
+        set => SetValue(IsSecondaryUrgentProperty, value);
+    }
+    
+    /// <summary>
+    /// The primary counter value.
+    /// </summary>
+    public int Value
+    {
+        get => (int)GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+    
+    /// <summary>
+    /// The secondary counter value.
+    /// </summary>
     public int SecondaryValue
     {
         get => (int)GetValue(SecondaryValueProperty);
         set => SetValue(SecondaryValueProperty, value);
     }
     
-    public int Value
-    {
-        get => (int)GetValue(ValueProperty);
-        set => SetValue(ValueProperty, value);
-    }
+    
 }

--- a/src/library/DIPS.Mobile.UI/Components/Counters/Counter.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Counters/Counter.Properties.cs
@@ -1,0 +1,68 @@
+namespace DIPS.Mobile.UI.Components.Counters;
+
+public partial class Counter
+{
+    public static readonly BindableProperty ValueProperty = BindableProperty.Create(
+        nameof(Value),
+        typeof(int),
+        typeof(Counter),
+        defaultBindingMode: BindingMode.OneWay);
+
+    public static readonly BindableProperty SecondaryValueProperty = BindableProperty.Create(
+        nameof(SecondaryValue),
+        typeof(int),
+        typeof(Counter),
+        defaultBindingMode: BindingMode.OneWay,
+        propertyChanged: ((bindable, _, _) => ((Counter)bindable).OnSecondaryValueChanged()));
+
+    public static readonly BindableProperty IsUrgentProperty = BindableProperty.Create(
+        nameof(IsUrgent),
+        typeof(bool),
+        typeof(Counter),
+        defaultBindingMode: BindingMode.OneWay,
+        propertyChanged: (bindable, _, _) => ((Counter)bindable).OnIsUrgentChanged());
+
+    public static readonly BindableProperty IsSecondaryUrgentProperty = BindableProperty.Create(
+        nameof(IsSecondaryUrgent),
+        typeof(bool),
+        typeof(Counter),
+        defaultBindingMode: BindingMode.OneWay,
+        propertyChanged: (bindable, _, _) => ((Counter)bindable).OnIsSecondaryUrgentChanged());
+
+    public bool IsSecondaryUrgent
+    {
+        get => (bool)GetValue(IsSecondaryUrgentProperty);
+        set => SetValue(IsSecondaryUrgentProperty, value);
+    }
+
+    public static readonly BindableProperty ModeProperty = BindableProperty.Create(
+        nameof(Mode),
+        typeof(CounterDisplayMode),
+        typeof(Counter),
+        defaultBindingMode: BindingMode.OneWay,
+        propertyChanged: (bindable, _, _) => ((Counter)bindable).OnModeChanged());
+
+    public CounterDisplayMode Mode
+    {
+        get => (CounterDisplayMode)GetValue(ModeProperty);
+        set => SetValue(ModeProperty, value);
+    }
+    
+    public bool IsUrgent
+    {
+        get => (bool)GetValue(IsUrgentProperty);
+        set => SetValue(IsUrgentProperty, value);
+    }
+    
+    public int SecondaryValue
+    {
+        get => (int)GetValue(SecondaryValueProperty);
+        set => SetValue(SecondaryValueProperty, value);
+    }
+    
+    public int Value
+    {
+        get => (int)GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Components/Counters/Counter.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Counters/Counter.cs
@@ -1,3 +1,4 @@
+using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.Resources.Styles;
 using DIPS.Mobile.UI.Resources.Styles.Label;
 using Microsoft.Maui.Controls.Shapes;
@@ -9,14 +10,14 @@ public partial class Counter : Grid
 {
     private readonly Border m_primaryBorder = new()
     {
-        StrokeShape = new RoundRectangle {CornerRadius = new CornerRadius(Sizes.GetSize(SizeName.size_2)), StrokeThickness = 0},
+        StrokeShape = new RoundRectangle {StrokeThickness = 0},
         Padding = 0,
         Margin = 0
     };
 
     private readonly Border m_secondaryBorder = new()
     {
-        StrokeShape = new RoundRectangle {CornerRadius = new CornerRadius(Sizes.GetSize(SizeName.size_2)), StrokeThickness = 0},
+        StrokeShape = new RoundRectangle {StrokeThickness = 0},
         Padding = 0,
         Margin = 0
     };
@@ -35,6 +36,8 @@ public partial class Counter : Grid
         var primaryLabel = new Label {Style = Styles.GetLabelStyle(LabelStyle.Body200), Margin = new Thickness(Sizes.GetSize(SizeName.size_2), 0)};
         var secondaryLabel = new Label {Style = Styles.GetLabelStyle(LabelStyle.Body200), Margin = new Thickness(Sizes.GetSize(SizeName.size_2), 0)};
 
+        UI.Effects.Layout.Layout.SetCornerRadius(this, Sizes.GetSize(SizeName.size_2));
+        
         m_primaryBorder.Content = primaryLabel;
         m_secondaryBorder.Content = secondaryLabel;
         
@@ -81,20 +84,6 @@ public partial class Counter : Grid
         }
         
         UpdateDivider();
-        UpdateCornerRadius();
-    }
-
-    private void UpdateCornerRadius()
-    {
-        if (m_primaryBorder.IsVisible && m_secondaryBorder.IsVisible)
-        {
-            ((RoundRectangle)m_primaryBorder.StrokeShape!).CornerRadius = new CornerRadius(Sizes.GetSize(SizeName.size_2), 0, Sizes.GetSize(SizeName.size_2), 0);
-            ((RoundRectangle)m_secondaryBorder.StrokeShape!).CornerRadius = new CornerRadius(0, Sizes.GetSize(SizeName.size_2), 0, Sizes.GetSize(SizeName.size_2));
-        }
-        else
-        {
-            ((RoundRectangle)m_primaryBorder.StrokeShape!).CornerRadius = new CornerRadius(Sizes.GetSize(SizeName.size_2));
-        }
     }
 
     private void UpdateDivider()

--- a/src/library/DIPS.Mobile.UI/Components/Counters/Counter.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Counters/Counter.cs
@@ -1,0 +1,116 @@
+using DIPS.Mobile.UI.Resources.Styles;
+using DIPS.Mobile.UI.Resources.Styles.Label;
+using Microsoft.Maui.Controls.Shapes;
+using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
+
+namespace DIPS.Mobile.UI.Components.Counters;
+
+public partial class Counter : Grid
+{
+    private readonly Border m_primaryBorder = new()
+    {
+        StrokeShape = new RoundRectangle {CornerRadius = new CornerRadius(Sizes.GetSize(SizeName.size_2)), StrokeThickness = 0},
+        Padding = 0,
+        Margin = 0
+    };
+
+    private readonly Border m_secondaryBorder = new()
+    {
+        StrokeShape = new RoundRectangle {CornerRadius = new CornerRadius(Sizes.GetSize(SizeName.size_2)), StrokeThickness = 0},
+        Padding = 0,
+        Margin = 0
+    };
+
+    private readonly BoxView m_divider = new() { Color = Colors.GetColor(ColorName.color_border_default), Margin = 0};
+
+    public Counter()
+    {
+        ColumnSpacing = 0;
+        ColumnDefinitions =
+        [
+            new ColumnDefinition {Width = GridLength.Auto},
+            new ColumnDefinition {Width = 1},
+            new ColumnDefinition {Width = GridLength.Auto}
+        ];
+        var primaryLabel = new Label {Style = Styles.GetLabelStyle(LabelStyle.Body200), Margin = new Thickness(Sizes.GetSize(SizeName.size_2), 0)};
+        var secondaryLabel = new Label {Style = Styles.GetLabelStyle(LabelStyle.Body200), Margin = new Thickness(Sizes.GetSize(SizeName.size_2), 0)};
+
+        m_primaryBorder.Content = primaryLabel;
+        m_secondaryBorder.Content = secondaryLabel;
+        
+        primaryLabel.SetBinding(Label.TextProperty, static (Counter counter) => counter.Value, source: this);
+        secondaryLabel.SetBinding(Label.TextProperty, static (Counter counter) => counter.SecondaryValue, source: this);
+        
+        this.Add(m_primaryBorder, 0);
+        this.Add(m_divider, 1);
+        this.Add(m_secondaryBorder, 2);
+        
+        OnModeChanged();
+        OnIsUrgentChanged();
+        OnIsSecondaryUrgentChanged();
+    }
+
+    private void OnIsUrgentChanged()
+    {
+        m_primaryBorder.BackgroundColor = Colors.GetColor(IsUrgent ? ColorName.color_fill_danger_subtle : ColorName.color_fill_subtle);
+        UpdateDivider();
+    }
+
+    private void OnModeChanged()
+    {
+        switch (Mode)
+        {
+            case CounterDisplayMode.Single:
+                {
+                    m_primaryBorder.IsVisible = true;
+                    m_secondaryBorder.IsVisible = false;
+                    break;
+                }
+            case CounterDisplayMode.Double:
+                {
+                    m_primaryBorder.IsVisible = true;
+                    m_secondaryBorder.IsVisible = true;
+                    break;
+                }
+            case CounterDisplayMode.Auto:
+                {
+                    m_primaryBorder.IsVisible = true;
+                    m_secondaryBorder.IsVisible = SecondaryValue != 0;
+                    break;
+                }
+        }
+        
+        UpdateDivider();
+        UpdateCornerRadius();
+    }
+
+    private void UpdateCornerRadius()
+    {
+        if (m_primaryBorder.IsVisible && m_secondaryBorder.IsVisible)
+        {
+            ((RoundRectangle)m_primaryBorder.StrokeShape!).CornerRadius = new CornerRadius(Sizes.GetSize(SizeName.size_2), 0, Sizes.GetSize(SizeName.size_2), 0);
+            ((RoundRectangle)m_secondaryBorder.StrokeShape!).CornerRadius = new CornerRadius(0, Sizes.GetSize(SizeName.size_2), 0, Sizes.GetSize(SizeName.size_2));
+        }
+        else
+        {
+            ((RoundRectangle)m_primaryBorder.StrokeShape!).CornerRadius = new CornerRadius(Sizes.GetSize(SizeName.size_2));
+        }
+    }
+
+    private void UpdateDivider()
+    {
+        m_divider.IsVisible = m_primaryBorder.IsVisible && m_secondaryBorder.IsVisible;
+        m_divider.Color = IsUrgent || IsSecondaryUrgent ? Colors.GetColor(ColorName.color_border_default_hover) : Colors.GetColor(ColorName.color_border_default);
+    }
+
+    private void OnIsSecondaryUrgentChanged()
+    {
+        m_secondaryBorder.BackgroundColor = Colors.GetColor(IsSecondaryUrgent ? ColorName.color_fill_danger_subtle : ColorName.color_fill_subtle);
+        UpdateDivider();
+    }
+
+    private void OnSecondaryValueChanged()
+    {
+        OnModeChanged();
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Components/Counters/Counter.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Counters/Counter.cs
@@ -1,26 +1,13 @@
-using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.Resources.Styles;
 using DIPS.Mobile.UI.Resources.Styles.Label;
-using Microsoft.Maui.Controls.Shapes;
 using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 
 namespace DIPS.Mobile.UI.Components.Counters;
 
 public partial class Counter : Grid
 {
-    private readonly Border m_primaryBorder = new()
-    {
-        StrokeShape = new RoundRectangle {StrokeThickness = 0},
-        Padding = 0,
-        Margin = 0
-    };
-
-    private readonly Border m_secondaryBorder = new()
-    {
-        StrokeShape = new RoundRectangle {StrokeThickness = 0},
-        Padding = 0,
-        Margin = 0
-    };
+    private readonly Label m_primaryLabel = new() {Style = Styles.GetLabelStyle(LabelStyle.Body200), Padding = new Thickness(Sizes.GetSize(SizeName.size_2), 0), BackgroundColor = Colors.GetColor(ColorName.color_fill_subtle)};
+    private readonly Label m_secondaryLabel = new() {Style = Styles.GetLabelStyle(LabelStyle.Body200), Padding = new Thickness(Sizes.GetSize(SizeName.size_2), 0), BackgroundColor = Colors.GetColor(ColorName.color_fill_subtle)};
 
     private readonly BoxView m_divider = new() { Color = Colors.GetColor(ColorName.color_border_default), Margin = 0};
 
@@ -33,20 +20,15 @@ public partial class Counter : Grid
             new ColumnDefinition {Width = 1},
             new ColumnDefinition {Width = GridLength.Auto}
         ];
-        var primaryLabel = new Label {Style = Styles.GetLabelStyle(LabelStyle.Body200), Margin = new Thickness(Sizes.GetSize(SizeName.size_2), 0)};
-        var secondaryLabel = new Label {Style = Styles.GetLabelStyle(LabelStyle.Body200), Margin = new Thickness(Sizes.GetSize(SizeName.size_2), 0)};
 
         UI.Effects.Layout.Layout.SetCornerRadius(this, Sizes.GetSize(SizeName.size_2));
         
-        m_primaryBorder.Content = primaryLabel;
-        m_secondaryBorder.Content = secondaryLabel;
+        m_primaryLabel.SetBinding(Label.TextProperty, static (Counter counter) => counter.Value, source: this);
+        m_secondaryLabel.SetBinding(Label.TextProperty, static (Counter counter) => counter.SecondaryValue, source: this);
         
-        primaryLabel.SetBinding(Label.TextProperty, static (Counter counter) => counter.Value, source: this);
-        secondaryLabel.SetBinding(Label.TextProperty, static (Counter counter) => counter.SecondaryValue, source: this);
-        
-        this.Add(m_primaryBorder, 0);
+        this.Add(m_primaryLabel, 0);
         this.Add(m_divider, 1);
-        this.Add(m_secondaryBorder, 2);
+        this.Add(m_secondaryLabel, 2);
         
         OnModeChanged();
         OnIsUrgentChanged();
@@ -55,7 +37,7 @@ public partial class Counter : Grid
 
     private void OnIsUrgentChanged()
     {
-        m_primaryBorder.BackgroundColor = Colors.GetColor(IsUrgent ? ColorName.color_fill_danger_subtle : ColorName.color_fill_subtle);
+        m_primaryLabel.BackgroundColor = Colors.GetColor(IsUrgent ? ColorName.color_fill_danger_subtle : ColorName.color_fill_subtle);
         UpdateDivider();
     }
 
@@ -65,20 +47,20 @@ public partial class Counter : Grid
         {
             case CounterDisplayMode.Single:
                 {
-                    m_primaryBorder.IsVisible = true;
-                    m_secondaryBorder.IsVisible = false;
+                    m_primaryLabel.IsVisible = true;
+                    m_secondaryLabel.IsVisible = false;
                     break;
                 }
             case CounterDisplayMode.Double:
                 {
-                    m_primaryBorder.IsVisible = true;
-                    m_secondaryBorder.IsVisible = true;
+                    m_primaryLabel.IsVisible = true;
+                    m_secondaryLabel.IsVisible = true;
                     break;
                 }
             case CounterDisplayMode.Auto:
                 {
-                    m_primaryBorder.IsVisible = true;
-                    m_secondaryBorder.IsVisible = SecondaryValue != 0;
+                    m_primaryLabel.IsVisible = true;
+                    m_secondaryLabel.IsVisible = SecondaryValue != 0;
                     break;
                 }
         }
@@ -88,13 +70,13 @@ public partial class Counter : Grid
 
     private void UpdateDivider()
     {
-        m_divider.IsVisible = m_primaryBorder.IsVisible && m_secondaryBorder.IsVisible;
+        m_divider.IsVisible = m_primaryLabel.IsVisible && m_secondaryLabel.IsVisible;
         m_divider.Color = IsUrgent || IsSecondaryUrgent ? Colors.GetColor(ColorName.color_border_default_hover) : Colors.GetColor(ColorName.color_border_default);
     }
 
     private void OnIsSecondaryUrgentChanged()
     {
-        m_secondaryBorder.BackgroundColor = Colors.GetColor(IsSecondaryUrgent ? ColorName.color_fill_danger_subtle : ColorName.color_fill_subtle);
+        m_secondaryLabel.BackgroundColor = Colors.GetColor(IsSecondaryUrgent ? ColorName.color_fill_danger_subtle : ColorName.color_fill_subtle);
         UpdateDivider();
     }
 

--- a/src/library/DIPS.Mobile.UI/Components/Counters/CounterDisplayMode.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Counters/CounterDisplayMode.cs
@@ -1,0 +1,17 @@
+namespace DIPS.Mobile.UI.Components.Counters;
+
+public enum CounterDisplayMode
+{
+    /// <summary>
+    ///     Only display the primary value.
+    /// </summary>
+    Single,
+    /// <summary>
+    ///     Display both primary and secondary values.
+    /// </summary>
+    Double,
+    /// <summary>
+    ///     Display the primary value, and the secondary value only if it is not 0.
+    /// </summary>
+    Auto
+}


### PR DESCRIPTION
### Description of Change
Added a `Counter` component for having an easy way to display an in-line counter. Supports an optional secondary value, and both primary and secondary values can be shown with an urgent style.

### Todos
- [ ] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->