### PR TITLE
[Touch][iOS] Block touch when context menu is open.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [48.1.1] 
+- [Touch][iOS] Block touch when context menu is open.
+
 ## [48.1.0] 
 - [ImageCapture] Fixed bug where if you edit an image, the edited image would not be displayed after saving.
 - [CameraPreview] Made methods public to add views to top/bottom toolbar.

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -29,19 +29,31 @@
     <dui:VerticalStackLayout >
         
         
-        <dui:Switch HorizontalOptions="Start" />
+        <Grid HeightRequest="100" WidthRequest="100"
+              BackgroundColor="Red">
+            <dui:ContextMenuEffect.Menu>
+                <dui:ContextMenu>
+                    <dui:ContextMenuItem Title="Hello!" />
+                </dui:ContextMenu>
+            </dui:ContextMenuEffect.Menu>    
+        </Grid>
         
-        <dui:ActivityIndicator IsRunning="True" 
-                               IsVisible="True"
-                               HeightRequest="20"
-                               WidthRequest="20"/>
-
-        <dui:SearchBar IsBusy="True"
-                       BarColor="Red"
-                       HasBusyIndication="True"
-                       CancelButtonTextColor="Green"
-                       HasCancelButton="True"
-                        />
+        <Grid HeightRequest="100" WidthRequest="100"
+              BackgroundColor="Red">
+            <dui:ContextMenuEffect.Menu>
+                <dui:ContextMenu>
+                    <dui:ContextMenuItem Title="Hello!" />
+                </dui:ContextMenu>
+            </dui:ContextMenuEffect.Menu>    
+        </Grid>
+        
+        <dui:Button Text="Click me"
+                    Clicked="Button_OnClicked" />
+        
+        <Grid BackgroundColor="Red"
+              WidthRequest="109"
+              HeightRequest="109"
+                    dui:Touch.Command="{Binding CancelCommand}" />
         
     </dui:VerticalStackLayout>
     

--- a/src/app/Playground/VetleSamples/VetlePage.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows.Input;
+using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.API.Tip;
 using DIPS.Mobile.UI.Components.Alerting.Dialog;
 using DIPS.Mobile.UI.Components.BottomSheets;
@@ -227,9 +228,9 @@ public partial class VetlePage
 
     private void Button_OnClicked(object sender, EventArgs e)
     {
-        /*SearchBar.HasCancelButton = !SearchBar.HasCancelButton;*/
-        /*SearchBar.IsVisible = !SearchBar.IsVisible;*/
-        _ = Navigation.PushModalAsync(new NavigationPage(new VetleTestPage1()));
+        var test = Platform.GetCurrentUIViewController();
+        
+        Console.WriteLine(test);
     }
 
     

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectGestureRecognizerDelegate.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectGestureRecognizerDelegate.cs
@@ -6,6 +6,13 @@ internal class TouchEffectGestureRecognizerDelegate : UIGestureRecognizerDelegat
 {
     public override bool ShouldReceiveTouch(UIGestureRecognizer recognizer, UITouch touch)
     {
+        // Do not allow touch recognition if a context menu is currently displayed.
+        // NOTE: This can be subject to change in future iOS versions
+        if (Platform.GetCurrentUIViewController()?.Class.Name?.Contains("UIContextMenuActionsOnlyViewController") ?? false)
+            return false;
+
+        var test = Platform.GetCurrentUIViewController()?.Class.Name;
+        
         if (touch.View.IsDescendantOfView(recognizer.View))
         {
             if (touch.View.Equals(recognizer.View))

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectTapGestureRecognizer.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectTapGestureRecognizer.cs
@@ -23,10 +23,9 @@ public class TouchEffectTapGestureRecognizer : UIGestureRecognizer
         Delegate = new TouchEffectGestureRecognizerDelegate();
         m_didBecomeActiveObserver = NSNotificationCenter.DefaultCenter.AddObserver(
         UIApplication.DidBecomeActiveNotification,
-        _ => ForceGestureRecognition()
-    );
+        _ => ForceGestureRecognition());
+    }
 
-}
     //Because of an issue where our Delegate do not recieve ShouldRecognizeSimultaneously. Which prevents the user from scrolling if the view is used in a scrolling context. This was introduced in iOS 18.3.x
     private void ForceGestureRecognition()
     {


### PR DESCRIPTION
### Description of Change

Now the touch effect will also not be receiving touch when a context menu is open, mimicking the behaviour of native iOS buttons.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->