### PR TITLE
[ItemPicker] Added `Large` size, which will transform its layout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [47.5.0] 
+- [ItemPicker] Added `Large` size, which will transform its layout.
+- [ItemPicker] Added `AdditionalContextMenuItem` property.
+- [Chip][Android] Set tint color to custom icon.
+- [Shell][iOS] Remove divider in navigationbar on all shell pages.
+
 ## [47.4.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Pickers/ItemPickersSamples.xaml
@@ -10,135 +10,143 @@
                  xmlns:sampleData="clr-namespace:Components.SampleData"
                  x:Class="Components.ComponentsSamples.Pickers.ItemPickersSamples"
                  Title="Item pickers"
-                 Padding="{dui:Sizes size_4}"
                  BackgroundColor="{dui:Colors color_background_default}">
     <dui:ContentPage.BindingContext>
         <pickers:ItemPickersSamplesViewModel />
     </dui:ContentPage.BindingContext>
-    <dui:VerticalStackLayout>
-        <dui:Label Text="ItemPicker, Mode: Context Menu"
-                   Margin="5" />
-        <dui:ItemPicker VerticalOptions="Start"
-                        HorizontalOptions="Start"
-                        Mode="ContextMenu"
-                        ItemsSource="{Binding People}"
-                        ItemDisplayProperty="DisplayName" />
-        <dui:Label Text="ItemPicker, Mode: Bottom Sheet"
-                   Margin="5" />
-        <dui:ItemPicker VerticalOptions="Start"
-                        HorizontalOptions="Start"
-                        Mode="BottomSheet"
-                        SelectedItem="{Binding SelectedPerson}"
-                        ItemsSource="{Binding People}" />
-        <dui:Label Text="ItemPicker, Mode: Bottom Sheet w/ Free Text"
-                   Margin="5" />
-        <dui:ItemPicker VerticalOptions="Start"
-                        HorizontalOptions="Start"
-                        Mode="BottomSheet"
-                        SelectedItem="{Binding SelectedPerson}"
-                        ItemsSource="{Binding People}" 
-                        FreeTextItemFactory="{Binding PersonFactory}"
-                        FreeTextPrefix="Free text: "/>
-        <dui:Label Text="MultiItemsPicker"
-                   Margin="5" />
-        <dui:MultiItemsPicker VerticalOptions="Start"
-                              Placeholder="{x:Static localizedStrings:LocalizedStrings.To}"
-                              HorizontalOptions="Start"
-                              HasDoneButton="True"
-                              SelectedItems="{Binding SelectedItems, Mode=TwoWay}"
-                              ItemsSource="{x:Static sampleData:SampleDataStorage.People}">
-            <dui:MultiItemsPicker.BottomSheetPickerConfiguration>
-                <dui:BottomSheetPickerConfiguration Title="Select multiple">
-                    <dui:BottomSheetPickerConfiguration.FooterTemplate>
-                        <DataTemplate>
-                                <dui:AlertView Title="Writing a lot of text here, a long text that should span across multiple lines to see if we can recreate thing"
-                                               Style="{dui:Styles Alert=Information}"
-                                               Margin="{dui:Margin Top=size_2, Bottom=size_2, Right=size_3, Left=size_3}"/>
-                        </DataTemplate>
-                    </dui:BottomSheetPickerConfiguration.FooterTemplate>
-                </dui:BottomSheetPickerConfiguration>
-            </dui:MultiItemsPicker.BottomSheetPickerConfiguration>
-            <dui:MultiItemsPicker.ResetBehaviour>
-                <dui:ResetBehaviour Command="{Binding ClearPeopleCommand, Mode=OneWay}"/>
-            </dui:MultiItemsPicker.ResetBehaviour>
-        </dui:MultiItemsPicker>
-        
-        <dui:Label Text="SegmentedControl: Mode: Single"
-                   Margin="5" />
-        
-        <dui:SegmentedControl SelectionMode="Single">
-            <x:Array Type="{x:Type x:String}">
-                <x:String>First</x:String>
-                <x:String>Second</x:String>
-                <x:String>Third</x:String>
-            </x:Array>
-        </dui:SegmentedControl>
-        <dui:Label Text="SegmentedControl: Mode: Multi"
-                   Margin="5" />
-        
-        <dui:SegmentedControl SelectionMode="Multi">
-            <x:Array Type="{x:Type x:String}">
-                <x:String>First</x:String>
-                <x:String>Second</x:String>
-                <x:String>Third</x:String>
-            </x:Array>
-        </dui:SegmentedControl>
-        
-        <dui:Label Text="Picker in ListItem"
-                   Margin="5" />
-        
-        <dui:ListItem Title="Title"
-                      CornerRadius="{dui:Sizes size_4}"
-                      Margin="{dui:Thickness Left=size_4, Right=size_4}"
-                      BackgroundColor="{dui:Colors color_background_subtle}">
-            
-            <dui:ItemPicker Mode="ContextMenu"
+    <ScrollView Padding="{dui:Sizes size_4}">
+        <dui:VerticalStackLayout>
+            <dui:Label Text="ItemPicker, Mode: Context Menu"
+                       Margin="5" />
+            <dui:ItemPicker VerticalOptions="Start"
+                            HorizontalOptions="Start"
+                            Mode="ContextMenu"
                             ItemsSource="{Binding People}"
-                            ItemDisplayProperty="DisplayName"/>
-        </dui:ListItem>
-        
-        <dui:Label Text="Picker in ListItem with custom bottom sheet configuration"
-                   Margin="5" />
-        
-        <dui:ListItem Title="Title"
-                      CornerRadius="{dui:Sizes size_4}"
-                      Margin="{dui:Thickness Left=size_4, Right=size_4}"
-                      BackgroundColor="{dui:Colors color_background_subtle}">
-            
-            <dui:ItemPicker Mode="BottomSheet"
+                            ItemDisplayProperty="DisplayName" />
+            <dui:Label Text="ItemPicker, Mode: Bottom Sheet"
+                       Margin="5" />
+            <dui:ItemPicker VerticalOptions="Start"
+                            HorizontalOptions="Start"
+                            Mode="BottomSheet"
+                            SelectedItem="{Binding SelectedPerson}"
+                            ItemsSource="{Binding People}" />
+            <dui:Label Text="ItemPicker, Mode: Bottom Sheet w/ Free Text"
+                       Margin="5" />
+            <dui:ItemPicker VerticalOptions="Start"
+                            HorizontalOptions="Start"
+                            Mode="BottomSheet"
+                            SelectedItem="{Binding SelectedPerson}"
                             ItemsSource="{Binding People}"
-                            ItemDisplayProperty="DisplayName">
-                <dui:ItemPicker.BottomSheetPickerConfiguration>
-                    <dui:BottomSheetPickerConfiguration Title="Title in bottom sheet "
-                                                        HasSearchBar="False"/>
-                </dui:ItemPicker.BottomSheetPickerConfiguration>
-            </dui:ItemPicker>
-        </dui:ListItem>
-        
-        <dui:Label Text="Picker in ListItem with bottom sheet footer"
-                   Margin="5" />
-        
-        <dui:ListItem Title="Title"
-                      CornerRadius="{dui:Sizes size_4}"
-                      Margin="{dui:Thickness Left=size_4, Right=size_4}"
-                      BackgroundColor="{dui:Colors color_background_subtle}">
-            
-            <dui:ItemPicker Mode="BottomSheet"
-                            ItemsSource="{Binding People}"
-                            ItemDisplayProperty="DisplayName">
-                <dui:ItemPicker.BottomSheetPickerConfiguration>
-                    <dui:BottomSheetPickerConfiguration Title="Title in bottom sheet "
-                                                        HasSearchBar="False">
+                            FreeTextItemFactory="{Binding PersonFactory}"
+                            FreeTextPrefix="Free text: " />
+            <dui:Label Text="ItemPicker, Size: Large"
+                       Margin="5" />
+            <dui:ItemPicker VerticalOptions="Start"
+                            Size="Large"
+                            SelectedItem="{Binding SelectedPerson}"
+                            ItemsSource="{Binding People}" />
+            <dui:Label Text="MultiItemsPicker"
+                       Margin="5" />
+            <dui:MultiItemsPicker VerticalOptions="Start"
+                                  Placeholder="{x:Static localizedStrings:LocalizedStrings.To}"
+                                  HorizontalOptions="Start"
+                                  HasDoneButton="True"
+                                  SelectedItems="{Binding SelectedItems, Mode=TwoWay}"
+                                  ItemsSource="{x:Static sampleData:SampleDataStorage.People}">
+                <dui:MultiItemsPicker.BottomSheetPickerConfiguration>
+                    <dui:BottomSheetPickerConfiguration Title="Select multiple">
                         <dui:BottomSheetPickerConfiguration.FooterTemplate>
-                            <DataTemplate x:DataType="pickers:ItemPickersSamplesViewModel">
-                                <dui:AlertView Style="{dui:Styles Alert=Information}"
-                                               Margin="{dui:Margin Top=size_2, Bottom=size_2, Right=size_3, Left=size_3}"
-                                               Title="{Binding AlertText}"/>
+                            <DataTemplate>
+                                <dui:AlertView
+                                    Title="Writing a lot of text here, a long text that should span across multiple lines to see if we can recreate thing"
+                                    Style="{dui:Styles Alert=Information}"
+                                    Margin="{dui:Margin Top=size_2, Bottom=size_2, Right=size_3, Left=size_3}" />
                             </DataTemplate>
                         </dui:BottomSheetPickerConfiguration.FooterTemplate>
                     </dui:BottomSheetPickerConfiguration>
-                </dui:ItemPicker.BottomSheetPickerConfiguration>
-            </dui:ItemPicker>
-        </dui:ListItem>
-    </dui:VerticalStackLayout>
+                </dui:MultiItemsPicker.BottomSheetPickerConfiguration>
+                <dui:MultiItemsPicker.ResetBehaviour>
+                    <dui:ResetBehaviour Command="{Binding ClearPeopleCommand, Mode=OneWay}" />
+                </dui:MultiItemsPicker.ResetBehaviour>
+            </dui:MultiItemsPicker>
+
+            <dui:Label Text="SegmentedControl: Mode: Single"
+                       Margin="5" />
+
+            <dui:SegmentedControl SelectionMode="Single">
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>First</x:String>
+                    <x:String>Second</x:String>
+                    <x:String>Third</x:String>
+                </x:Array>
+            </dui:SegmentedControl>
+            <dui:Label Text="SegmentedControl: Mode: Multi"
+                       Margin="5" />
+
+            <dui:SegmentedControl SelectionMode="Multi">
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>First</x:String>
+                    <x:String>Second</x:String>
+                    <x:String>Third</x:String>
+                </x:Array>
+            </dui:SegmentedControl>
+
+            <dui:Label Text="Picker in ListItem"
+                       Margin="5" />
+
+            <dui:ListItem Title="Title"
+                          CornerRadius="{dui:Sizes size_4}"
+                          Margin="{dui:Thickness Left=size_4, Right=size_4}"
+                          BackgroundColor="{dui:Colors color_background_subtle}">
+
+                <dui:ItemPicker Mode="ContextMenu"
+                                ItemsSource="{Binding People}"
+                                ItemDisplayProperty="DisplayName" />
+            </dui:ListItem>
+
+            <dui:Label Text="Picker in ListItem with custom bottom sheet configuration"
+                       Margin="5" />
+
+            <dui:ListItem Title="Title"
+                          CornerRadius="{dui:Sizes size_4}"
+                          Margin="{dui:Thickness Left=size_4, Right=size_4}"
+                          BackgroundColor="{dui:Colors color_background_subtle}">
+
+                <dui:ItemPicker Mode="BottomSheet"
+                                ItemsSource="{Binding People}"
+                                ItemDisplayProperty="DisplayName">
+                    <dui:ItemPicker.BottomSheetPickerConfiguration>
+                        <dui:BottomSheetPickerConfiguration Title="Title in bottom sheet "
+                                                            HasSearchBar="False" />
+                    </dui:ItemPicker.BottomSheetPickerConfiguration>
+                </dui:ItemPicker>
+            </dui:ListItem>
+
+            <dui:Label Text="Picker in ListItem with bottom sheet footer"
+                       Margin="5" />
+
+            <dui:ListItem Title="Title"
+                          CornerRadius="{dui:Sizes size_4}"
+                          Margin="{dui:Thickness Left=size_4, Right=size_4}"
+                          BackgroundColor="{dui:Colors color_background_subtle}">
+
+                <dui:ItemPicker Mode="BottomSheet"
+                                ItemsSource="{Binding People}"
+                                ItemDisplayProperty="DisplayName">
+                    <dui:ItemPicker.BottomSheetPickerConfiguration>
+                        <dui:BottomSheetPickerConfiguration Title="Title in bottom sheet "
+                                                            HasSearchBar="False">
+                            <dui:BottomSheetPickerConfiguration.FooterTemplate>
+                                <DataTemplate x:DataType="pickers:ItemPickersSamplesViewModel">
+                                    <dui:AlertView Style="{dui:Styles Alert=Information}"
+                                                   Margin="{dui:Margin Top=size_2, Bottom=size_2, Right=size_3, Left=size_3}"
+                                                   Title="{Binding AlertText}" />
+                                </DataTemplate>
+                            </dui:BottomSheetPickerConfiguration.FooterTemplate>
+                        </dui:BottomSheetPickerConfiguration>
+                    </dui:ItemPicker.BottomSheetPickerConfiguration>
+                </dui:ItemPicker>
+            </dui:ListItem>
+        </dui:VerticalStackLayout>
+    </ScrollView>
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/CollectionViewTests/GroupedCollectionView2.xaml
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/GroupedCollectionView2.xaml
@@ -59,7 +59,7 @@
                         <dui:ListItem.UnderlyingContent>
                             <Grid Padding="8">
                                 <dui:Label Text="{Binding .}"
-                                           TextColor="{dui:Colors color_neutral_60}" />
+                                           TextColor="{dui:Colors color_text_subtle}" />
                                 
                                 <dui:Divider VerticalOptions="End" />
                             </Grid>

--- a/src/app/Playground/VetleSamples/SegmentedControl.xaml
+++ b/src/app/Playground/VetleSamples/SegmentedControl.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<dui:SegmentedControl xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:dui="http://dips.com/mobile.ui"
+             x:Class="Playground.VetleSamples.SegmentedControl"
+             SelectionMode="Multi"/>
+    

--- a/src/app/Playground/VetleSamples/SegmentedControl.xaml.cs
+++ b/src/app/Playground/VetleSamples/SegmentedControl.xaml.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Playground.VetleSamples;
+
+public partial class SegmentedControl
+{
+    private const string BoldCharacter = "𝐁";
+    private const string UnderlineCharacter = "U̲";
+    private const string ItalicCharacter = "𝘐";
+
+    public SegmentedControl()
+    {
+        InitializeComponent();
+
+        ItemsSource = new List<string> { BoldCharacter, UnderlineCharacter, ItalicCharacter };
+    }
+
+}

--- a/src/app/Playground/VetleSamples/TextHighlighter.cs
+++ b/src/app/Playground/VetleSamples/TextHighlighter.cs
@@ -8,7 +8,7 @@ namespace Arena.Mobile.Domains.MunicipalCare.Shared.Converters;
 public class TextHighlighter : IMultiValueConverter, IMarkupExtension
 {
     public string FontFamily { get; set; } = "UI";
-    public Color TextColor { get; set; } = DIPS.Mobile.UI.Resources.Colors.Colors.GetColor(ColorName.color_neutral_90);
+    public Color TextColor { get; set; } = DIPS.Mobile.UI.Resources.Colors.Colors.GetColor(ColorName.color_text_default);
     public double FontSize { get; set; } = 16;
     public bool ShouldAddEllipsisAtStart { get; set; } = true;
     

--- a/src/app/Playground/VetleSamples/TextHighlighterConverter.cs
+++ b/src/app/Playground/VetleSamples/TextHighlighterConverter.cs
@@ -7,7 +7,7 @@ namespace Playground.VetleSamples;
 public class TextHighlighterConverter : IMultiValueConverter, IMarkupExtension
 {
     public string FontFamily { get; set; } = "UI";
-    public Color TextColor { get; set; } = DIPS.Mobile.UI.Resources.Colors.Colors.GetColor(ColorName.color_neutral_90);
+    public Color TextColor { get; set; } = DIPS.Mobile.UI.Resources.Colors.Colors.GetColor(ColorName.color_text_default);
     public int FontSize { get; set; } = 16;
     public bool ShouldAddEllipsisAtStart { get; set; } = true;
     

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -28,6 +28,10 @@
         
     <dui:ItemPicker Size="Large"
                     VerticalOptions="Start">
+        <dui:ItemPicker.AdditionalContextMenuItem>
+            <dui:ContextMenuItem Title="Hello!" />
+        </dui:ItemPicker.AdditionalContextMenuItem>
+        
         <dui:ItemPicker.ItemsSource>
             <x:Array Type="{x:Type x:String}">
                 <x:String>Lol</x:String>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -25,20 +25,24 @@
         <ToolbarItem Text="Hello"></ToolbarItem>
     </dui:ContentPage.ToolbarItems>
 
+       
+    <dui:VerticalStackLayout>
+        <dui:ItemPicker Size="Large"
+                        VerticalOptions="Start"
+                        ItemsSource="{Binding TestObjects}"
+                        ItemDisplayProperty="Name">
+            <dui:ItemPicker.AdditionalContextMenuItem>
+                <dui:ContextMenuItem Title="Hello!"
+                                     Command="{Binding Navigate}"/>
+            </dui:ItemPicker.AdditionalContextMenuItem>
+        </dui:ItemPicker>
+    
+        <dui:Chip Style="{dui:Styles Chip=Input}"
+                  Title="hlos"
+                  CustomIcon="{dui:Icons arrow_back_line}"/>
         
-    <dui:ItemPicker Size="Large"
-                    VerticalOptions="Start">
-        <dui:ItemPicker.AdditionalContextMenuItem>
-            <dui:ContextMenuItem Title="Hello!" />
-        </dui:ItemPicker.AdditionalContextMenuItem>
-        
-        <dui:ItemPicker.ItemsSource>
-            <x:Array Type="{x:Type x:String}">
-                <x:String>Lol</x:String>
-            </x:Array>
-        </dui:ItemPicker.ItemsSource>
-        
-    </dui:ItemPicker>
+    </dui:VerticalStackLayout>
+    
 
 
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -25,9 +25,7 @@
     </dui:ContentPage.ToolbarItems>
 
         
-        
-    <dui:Button Clicked="Button_OnClicked"/>
-        
+    <dui:ItemPicker Size="Large" HorizontalOptions="Fill" VerticalOptions="Start" />
 
 
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -7,6 +7,7 @@
                  xmlns:vetleSamples="clr-namespace:Playground.VetleSamples"
                  xmlns:dui="http://dips.com/mobile.ui"
                  xmlns:iOsSpecific="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
+                 xmlns:system="clr-namespace:System;assembly=System.Runtime"
                  x:Class="Playground.VetleSamples.VetlePage"
                  x:Name="This"
                  HideSoftInputOnTapped="True"
@@ -25,7 +26,15 @@
     </dui:ContentPage.ToolbarItems>
 
         
-    <dui:ItemPicker Size="Large" HorizontalOptions="Fill" VerticalOptions="Start" />
+    <dui:ItemPicker Size="Large"
+                    VerticalOptions="Start">
+        <dui:ItemPicker.ItemsSource>
+            <x:Array Type="{x:Type x:String}">
+                <x:String>Lol</x:String>
+            </x:Array>
+        </dui:ItemPicker.ItemsSource>
+        
+    </dui:ItemPicker>
 
 
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -27,7 +27,9 @@
 
        
     <dui:VerticalStackLayout>
-        <dui:ItemPicker Size="Large"
+        <vetleSamples:SegmentedControl></vetleSamples:SegmentedControl>
+        
+        <!--<dui:ItemPicker Size="Large"
                         VerticalOptions="Start"
                         ItemsSource="{Binding TestObjects}"
                         ItemDisplayProperty="Name">
@@ -35,11 +37,21 @@
                 <dui:ContextMenuItem Title="Hello!"
                                      Command="{Binding Navigate}"/>
             </dui:ItemPicker.AdditionalContextMenuItem>
-        </dui:ItemPicker>
+        </dui:ItemPicker>-->
     
+        <dui:MultiItemsPicker ItemsSource="{Binding TestObjects}"
+                              ItemDisplayProperty="Name"
+                              Placeholder="To"/>
+        
+        <dui:Chip IsCloseable="True"
+                  HorizontalOptions="Start"
+                  Title="Hello"></dui:Chip>
+        
+        <dui:ItemPicker Size="Large" />
+        <!--
         <dui:Chip Style="{dui:Styles Chip=Input}"
                   Title="hlos"
-                  CustomIcon="{dui:Icons arrow_back_line}"/>
+                  CustomIcon="{dui:Icons arrow_back_line}"/>-->
         
     </dui:VerticalStackLayout>
     

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/ButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/ButtonHandler.cs
@@ -17,7 +17,10 @@ public partial class ButtonHandler
             [nameof(Button.AdditionalHitBoxSize)] = MapAdditionalHitBoxSize,
             [nameof(Button.ImageTintColor)] = MapImageTintColor,
             [nameof(Button.ImagePlacement)] = MapImageToRightSide,
-            [nameof(IImage.Source)] = OverrideMapImageSource
+            [nameof(IImage.Source)] = OverrideMapImageSource,
+#if __IOS__
+            [nameof(IButton.Padding)] = OverrideMapPadding
+#endif
         };
 
     private static partial void OverrideMapImageSource(ButtonHandler handler, Button button);

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/ButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/ButtonHandler.cs
@@ -18,9 +18,6 @@ public partial class ButtonHandler
             [nameof(Button.ImageTintColor)] = MapImageTintColor,
             [nameof(Button.ImagePlacement)] = MapImageToRightSide,
             [nameof(IImage.Source)] = OverrideMapImageSource,
-#if __IOS__
-            [nameof(IButton.Padding)] = OverrideMapPadding
-#endif
         };
 
     private static partial void OverrideMapImageSource(ButtonHandler handler, Button button);

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/iOS/ButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/iOS/ButtonHandler.cs
@@ -49,9 +49,4 @@ public partial class ButtonHandler : Microsoft.Maui.Handlers.ButtonHandler
         if (handler.PlatformView is UIButtonWithExtraTappableArea uiButton)
             uiButton.AdditionalHitBoxSize = button.AdditionalHitBoxSize;
     }
-
-    private static void OverrideMapPadding(ButtonHandler arg1, Button arg2)
-    {
-        
-    }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/iOS/ButtonHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/iOS/ButtonHandler.cs
@@ -49,5 +49,9 @@ public partial class ButtonHandler : Microsoft.Maui.Handlers.ButtonHandler
         if (handler.PlatformView is UIButtonWithExtraTappableArea uiButton)
             uiButton.AdditionalHitBoxSize = button.AdditionalHitBoxSize;
     }
-    
+
+    private static void OverrideMapPadding(ButtonHandler arg1, Button arg2)
+    {
+        
+    }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Chips/Android/ChipHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/Android/ChipHandler.cs
@@ -31,8 +31,24 @@ public class ChipHandler : ViewHandler<Chip, Google.Android.Material.Chip.Chip>
         [nameof(Chip.IsToggled)] = MapIsToggled,
         [nameof(Chip.TitleColor)] = MapTitleColor,
         [nameof(Chip.IsToggleable)] = MapIsToggleable,
-        [nameof(Chip.CustomIcon)] = MapCustomIcon
+        [nameof(Chip.CustomIcon)] = MapCustomIcon,
+        [nameof(Chip.CustomRightIcon)] = MapCustomRightIcon
     };
+
+    private static void MapCustomRightIcon(ChipHandler handler, Chip chip)
+    {
+        if(chip.IsCloseable || chip.CustomRightIcon is not FileImageSource fileImageSource)
+            return;
+        
+        handler.PlatformView.CloseIconVisible = true;
+        DUI.TryGetResourceId(fileImageSource.File, out var id, defType:"drawable");
+        
+        if (id == 0)
+            return;
+
+        var drawable = Platform.AppContext.Resources?.GetDrawable(id);
+        handler.PlatformView.CloseIcon = drawable;
+    }
 
     private static void MapCustomIcon(ChipHandler handler, Chip chip)
     {

--- a/src/library/DIPS.Mobile.UI/Components/Chips/Android/ChipHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/Android/ChipHandler.cs
@@ -49,11 +49,20 @@ public class ChipHandler : ViewHandler<Chip, Google.Android.Material.Chip.Chip>
         platformView.SetTextColor(Colors.GetColor(ColorName.color_text_default).ToPlatform());
         platformView.SetEnsureMinTouchTargetSize(false); //Remove extra margins around the chip, this is added to get more space to hit the chip but its not necessary : https://stackoverflow.com/a/57188310
         platformView.Click += OnChipTapped;
+        VirtualView.SizeChanged += VirtualViewOnSizeChanged;
     }
-    
+
+    private void VirtualViewOnSizeChanged(object? sender, EventArgs e)
+    {
+        // This is a workaround because setting padding top and bottom does not work as expected on Android.
+        VirtualView.MinimumHeightRequest = VirtualView.InnerPadding.Bottom + VirtualView.InnerPadding.Top + VirtualView.Height;
+        VirtualView.SizeChanged -= VirtualViewOnSizeChanged;
+    }
+
     private static void MapPadding(ChipHandler handler, Chip chip)
     {
-        handler.PlatformView.SetPadding((int)chip.InnerPadding.Left.ToMauiPixel(), (int)chip.InnerPadding.Top.ToMauiPixel(), (int)chip.InnerPadding.Right.ToMauiPixel(), (int)chip.InnerPadding.Bottom.ToMauiPixel());
+        handler.PlatformView.ChipStartPadding = chip.InnerPadding.Left.ToMauiPixel();
+        handler.PlatformView.ChipEndPadding = chip.InnerPadding.Right.ToMauiPixel();
     }
 
     private static void MapTitleTextAlignment(ChipHandler handler, Chip chip)
@@ -90,7 +99,6 @@ public class ChipHandler : ViewHandler<Chip, Google.Android.Material.Chip.Chip>
         var id = DUI.GetResourceId(fileImageSource.File.Replace(".png", string.Empty), "drawable");
         var icon = Platform.AppContext.GetDrawable((int)id);
         handler.PlatformView.ChipIcon = icon;
-        handler.PlatformView.TextStartPadding = handler.PlatformView.ChipIconSize;
     }
     
     private static void MapCustomIconTintColor(ChipHandler handler, Chip chip)
@@ -126,6 +134,7 @@ public class ChipHandler : ViewHandler<Chip, Google.Android.Material.Chip.Chip>
         {
             handler.PlatformView.CloseIconVisible = true;
             handler.PlatformView.SetOnCloseIconClickListener(new ChipCloseListener(handler));
+            
             DUI.TryGetResourceId(Icons.GetIconName(Chip.CloseIconName), out var id, defType:"drawable");
             if (id != 0)
             {

--- a/src/library/DIPS.Mobile.UI/Components/Chips/Chip.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/Chip.Properties.cs
@@ -25,6 +25,16 @@ public partial class Chip
         get => (Color)GetValue(CustomIconTintColorProperty);
         set => SetValue(CustomIconTintColorProperty, value);
     }
+
+    /// <summary>
+    /// Set an icon that will be displayed on the right side of the chip.
+    /// <remarks>Will be hidden if <see cref="IsCloseable"/> is true</remarks>
+    /// </summary>
+    public ImageSource? CustomRightIcon
+    {
+        get => (ImageSource)GetValue(CustomRightIconProperty);
+        set => SetValue(CustomRightIconProperty, value);
+    }
     
     /// <summary>
     /// The color of the chip.
@@ -249,6 +259,11 @@ public partial class Chip
     public static readonly BindableProperty IsToggleableProperty = BindableProperty.Create(
         nameof(IsToggleable),
         typeof(bool),
+        typeof(Chip));
+    
+    public static readonly BindableProperty CustomRightIconProperty = BindableProperty.Create(
+        nameof(CustomRightIcon),
+        typeof(ImageSource),
         typeof(Chip));
 
 }

--- a/src/library/DIPS.Mobile.UI/Components/Chips/Chip.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/Chip.Properties.cs
@@ -213,6 +213,31 @@ public partial class Chip
     /// </summary>
     public event EventHandler? CloseTapped;
 
+    
+    internal Thickness InnerPadding
+    {
+        get => (Thickness)GetValue(InnerPaddingProperty);
+        set => SetValue(InnerPaddingProperty, value);
+    }
+
+    internal TextAlignment TitleTextAlignment
+    {
+        get => (TextAlignment)GetValue(TitleTextAlignmentProperty);
+        set => SetValue(TitleTextAlignmentProperty, value);
+    }
+    
+    internal static readonly BindableProperty TitleTextAlignmentProperty = BindableProperty.Create(
+        nameof(TitleTextAlignment),
+        typeof(TextAlignment),
+        typeof(Chip),
+        defaultValue: TextAlignment.Center);
+    
+    internal static readonly BindableProperty InnerPaddingProperty = BindableProperty.Create(
+        nameof(InnerPadding),
+        typeof(Thickness),
+        typeof(Chip),
+        defaultValue: new Thickness(Sizes.GetSize(SizeName.size_2), 0));
+
     public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(
         nameof(CommandParameter),
         typeof(object),

--- a/src/library/DIPS.Mobile.UI/Components/Chips/Chip.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/Chip.cs
@@ -1,4 +1,3 @@
-using DIPS.Mobile.UI.Resources.Styles;
 using DIPS.Mobile.UI.Resources.Styles.Chip;
 
 namespace DIPS.Mobile.UI.Components.Chips;
@@ -15,7 +14,7 @@ public partial class Chip : ContentView
 #if __IOS__
         ConstructView();
 #endif
-        
+      
         Style = m_buttonToggleStyle = InputStyle.Current;
     }
 

--- a/src/library/DIPS.Mobile.UI/Components/Chips/iOS/Chip.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/iOS/Chip.cs
@@ -21,7 +21,7 @@ public partial class Chip
         var container = new Grid
         {
             ColumnSpacing = Sizes.GetSize(SizeName.content_margin_xsmall),
-            Padding = new Thickness(Sizes.GetSize(SizeName.content_margin_small), Sizes.GetSize(SizeName.content_margin_xsmall)),
+            
             ColumnDefinitions = 
             [
                 new ColumnDefinition(GridLength.Auto), 
@@ -30,6 +30,8 @@ public partial class Chip
             ],
             RowDefinitions = [new RowDefinition(GridLength.Star)]
         };
+        
+        container.SetBinding(PaddingProperty, static (Chip chip) => chip.InnerPadding, source: this);
 
         m_customIcon = CreateCustomIcon();
         m_border = CreateBorder();
@@ -58,7 +60,8 @@ public partial class Chip
             Source = Icons.GetIcon(ToggledIconName), 
             HeightRequest = Sizes.GetSize(SizeName.size_4), 
             WidthRequest = Sizes.GetSize(SizeName.size_4),
-            VerticalOptions = LayoutOptions.Center
+            VerticalOptions = LayoutOptions.Center,
+            IsVisible = false
         };
         image.SetBinding(Image.SourceProperty, static (Chip chip) => chip.CustomRightIcon, source: this);
         
@@ -132,12 +135,12 @@ public partial class Chip
             TextColor = Colors.GetColor(ColorName.color_text_action),
             Style = Styles.GetLabelStyle(LabelStyle.Body200),
             VerticalOptions = LayoutOptions.Center,
-            HorizontalOptions = LayoutOptions.Center,
             MaxLines = 1,
             LineBreakMode = LineBreakMode.TailTruncation
         };
         label.SetBinding(Label.TextProperty, static (Chip chip) => chip.Title, source: this);
         label.SetBinding(Label.TextColorProperty, static (Chip chip) => chip.TitleColor, source: this);
+        label.SetBinding(Label.HorizontalTextAlignmentProperty, static (Chip chip) => chip.TitleTextAlignment, source: this);
 
         return label;
     }
@@ -180,7 +183,7 @@ public partial class Chip
 
         if (propertyName.Equals(nameof(CustomRightIcon)))
         {
-            m_customRightIcon.IsVisible = CustomRightIcon is not null;
+            m_customRightIcon.IsVisible = CustomRightIcon is not null && !IsCloseable;
         }
     }
 

--- a/src/library/DIPS.Mobile.UI/Components/Chips/iOS/Chip.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/iOS/Chip.cs
@@ -1,3 +1,4 @@
+using DIPS.Mobile.UI.Converters.ValueConverters;
 using DIPS.Mobile.UI.Effects.Touch;
 using DIPS.Mobile.UI.Resources.Styles;
 using DIPS.Mobile.UI.Resources.Styles.Label;
@@ -10,6 +11,7 @@ public partial class Chip
 {
     private Image m_toggleableIcon;
     private Image m_customIcon;
+    private Image m_customRightIcon;
     private ImageButton m_closeButton;
     private Label m_titleLabel;
     private Border m_border;
@@ -34,6 +36,7 @@ public partial class Chip
         m_toggleableIcon = CreateIsToggleableIcon();
         m_titleLabel = CreateTitleLabel();
         m_closeButton = CreateCloseButton();
+        m_customRightIcon = CreateCustomRightIcon();
         
         Touch.SetCommand(m_border, new Command(() => OnTappedButtonChip(false)));
 
@@ -41,10 +44,25 @@ public partial class Chip
         container.Add(m_toggleableIcon);
         container.Add(m_titleLabel, 1);
         container.Add(m_closeButton, 2);
+        container.Add(m_customRightIcon, 2);
 
         m_border.Content = container;
         
         Content = m_border;
+    }
+
+    private Image CreateCustomRightIcon()
+    {
+        var image = new Images.Image.Image 
+        { 
+            Source = Icons.GetIcon(ToggledIconName), 
+            HeightRequest = Sizes.GetSize(SizeName.size_4), 
+            WidthRequest = Sizes.GetSize(SizeName.size_4),
+            VerticalOptions = LayoutOptions.Center
+        };
+        image.SetBinding(Image.SourceProperty, static (Chip chip) => chip.CustomRightIcon, source: this);
+        
+        return image;
     }
 
     private Image CreateCustomIcon()
@@ -158,6 +176,11 @@ public partial class Chip
         if (propertyName.Equals(nameof(CustomIcon)))
         {
             m_customIcon.IsVisible = CustomIcon is not null;
+        }
+
+        if (propertyName.Equals(nameof(CustomRightIcon)))
+        {
+            m_customRightIcon.IsVisible = CustomRightIcon is not null;
         }
     }
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Mode.ContextMenu.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Mode.ContextMenu.cs
@@ -1,86 +1,98 @@
 using DIPS.Mobile.UI.API.Vibration;
 using DIPS.Mobile.UI.Components.ContextMenus;
-using DIPS.Mobile.UI.Extensions;
 
-namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
+namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker;
+
+public partial class ItemPicker
 {
-    public partial class ItemPicker
+    private void UpdateContextMenuItems()
     {
-        private void UpdateContextMenuItems()
+        if (m_contextMenu == null)
         {
-            if (m_contextMenu?.ItemsSource is null)
-            {
-                return;
-            }
+            return;
+        }
             
-            foreach (var item in m_contextMenu.ItemsSource)
-            {
-                if(item is ContextMenuItem contextMenuItem)
-                    contextMenuItem.IsChecked = false;
-            }
+        if (m_contextMenu.ItemsSource == null)
+        {
+            return;
+        }
+            
+        foreach (var item in m_contextMenu.ItemsSource)
+        {
+            if(item is ContextMenuItem contextMenuItem)
+                contextMenuItem.IsChecked = false;
+        }
 
-            if (SelectedItem is not null)
+        if (SelectedItem is not null)
+        {
+            var selectedItem = m_contextMenu.ItemsSource?.FirstOrDefault(i =>
             {
-                var selectedItem = m_contextMenu.ItemsSource?.FirstOrDefault(i =>
+                if (i is ContextMenuItem item)
                 {
-                    if (i is ContextMenuItem item)
-                    {
-                        return item.Title != null && item.Title.Equals(SelectedItem.GetPropertyValue(ItemDisplayProperty),
-                            StringComparison.InvariantCultureIgnoreCase);
-                    }
+                    return item.Title != null && 
+                           item.Title.Equals(SelectedItem.GetPropertyValue(ItemDisplayProperty), 
+                               StringComparison.InvariantCultureIgnoreCase);
+                }
 
-                    return false;
-                });
-
-                if (selectedItem is ContextMenuItem contextMenuItem)
-                    contextMenuItem.IsChecked = true;
+                return false;
+            });
+            if (selectedItem is ContextMenuItem contextMenuItem)
+            {
+                contextMenuItem.IsChecked = true;
             }
-            
-            m_contextMenu.SendItemsSourceUpdated();
         }
+            
+        m_contextMenu.SendItemsSourceUpdated();
+    }
 
-        private void AddContextMenuItems()
+    private void AddContextMenuItems()
+    {
+        if (ItemsSource == null)
         {
-            if (ItemsSource == null)
-            {
-                return;
-            }
-
-            m_contextMenu.ItemsSource!.Clear();
-            
-            foreach (var obj in ItemsSource)
-            {
-                var itemDisplayName = obj.GetPropertyValue(ItemDisplayProperty);
-                m_contextMenu.ItemsSource?.Add(new ContextMenuItem
-                {
-                    Title = itemDisplayName, 
-                    IsChecked = SelectedItem == obj, 
-                    IsCheckable = true
-                });
-            }
-
-            if (AdditionalContextMenuItem is not null)
-            {
-                m_contextMenu.ItemsSource?.Add(new ContextMenuSeparatorItem());
-                m_contextMenu.ItemsSource?.Add(AdditionalContextMenuItem);
-            }
-            
-            m_contextMenu.SendItemsSourceUpdated();
+            return;
         }
-
-        private void SetSelectedItemBasedOnContextMenuItem(ContextMenuItem item)
+        m_contextMenu.ItemsSource!.Clear();
+            
+        foreach (var obj in ItemsSource)
         {
-            if (item == AdditionalContextMenuItem)
+            var itemDisplayName = obj.GetPropertyValue(ItemDisplayProperty);
+            m_contextMenu.ItemsSource?.Add(new ContextMenuItem
             {
-                return;
-            }
-            
-            if (HasHaptics)
-            {
-                VibrationService.SelectionChanged();    
-            }
-            
-            SelectedItem = GetItemFromDisplayProperty(item.Title!);
+                Title = itemDisplayName, 
+                IsChecked = SelectedItem == obj, 
+                IsCheckable = true
+            });
         }
+
+        if (AdditionalContextMenuItem is not null)
+        {
+            m_contextMenu.ItemsSource?.Add(new ContextMenuSeparatorItem());
+            m_contextMenu.ItemsSource?.Add(AdditionalContextMenuItem);
+        }
+            
+        m_contextMenu.SendItemsSourceUpdated();
+    }
+
+    private void SetSelectedItemBasedOnContextMenuItem(ContextMenuItem item)
+    {
+        // If the item tapped is the AdditionalContextMenuItem, we do not want to change the SelectedItem
+        if (item == AdditionalContextMenuItem)
+        {
+            return;
+        }
+        
+        if (HasHaptics)
+        {
+            VibrationService.SelectionChanged();    
+        }
+            
+        // If the SelectedItem is tapped again, we need to update the context menu items, so that the item is still checked
+        if (SelectedItem == GetItemFromDisplayProperty(item.Title!))
+        {
+            UpdateContextMenuItems();    
+            return;
+        }
+            
+        SelectedItem = GetItemFromDisplayProperty(item.Title!);
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Properties.cs
@@ -2,173 +2,197 @@ using System.Collections;
 using System.Windows.Input;
 using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
 
-namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
+namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker;
+
+public partial class ItemPicker
 {
-    public partial class ItemPicker
+    public static readonly BindableProperty HasHapticsProperty = BindableProperty.Create(
+        nameof(HasHaptics),
+        typeof(bool),
+        typeof(ItemPicker), defaultValue: true);
+
+    /// <summary>
+    /// Determines if the phone should stimulate the sense of touch and motion by the use of vibration when people tap the item.
+    /// </summary>
+    public bool HasHaptics
     {
-        public static readonly BindableProperty HasHapticsProperty = BindableProperty.Create(
-            nameof(HasHaptics),
-            typeof(bool),
-            typeof(ItemPicker), defaultValue:true);
-
-        /// <summary>
-        /// Determines if the phone should stimulate the sense of touch and motion by the use of vibration when people tap the item.
-        /// </summary>
-        public bool HasHaptics
-        {
-            get => (bool)GetValue(HasHapticsProperty);
-            set => SetValue(HasHapticsProperty, value);
-        }
-
-        /// <summary>
-        /// Determines whether the search bar should be focused when opening ItemPicker
-        /// </summary>
-        /// <remarks>Only valid when <see cref="Mode"/> is set to BottomSheet</remarks>
-        public bool ShouldAutoFocusSearchBar
-        {
-            get => (bool)GetValue(AutoFocusSearchBarProperty);
-            set => SetValue(AutoFocusSearchBarProperty, value);
-        }
-        
-        /// <summary>
-        /// The item that was selected by people when using the picker.
-        /// </summary>
-        public object? SelectedItem
-        {
-            get => GetValue(SelectedItemProperty);
-            set => SetValue(SelectedItemProperty, value);
-        }
-
-        public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(
-            nameof(ItemsSource),
-            typeof(IEnumerable),
-            typeof(ItemPicker),
-            propertyChanged: ItemsSourceChanged);
-
-        /// <summary>
-        /// The items people can select from when opening the picker.
-        /// </summary>
-        public IEnumerable? ItemsSource
-        {
-            get => (IEnumerable)GetValue(ItemsSourceProperty);
-            set => SetValue(ItemsSourceProperty, value);
-        }
-
-        /// <summary>
-        /// The name of the property of <see cref="SelectedItem"/> to use when displaying the  item for people in the picker.
-        /// </summary>
-        /// <remarks>
-        /// When this is not set, it fall back to <code>.ToString()</code> of the <see cref="SelectedItem"/>.
-        /// This is used when people search if <see cref="Mode"/> is set to <see cref="PickerMode.BottomSheet"/>
-        /// This is not used if you set a <see cref="BottomSheetPickerConfiguration.SelectableItemTemplate"/>
-        /// </remarks>
-        public string? ItemDisplayProperty { get; set; }
-
-        public static readonly BindableProperty SelectedItemCommandProperty = BindableProperty.Create(
-            nameof(SelectedItemCommand),
-            typeof(ICommand),
-            typeof(ItemPicker));
-
-        /// <summary>
-        /// The command to be executed when people select/de-select an item from the picker.
-        /// </summary>
-        public ICommand SelectedItemCommand
-        {
-            get => (ICommand)GetValue(SelectedItemCommandProperty);
-            set => SetValue(SelectedItemCommandProperty, value);
-        }
-
-        public PickerMode Mode { get; set; }
-
-        /// <summary>
-        /// The event to be raised when people select an item from the picker.
-        /// </summary>
-        public event EventHandler<object>? DidSelectItem;
-
-        /// <summary>
-        /// The place holder for people to see when they have not selected a item.
-        /// </summary>
-        public string Placeholder
-        {
-            get => (string)GetValue(PlaceholderProperty);
-            set => SetValue(PlaceholderProperty, value);
-        }
-
-        /// <summary>
-        /// Factory for creating an Item containing free text. Set this property to enable free text. When free text is
-        /// enabled, people will be able to add what they enter into the search bar as a custom selection.
-        /// </summary>
-        /// <remarks>
-        /// Free text is only available in <see cref="PickerMode.BottomSheet"/>, and with <see cref="BottomSheetPickerConfiguration.HasSearchBar"/> enabled.
-        /// </remarks>
-        public Func<string, object>? FreeTextItemFactory
-        {
-            get => (Func<string, object>)GetValue(FreeTextItemFactoryProperty);
-            set => SetValue(FreeTextItemFactoryProperty, value);
-        }
-        
-        /// <summary>
-        /// Prefix that will be added before a free text item as it appears in the bottom sheet.
-        /// </summary>
-        public string FreeTextPrefix
-        {
-            get => (string)GetValue(FreeTextPrefixProperty);
-            set => SetValue(FreeTextPrefixProperty, value);
-        }
-        
-        /// <summary>
-        /// Opens the picker.
-        /// </summary>
-        /// <remarks>This will not work if <see cref="Mode"/> is <see cref="PickerMode.ContextMenu"/></remarks>
-        public ICommand OpenCommand => new Command(Open);
-
-        /// <summary>
-        /// Opens the picker.
-        /// </summary>
-        /// <remarks>This will not work if <see cref="Mode"/> is <see cref="PickerMode.ContextMenu"/></remarks>
-        public partial void Open();
-
-        public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create(
-            nameof(Placeholder),
-            typeof(string),
-            typeof(ItemPicker), defaultValue: DUILocalizedStrings.Choose);
-
-        public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(
-            nameof(SelectedItem),
-            typeof(object),
-            typeof(ItemPicker),
-            propertyChanged: (bindable, _, _) => ((ItemPicker)bindable).SelectedItemChanged(),
-            defaultBindingMode: BindingMode.TwoWay);
-        
-        public static readonly BindableProperty AutoFocusSearchBarProperty = BindableProperty.Create(
-            nameof(ShouldAutoFocusSearchBar),
-            typeof(bool),
-            typeof(ItemPicker));
-
-        public static readonly BindableProperty FreeTextItemFactoryProperty = BindableProperty.Create(
-            nameof(FreeTextItemFactory),
-            typeof(Func<string, object>),
-            typeof(ItemPicker));
-
-        public static readonly BindableProperty FreeTextPrefixProperty = BindableProperty.Create(
-            nameof(FreeTextPrefix),
-            typeof(string),
-            typeof(ItemPicker),
-            defaultValue: string.Empty);
+        get => (bool)GetValue(HasHapticsProperty);
+        set => SetValue(HasHapticsProperty, value);
     }
 
-    public enum PickerMode
+    /// <summary>
+    /// Determines whether the search bar should be focused when opening ItemPicker
+    /// </summary>
+    /// <remarks>Only valid when <see cref="Mode"/> is set to BottomSheet</remarks>
+    public bool ShouldAutoFocusSearchBar
     {
-        /// <summary>
-        /// Display the picker as a context menu.
-        /// </summary>
-        /// <remarks>Best suited when the list of items are short or the names of the items are short.</remarks>
-        ContextMenu,
-
-        /// <summary>
-        /// Display the picker in a sheet.
-        /// </summary>
-        /// <remarks>Best suited when the list of items are long or the the names of the items are long.</remarks>
-        BottomSheet,
+        get => (bool)GetValue(AutoFocusSearchBarProperty);
+        set => SetValue(AutoFocusSearchBarProperty, value);
     }
+
+    /// <summary>
+    /// The item that was selected by people when using the picker.
+    /// </summary>
+    public object? SelectedItem
+    {
+        get => GetValue(SelectedItemProperty);
+        set => SetValue(SelectedItemProperty, value);
+    }
+
+    public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(
+        nameof(ItemsSource),
+        typeof(IEnumerable),
+        typeof(ItemPicker),
+        propertyChanged: ItemsSourceChanged);
+
+    /// <summary>
+    /// The items people can select from when opening the picker.
+    /// </summary>
+    public IEnumerable? ItemsSource
+    {
+        get => (IEnumerable)GetValue(ItemsSourceProperty);
+        set => SetValue(ItemsSourceProperty, value);
+    }
+
+    /// <summary>
+    /// The name of the property of <see cref="SelectedItem"/> to use when displaying the  item for people in the picker.
+    /// </summary>
+    /// <remarks>
+    /// When this is not set, it fall back to <code>.ToString()</code> of the <see cref="SelectedItem"/>.
+    /// This is used when people search if <see cref="Mode"/> is set to <see cref="PickerMode.BottomSheet"/>
+    /// This is not used if you set a <see cref="BottomSheetPickerConfiguration.SelectableItemTemplate"/>
+    /// </remarks>
+    public string? ItemDisplayProperty { get; set; }
+
+    public static readonly BindableProperty SelectedItemCommandProperty = BindableProperty.Create(
+        nameof(SelectedItemCommand),
+        typeof(ICommand),
+        typeof(ItemPicker));
+
+    /// <summary>
+    /// The command to be executed when people select/de-select an item from the picker.
+    /// </summary>
+    public ICommand SelectedItemCommand
+    {
+        get => (ICommand)GetValue(SelectedItemCommandProperty);
+        set => SetValue(SelectedItemCommandProperty, value);
+    }
+
+    public PickerMode Mode { get; set; }
+
+    /// <summary>
+    /// The event to be raised when people select an item from the picker.
+    /// </summary>
+    public event EventHandler<object>? DidSelectItem;
+
+    /// <summary>
+    /// The place holder for people to see when they have not selected a item.
+    /// </summary>
+    public string Placeholder
+    {
+        get => (string)GetValue(PlaceholderProperty);
+        set => SetValue(PlaceholderProperty, value);
+    }
+
+    /// <summary>
+    /// Factory for creating an Item containing free text. Set this property to enable free text. When free text is
+    /// enabled, people will be able to add what they enter into the search bar as a custom selection.
+    /// </summary>
+    /// <remarks>
+    /// Free text is only available in <see cref="PickerMode.BottomSheet"/>, and with <see cref="BottomSheetPickerConfiguration.HasSearchBar"/> enabled.
+    /// </remarks>
+    public Func<string, object>? FreeTextItemFactory
+    {
+        get => (Func<string, object>)GetValue(FreeTextItemFactoryProperty);
+        set => SetValue(FreeTextItemFactoryProperty, value);
+    }
+
+    /// <summary>
+    /// Prefix that will be added before a free text item as it appears in the bottom sheet.
+    /// </summary>
+    public string FreeTextPrefix
+    {
+        get => (string)GetValue(FreeTextPrefixProperty);
+        set => SetValue(FreeTextPrefixProperty, value);
+    }
+
+    /// <summary>
+    /// Opens the picker.
+    /// </summary>
+    /// <remarks>This will not work if <see cref="Mode"/> is <see cref="PickerMode.ContextMenu"/></remarks>
+    public ICommand OpenCommand => new Command(Open);
+
+    /// <summary>
+    /// Opens the picker.
+    /// </summary>
+    /// <remarks>This will not work if <see cref="Mode"/> is <see cref="PickerMode.ContextMenu"/></remarks>
+    public partial void Open();
+
+    
+    public PickerSize Size
+    {
+        get => (PickerSize)GetValue(SizeProperty);
+        set => SetValue(SizeProperty, value);
+    }
+
+    public static readonly BindableProperty SizeProperty = BindableProperty.Create(
+        nameof(Size),
+        typeof(PickerSize),
+        typeof(ItemPicker));
+    
+    public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create(
+        nameof(Placeholder),
+        typeof(string),
+        typeof(ItemPicker), defaultValue: DUILocalizedStrings.Choose);
+
+    public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(
+        nameof(SelectedItem),
+        typeof(object),
+        typeof(ItemPicker),
+        propertyChanged: (bindable, _, _) => ((ItemPicker)bindable).SelectedItemChanged(),
+        defaultBindingMode: BindingMode.TwoWay);
+
+    public static readonly BindableProperty AutoFocusSearchBarProperty = BindableProperty.Create(
+        nameof(ShouldAutoFocusSearchBar),
+        typeof(bool),
+        typeof(ItemPicker));
+
+    public static readonly BindableProperty FreeTextItemFactoryProperty = BindableProperty.Create(
+        nameof(FreeTextItemFactory),
+        typeof(Func<string, object>),
+        typeof(ItemPicker));
+
+    public static readonly BindableProperty FreeTextPrefixProperty = BindableProperty.Create(
+        nameof(FreeTextPrefix),
+        typeof(string),
+        typeof(ItemPicker),
+        defaultValue: string.Empty);
+}
+
+public enum PickerMode
+{
+    /// <summary>
+    /// Display the picker as a context menu.
+    /// </summary>
+    /// <remarks>Best suited when the list of items are short or the names of the items are short.</remarks>
+    ContextMenu,
+
+    /// <summary>
+    /// Display the picker in a sheet.
+    /// </summary>
+    /// <remarks>Best suited when the list of items are long or the the names of the items are long.</remarks>
+    BottomSheet,
+}
+
+public enum PickerSize
+{
+    /// <summary>
+    /// The picker will be displayed in a small size.
+    /// </summary>
+    Small,
+
+    /// <summary>
+    /// The picker will be displayed in a large size.
+    /// </summary>
+    Large,
 }

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Properties.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Windows.Input;
+using DIPS.Mobile.UI.Components.ContextMenus;
 using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
 
 namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker;
@@ -117,6 +118,16 @@ public partial class ItemPicker
     }
 
     /// <summary>
+    /// Will be used to add an additional context menu item to the picker.
+    /// <remarks>Only works if <see cref="Mode"/> is set to <see cref="PickerMode.ContextMenu"/></remarks>
+    /// </summary>
+    public ContextMenuItem? AdditionalContextMenuItem
+    {
+        get => (ContextMenuItem)GetValue(AdditionalContextMenuItemProperty);
+        set => SetValue(AdditionalContextMenuItemProperty, value);
+    }
+
+    /// <summary>
     /// Opens the picker.
     /// </summary>
     /// <remarks>This will not work if <see cref="Mode"/> is <see cref="PickerMode.ContextMenu"/></remarks>
@@ -134,6 +145,11 @@ public partial class ItemPicker
         get => (PickerSize)GetValue(SizeProperty);
         set => SetValue(SizeProperty, value);
     }
+    
+    public static readonly BindableProperty AdditionalContextMenuItemProperty = BindableProperty.Create(
+        nameof(AdditionalContextMenuItem),
+        typeof(ContextMenuItem),
+        typeof(ItemPicker));
 
     public static readonly BindableProperty SizeProperty = BindableProperty.Create(
         nameof(Size),

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.cs
@@ -16,7 +16,6 @@ public partial class ItemPicker : ContentView
     {
         m_chip.SetBinding(IsEnabledProperty, static (ItemPicker itemPicker) => itemPicker.IsEnabled, source: this);
         m_chip.SetBinding(MaximumHeightRequestProperty, static (Chip chip) => chip.MaximumHeightRequest, source: this);
-        MaximumWidthRequest = 200;
     }
     
     protected override void OnHandlerChanging(HandlerChangingEventArgs args)
@@ -31,6 +30,15 @@ public partial class ItemPicker : ContentView
 
     private void LayoutContent()
     {
+        if (Size is PickerSize.Small)
+        {
+            MaximumWidthRequest = 200;
+        }
+        else
+        {
+            /*m_chip.CustomRightIcon = */
+        }
+        
         Content = m_chip;
 
         if (Mode == PickerMode.ContextMenu)
@@ -48,7 +56,7 @@ public partial class ItemPicker : ContentView
         SelectedItemChanged();
     }
 
-    internal void UpdateChipTitle(string? title)
+    private void UpdateChipTitle(string? title)
     {
         var hasPlaceHolder = title == null || string.IsNullOrEmpty(title);
         m_chip.Title = hasPlaceHolder ? Placeholder : title!;

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.cs
@@ -36,7 +36,9 @@ public partial class ItemPicker : ContentView
         }
         else
         {
-            /*m_chip.CustomRightIcon = */
+            m_chip.InnerPadding = new Thickness(Sizes.GetSize(SizeName.size_3), Sizes.GetSize(SizeName.size_2));
+            m_chip.TitleTextAlignment = TextAlignment.Start;
+            m_chip.CustomRightIcon = Icons.GetIcon(IconName.arrow_dropdown_line);
         }
         
         Content = m_chip;

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
@@ -31,11 +31,7 @@ namespace DIPS.Mobile.UI.Components.Shell
             SetTabBarTitleColor(this, Colors.GetColor(ColorName.color_text_action));
             SetTabBarUnselectedColor(this, Colors.GetColor(ColorName.color_icon_subtle));
 
-#if __ANDROID__
             SetNavBarHasShadow(this, false);
-#elif __IOS__
-            SetNavBarHasShadow(this, true);            
-#endif
         }
 
         private async void OnNavigated(object? sender, ShellNavigatedEventArgs e)


### PR DESCRIPTION
### Description of Change

Additionally, added so that ItemPicker can take in `AdditionalContextMenuItem`, to for example navigate to a page in the same context menu.

Also fixed a bug on Android where the CustomIconTintColor were not applied. Furthermore, removed all dividers in the navigationbar on shell pages on iOS.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->