### PR TITLE
[ContextMenu][iOS] Make sure nothing breaks when context menu item is tapped.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [49.5.1] 
+ - [ContextMenu][iOS] Make sure nothing breaks when context menu item is tapped.
+
 ## [49.5.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
@@ -5,8 +5,14 @@ namespace DIPS.Mobile.UI.Components.ContextMenus;
 /// </summary>
 public partial class ContextMenuItem : Element, IContextMenuItem
 {
-    internal void SendClicked(ContextMenu contextMenu)
+    internal async void SendClicked(ContextMenu contextMenu)
     {
+#if __IOS__
+        // We need a small delay to make sure that something is not presented on top of the context menu's UIViewController, which breaks the app.
+        // This can happen in release, where everything runs fast.
+        await Task.Delay(1);
+#endif
+        
         contextMenu.SendClicked(this);
         Command?.Execute(CommandParameter);
         DidClick?.Invoke(this, EventArgs.Empty);


### PR DESCRIPTION
### Description of Change


In release mode, everything runs much faster than in debug. In this case, presenting a BottomSheet directly after tapping a ContextMenuItem, can present the BottomSheet on top of the context menu's UIViewController. Which breaks the app.

In this PR, we make sure to set a small delay, before executing commands etc. making sure the BottomSheet does not present on top of the context menu.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->