### PR TITLE
`AlertView` can now be easily animated, and fixed some bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [48.1.2] 
+- [AlertView] Fixed icon tint colors not being set.
+- [AlertView] Fixed icon size.
+- [AlertView] Now using correct text style on title, if the description is not set.
+- [AlertView] Can now be easily animated.
+- [Animations] Added Scale animation.
+
 ## [48.1.1] 
 - [Touch][iOS] Block touch when context menu is open.
 

--- a/src/app/Components/ComponentsSamples/Alerting/Alerts/AlertSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Alerting/Alerts/AlertSamples.xaml
@@ -9,15 +9,19 @@
                  xmlns:localizedStrings="clr-namespace:Components.Resources.LocalizedStrings"
                  xmlns:alerts="clr-namespace:Components.ComponentsSamples.Alerting.Alerts"
                  x:Class="Components.ComponentsSamples.Alerting.Alerts.AlertSamples"
-                 Title="{x:Static localizedStrings:LocalizedStrings.Alert}"
-                 Padding="{dui:Sizes size_5}">
+                 Title="{x:Static localizedStrings:LocalizedStrings.Alert}">
+    
     <dui:ContentPage.BindingContext>
         <alerts:AlertSamplesViewModel />
     </dui:ContentPage.BindingContext>
     
-    <ScrollView>
+    <ScrollView Padding="{dui:Sizes size_5}">
     
         <dui:VerticalStackLayout>
+            
+            <dui:Button Text="Animate"
+                        HorizontalOptions="End"
+                        Clicked="Button_OnClicked"/>
             
             <dui:VerticalStackLayout>
                 <dui:Label Text="Information"
@@ -34,13 +38,18 @@
                            Style="{dui:Styles Label=SectionHeader}" />
                 <dui:AlertView Title="Something went wrong"
                                Description="Something terribly wrong happened."
-                               Style="{dui:Styles Alert=Error}" />
+                               Style="{dui:Styles Alert=Error}"
+                               ShouldAnimate="True"/>
             </dui:VerticalStackLayout>
             <dui:VerticalStackLayout>
                 <dui:Label Text="Warning"
                            Style="{dui:Styles Label=SectionHeader}" />
+                
                 <dui:AlertView Title="We warn you"
                                Description="Dont do it...okay do it. No, dont!"
+                               Style="{dui:Styles Alert=Warning}" />
+                <dui:AlertView Title="We warn you with only title"
+                               Margin="{dui:Thickness Top=size_2}"
                                Style="{dui:Styles Alert=Warning}" />
             </dui:VerticalStackLayout>
             <dui:VerticalStackLayout>

--- a/src/app/Components/ComponentsSamples/Alerting/Alerts/AlertSamples.xaml.cs
+++ b/src/app/Components/ComponentsSamples/Alerting/Alerts/AlertSamples.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows.Input;
+using DIPS.Mobile.UI.Components.Alerting.Alert;
 using DIPS.Mobile.UI.Components.Alerting.SystemMessage;
 
 namespace Components.ComponentsSamples.Alerting.Alerts;
@@ -10,4 +11,12 @@ public partial class AlertSamples
         InitializeComponent();
     }
 
+    private void Button_OnClicked(object? sender, EventArgs e)
+    {
+        foreach (var vte in this.GetVisualTreeDescendants())
+        {
+            if(vte is AlertView alertView)
+                alertView.Animate();
+        }
+    }
 }

--- a/src/library/DIPS.Mobile.UI/API/Builder/AppHostBuilderExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Builder/AppHostBuilderExtensions.cs
@@ -75,6 +75,7 @@ public static partial class AppHostBuilderExtensions
             effects.Add<Layout, LayoutPlatformEffect>();
             effects.Add<FadeInEffect, FadeInPlatformEffect>();
             effects.Add<FadeOutEffect, FadeOutPlatformEffect>();
+            effects.Add<ScaleInEffect, ScaleInPlatformEffect>();
         });
 
         builder.UseSkiaSharp();

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.Properties.cs
@@ -163,6 +163,12 @@ public partial class AlertView
         typeof(AlertView),
         Label.MaxLinesProperty.DefaultValue);
 
+    public static readonly BindableProperty ShouldAnimateProperty = BindableProperty.Create(
+        nameof(ShouldAnimate),
+        typeof(bool),
+        typeof(AlertView),
+        propertyChanged: (bindable, _, _) => ((AlertView)bindable).OnShouldAnimateChanged());
+    
     /// <summary>
     /// Determines how many lines the <see cref="Description"/> property can take up before it is truncated.
     /// </summary>
@@ -179,5 +185,14 @@ public partial class AlertView
     {
         get => (int)GetValue(TitleMaxLinesProperty);
         set => SetValue(TitleMaxLinesProperty, value);
+    }
+
+    /// <summary>
+    /// Determines whether the alert should animate when it appears.
+    /// </summary>
+    public bool ShouldAnimate
+    {
+        get => (bool)GetValue(ShouldAnimateProperty);
+        set => SetValue(ShouldAnimateProperty, value);
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.Properties.cs
@@ -167,6 +167,7 @@ public partial class AlertView
         nameof(ShouldAnimate),
         typeof(bool),
         typeof(AlertView),
+        true,
         propertyChanged: (bindable, _, _) => ((AlertView)bindable).OnShouldAnimateChanged());
     
     /// <summary>

--- a/src/library/DIPS.Mobile.UI/Effects/Animation/Animation.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Animation/Animation.Properties.cs
@@ -28,6 +28,18 @@ public partial class Animation
             }
         });
     
+    public static readonly BindableProperty ScaleInProperty = BindableProperty.CreateAttached("ScaleIn",
+        typeof(AnimationConfig),
+        typeof(Animation),
+        null,
+        propertyChanged: (bindable, _, _) =>
+        {
+            if (bindable is VisualElement visualElement)
+            {
+                visualElement.Effects.Add(new ScaleInEffect());
+            }
+        });
+    
     public static AnimationConfig GetFadeIn(BindableObject view)
     {
         return (AnimationConfig)view.GetValue(FadeInProperty);
@@ -54,6 +66,16 @@ public partial class Animation
     {
         view.SetValue(FadeOutProperty, name);
     }
+    
+    public static AnimationConfig GetScaleIn(BindableObject view)
+    {
+        return (AnimationConfig)view.GetValue(ScaleInProperty);
+    }
+    
+    public static void SetScaleIn(BindableObject view, AnimationConfig scaleIn)
+    {
+        view.SetValue(ScaleInProperty, scaleIn);
+    }
 }
 
 public class AnimationConfig : BindableObject
@@ -69,6 +91,17 @@ public class AnimationConfig : BindableObject
         get => (Easing)GetValue(EasingProperty);
         set => SetValue(EasingProperty, value);
     }
+
+    public float StartingValue
+    {
+        get => (float)GetValue(StartingValueProperty);
+        set => SetValue(StartingValueProperty, value);
+    }
+    
+    public static readonly BindableProperty StartingValueProperty = BindableProperty.Create(
+        nameof(StartingValue),
+        typeof(float),
+        typeof(Animation));
 
     public static readonly BindableProperty DurationProperty = BindableProperty.Create(
         nameof(Duration),

--- a/src/library/DIPS.Mobile.UI/Effects/Animation/Effects/ScaleInEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Animation/Effects/ScaleInEffect.cs
@@ -3,9 +3,9 @@ using Microsoft.Maui.Controls.Platform;
 
 namespace DIPS.Mobile.UI.Effects.Animation.Effects;
 
-internal class FadeInEffect : RoutingEffect;
+public class ScaleInEffect : RoutingEffect;
 
-internal class FadeInPlatformEffect : PlatformEffect
+internal class ScaleInPlatformEffect : PlatformEffect
 {
 #nullable disable
     private AnimationConfig m_config;
@@ -15,18 +15,18 @@ internal class FadeInPlatformEffect : PlatformEffect
     {
         Element.PropertyChanged += ElementOnPropertyChanged;
 
-        m_config = Animation.GetFadeIn(Element);
+        m_config = Animation.GetScaleIn(Element);
         if (Element is not VisualElement visualElement)
             return;
 
-        visualElement.Opacity = m_config.StartingValue;
+        visualElement.Scale = m_config.StartingValue;
         
         if (visualElement.IsVisible)
         {
-            visualElement.FadeTo(1, m_config.Duration, easing: m_config.Easing);
+            visualElement.ScaleTo(1, m_config.Duration, easing: m_config.Easing);
         }
     }
-    
+
     private void ElementOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName != VisualElement.IsVisibleProperty.PropertyName)
@@ -34,11 +34,11 @@ internal class FadeInPlatformEffect : PlatformEffect
 
         if (Element is VisualElement { IsVisible: true } visualElement)
         {
-            visualElement.Opacity = m_config.StartingValue;
-            visualElement.FadeTo(1, m_config.Duration, easing: m_config.Easing);
+            visualElement.Scale = m_config.StartingValue;
+            visualElement.ScaleTo(1, m_config.Duration, easing: m_config.Easing);
         }
     }
-    
+
     protected override void OnDetached()
     {
         Element.PropertyChanged -= ElementOnPropertyChanged;

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Alert/AlertTypeStyle.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Alert/AlertTypeStyle.cs
@@ -18,10 +18,10 @@ public class AlertTypeStyle
                 Property = VisualElement.BackgroundProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_surface_information)
             },
-            new Setter()
+            new Setter
             {
                 Property = AlertView.IconColorProperty,
-                Value = Colors.Colors.GetColor(ColorName.color_icon_default)
+                Value = Colors.Colors.GetColor(ColorName.color_icon_information)
             }
         }
     };
@@ -39,7 +39,7 @@ public class AlertTypeStyle
                 Property = VisualElement.BackgroundProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_surface_danger)
             },
-            new Setter()
+            new Setter
             {
                 Property = AlertView.IconColorProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_icon_danger)


### PR DESCRIPTION
### Description of Change

- [AlertView] Fixed icon tint colors not being set.
- [AlertView] Fixed icon size.
- [AlertView] Now using correct text style on title, if the description is not set.
- [AlertView] Can now be easily animated.
- [Animations] Added Scale animation.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->