### PR TITLE
use opacity instead of tintcolor to toggle checkmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [49.9.2]
+## [49.9.3]
 - [Checkmark][iOS] Fix bug where checkmark is never visible.
 ## [49.9.2] 
 - [ChipGroup][iOS] Chips now won't be truncated when there is available space.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [49.9.3]
-- [Checkmark][iOS] Fix bug where checkmark is never visible.
+- [Checkmark][CheckmarkListItem][iOS] Fix bug where checkmark is never visible.
+
 ## [49.9.2] 
 - [ChipGroup][iOS] Chips now won't be truncated when there is available space.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [49.9.2]
+- [Checkmark][iOS] Fix bug where checkmark is never visible.
 ## [49.9.2] 
 - [ChipGroup][iOS] Chips now won't be truncated when there is available space.
 

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Extensions/CheckmarkListItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Extensions/CheckmarkListItem.cs
@@ -46,10 +46,9 @@ public partial class CheckmarkListItem : ListItem, ISelectable
 #if __ANDROID__
         Icon = Icons.GetIcon(IsSelected ? IconName.checkbox_checked_fill : IconName.checkbox_unchecked_line);
 #elif __IOS__
-        m_iconOptions.Color = IsSelected ? ISelectable.s_tintColor : Colors.Transparent;
+        m_iconOptions.Opacity = IsSelected ? (float)1.0 : (float)0.0;
 #endif
         
         SelectionChanged?.Invoke(this, new SelectionChangedEventArgs(!IsSelected, IsSelected));
     }
-    
 }

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Icon/IconOptions.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Icon/IconOptions.Properties.cs
@@ -8,6 +8,12 @@ public partial class IconOptions
         set => SetValue(IsVisibleProperty, value);
     }
     
+    public float Opacity
+    {
+        get => (float)GetValue(OpacityProperty);
+        set => SetValue(OpacityProperty, value);
+    }
+    
     public Color Color
     {
         get => (Color)GetValue(ColorProperty);
@@ -51,4 +57,10 @@ public partial class IconOptions
         typeof(bool),
         typeof(IconOptions),
         defaultValue: true);
+    
+    public static readonly BindableProperty OpacityProperty = BindableProperty.Create(
+        nameof(Opacity),
+        typeof(float),
+        typeof(IconOptions),
+        defaultValue: (float)0.0);
 }

--- a/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Icon/IconOptions.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ListItems/Options/Icon/IconOptions.cs
@@ -23,6 +23,7 @@ public partial class IconOptions : ListItemOptions
         listItem.ImageIcon.SetBinding(Image.TintColorProperty, static (IconOptions options) => options.Color, source: this);
         listItem.ImageIcon.SetBinding(VisualElement.IsVisibleProperty, static (IconOptions options) => options.IsVisible, source: this);
         listItem.ImageIcon.SetBinding(View.VerticalOptionsProperty, static (IconOptions options) => options.VerticalOptions, source: this);
+        listItem.ImageIcon.SetBinding(VisualElement.OpacityProperty, static (IconOptions options) => options.Opacity, source: this);
     }
 
 }

--- a/src/library/DIPS.Mobile.UI/Components/Selection/Checkmark.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Selection/Checkmark.cs
@@ -33,7 +33,7 @@ public partial class Checkmark : ImageButton, ISelectable
 #if __ANDROID__
         Source = Icons.GetIcon(IsSelected ? IconName.checkbox_checked_fill : IconName.checkbox_unchecked_line);
 #elif __IOS__
-        TintColor = IsSelected ? ISelectable.s_tintColor : Colors.Transparent;
+        Opacity = IsSelected ? 1 : 0;
 #endif
         SelectedCommand?.Execute(SelectedCommandParameter);
         SelectionChanged?.Invoke(this, new SelectionChangedEventArgs(!IsSelected, IsSelected));


### PR DESCRIPTION
### Description of Change

Fix bug where checkmark and checkmark in checkmarklistitem is never visible on iOS by changing Opacity instead of TintColor when IsSelected changes.

### Todos
- [ ] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [x] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->