### PR TITLE
[AlertView] Don't trigger animation from `AlertViewService` if `ShouldAnimate` is set to `false`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [49.1.1] 
+- [AlertView] Don't trigger animation from `AlertViewService` if `ShouldAnimate` is set to `false`.
+
 ## [49.1.0] 
 - [ItemPicker] Added `IsReadOnly` property.
 - [AlertView] Fixed bug where animating it, would break consumers' bindings on IsVisible.

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.cs
@@ -264,7 +264,7 @@ public partial class AlertView : Border
 
     internal void Animate()
     {
-        if(!IsVisible)
+        if(!IsVisible || !ShouldAnimate)
             return;
         
         this.Animate(AnimationType.FadeIn, config =>


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->