### PR TITLE
[AlertView] Fixed bug where triggering animation would make non-visible `AlertView` visible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [48.4.1] 
+- [AlertView] Fixed bug where triggering animation would make non-visible `AlertView` visible.
+
 ## [48.4.0] 
 - Added `LoadingOverlay`.
 

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.cs
@@ -252,6 +252,9 @@ public partial class AlertView : Border
 
     internal void Animate()
     {
+        if(!IsVisible)
+            return;
+        
         IsVisible = false;
         IsVisible = true;
     }


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->