### PR TITLE
[ItemPicker] BottomSheetPickerConfiguration's properties can now be bound.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [47.7.1] 
+- [ItemPicker] BottomSheetPickerConfiguration's properties can now be bound.
+
 ## [47.7.0] 
 - [ItemPicker] Added `Large` size, which will transform its layout.
 - [ItemPicker] Added `AdditionalContextMenuItem` property.

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -27,32 +27,19 @@
 
        
     <dui:VerticalStackLayout>
-        <vetleSamples:SegmentedControl></vetleSamples:SegmentedControl>
-        
-        <!--<dui:ItemPicker Size="Large"
-                        VerticalOptions="Start"
-                        ItemsSource="{Binding TestObjects}"
-                        ItemDisplayProperty="Name">
-            <dui:ItemPicker.AdditionalContextMenuItem>
-                <dui:ContextMenuItem Title="Hello!"
-                                     Command="{Binding Navigate}"/>
-            </dui:ItemPicker.AdditionalContextMenuItem>
-        </dui:ItemPicker>-->
-    
-        <dui:MultiItemsPicker ItemsSource="{Binding TestObjects}"
-                              ItemDisplayProperty="Name"
-                              Placeholder="To"/>
-        
-        <dui:Chip IsCloseable="True"
-                  HorizontalOptions="Start"
-                  Title="Hello"></dui:Chip>
-        
-        <dui:ItemPicker Size="Large" />
-        <!--
-        <dui:Chip Style="{dui:Styles Chip=Input}"
-                  Title="hlos"
-                  CustomIcon="{dui:Icons arrow_back_line}"/>-->
-        
+        <dui:ItemPicker Mode="BottomSheet">
+            
+            <dui:ItemPicker.BottomSheetPickerConfiguration>
+                <dui:BottomSheetPickerConfiguration Title="{Binding TestString}" />
+            </dui:ItemPicker.BottomSheetPickerConfiguration>
+            
+            <dui:ItemPicker.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>Lol</x:String>
+                </x:Array>
+            </dui:ItemPicker.ItemsSource>
+        </dui:ItemPicker>
+
     </dui:VerticalStackLayout>
     
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Mode.BottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPicker.Mode.BottomSheet.cs
@@ -5,7 +5,17 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
 {
     public partial class ItemPicker
     {
-        public BottomSheetPickerConfiguration BottomSheetPickerConfiguration { get; set; } = new();
+        private BottomSheetPickerConfiguration m_bottomSheetPickerConfiguration = new();
+
+        public BottomSheetPickerConfiguration BottomSheetPickerConfiguration
+        {
+            get => m_bottomSheetPickerConfiguration;
+            set
+            {
+                m_bottomSheetPickerConfiguration = value;
+                m_bottomSheetPickerConfiguration.SetBinding(BindingContextProperty, static (ItemPicker itemPicker) => itemPicker.BindingContext, source: this);
+            }
+        }
 
         internal void OpenBottomSheet() => _ = BottomSheetService.Open(new ItemPickerBottomSheet(this));
     }


### PR DESCRIPTION
### Description of Change

Same method as in MultiItemsPicker

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->