### PR TITLE
AlertView and Label changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [49.9.7]
+- [Label] Fixed bug where Spans would lose formatting from FormattedText when `TruncatedText` was set.
+- [Label] Added `TruncatedTextStyle` property with new `SpanStyle` enum to apply span styles to custom truncation text.
+- [Styles] Added `SpanStyle` enum and styling system for spans, with shared style definitions between `LabelStyle` and `SpanStyle` for easier maintenance.
+
 ## [49.9.6]
 - Update color resources
 - Revert changes that broke navigationlistitem with icon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [AlertView] Optimized layout.
 - [AlertView][BreakingChange] Removed `ButtonAlignment`, `TitleMaxLines` and `DescriptionMaxLines` properties.
 - [AlertView] The component now corresponds to figma.
+- [AlertView] Added comprehensive accessibility support with proper screen reader announcements and navigation.
 - [Label] Fixed bug where Spans would lose formatting from FormattedText when `TruncatedText` was set.
 - [Label] Added `TruncatedTextStyle` property with new `SpanStyle` enum to apply span styles to custom truncation text.
 - [Styles] Added `SpanStyle` enum and styling system for spans, with shared style definitions between `LabelStyle` and `SpanStyle` for easier maintenance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## [49.9.7]
+## [50.0.0]
+- [AlertView] Optimized layout.
+- [AlertView][BreakingChange] Removed `ButtonAlignment`, `TitleMaxLines` and `DescriptionMaxLines` properties.
+- [AlertView] The component now corresponds to figma.
 - [Label] Fixed bug where Spans would lose formatting from FormattedText when `TruncatedText` was set.
 - [Label] Added `TruncatedTextStyle` property with new `SpanStyle` enum to apply span styles to custom truncation text.
 - [Styles] Added `SpanStyle` enum and styling system for spans, with shared style definitions between `LabelStyle` and `SpanStyle` for easier maintenance.

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -28,12 +28,12 @@
 
     <dui:VerticalStackLayout>
         
-        <dui:AlertView Title="Hello! ASijdoaisjd "
+        <dui:AlertView Title="Hello! ASijdoaisjd asmdklamslkdmaslkdmaskldsa"
                        LeftButtonText="Hello"
                        ShowCloseButton="True"
                        ></dui:AlertView>
         
-        <dui:AlertView Title="Hello! ASijdoaisjd "
+        <dui:AlertView Title="Hello! ASijdoaisjdASijdoaisjdASijdoaisjdASijdoaisjdASijdoaisjdASijdoaisjdASijdoaisjdASijdoaisjdASijdoaisjdASijdoaisjdASijdoaisjdASijdoaisjdASijdoaisjdASijdoaisjdASijdoaisjdASijdoaisjdASijdoaisjd "
                        ShowCloseButton="True"
                        Description="Ll"
                        LeftButtonText="Hello"

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -26,15 +26,33 @@
         <ToolbarItem Text="Hello"></ToolbarItem>
     </dui:ContentPage.ToolbarItems>
 
-
-    <VerticalStackLayout>
+    <dui:VerticalStackLayout>
+        <!--<Grid ColumnDefinitions="*, *">
+            <dui:Label Text=" Hlegopkjoiweg jwoiegj wioeujg oiwrj giuegie jgioerw jgoierjgoiejg oerwjgoierj goiejwoijeoirg eroigeo"
+                       TruncatedText="... l0l"
+                       MaxLines="1"
+                       LineBreakMode="TailTruncation"></dui:Label>
+        </Grid>
         
-    <dui:SearchBar Placeholder="Hello"/>
+        <dui:AlertView Title="You have unsaved changes"
+                       LeftButtonText="Save"
+                       ButtonAlignment="Auto"
+                       LeftButtonCommand="{Binding CompletedCommand}" />
+        
+        <dui:AlertView Title="Test asidoasoidjoaisjd asoidjsaoidjasiodjai askld masoid masoiso"
+                       LeftButtonText="Yo"
+                       ButtonAlignment="Underlying"
+                       LeftButtonCommand="{Binding CompletedCommand}"></dui:AlertView>
+        
+        <dui:AlertView Title="Test" />-->
+        
+        <dui:AlertView Title="Test asdk asksaopdkaspodka sodkasoidkasio djaiosdjsoid mjoisj doiasj doiasj doisajdoiasjdoiasjdoias jdoiasjdoiasjdoisajdosajdoiasjd aoisdjaoisdjasiodjas oidjsa"
+                       Description="Hello"
+                       ButtonAlignment="Underlying"
+                       LeftButtonCommand="{Binding CompletedCommand}"
+                       LeftButtonText="STRE"/>
     
-    <dui:Label Text="Hello"></dui:Label>
-    <dui:Label Text="Hello"
-               TextColor="{dui:Colors color_text_subtle}"></dui:Label>
+    </dui:VerticalStackLayout>
     
-    </VerticalStackLayout>
-
+    
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -27,14 +27,17 @@
     </dui:ContentPage.ToolbarItems>
 
     <dui:VerticalStackLayout>
-        <!--<Grid ColumnDefinitions="*, *">
-            <dui:Label Text=" Hlegopkjoiweg jwoiegj wioeujg oiwrj giuegie jgioerw jgoierjgoiejg oerwjgoierj goiejwoijeoirg eroigeo"
-                       TruncatedText="... l0l"
-                       MaxLines="1"
-                       LineBreakMode="TailTruncation"></dui:Label>
-        </Grid>
         
-        <dui:AlertView Title="You have unsaved changes"
+        <dui:AlertView Title="Hello! ASijdoaisjd "
+                       LeftButtonText="Hello"
+                       LeftButtonCommand="{Binding CompletedCommand}"></dui:AlertView>
+        
+        <dui:AlertView Title="Hello! ASijdoaisjd "
+                       Description="Ll"
+                       LeftButtonText="Hello"
+                       LeftButtonCommand="{Binding CompletedCommand}"></dui:AlertView>
+        
+        <!--<dui:AlertView Title="You have unsaved changes"
                        LeftButtonText="Save"
                        ButtonAlignment="Auto"
                        LeftButtonCommand="{Binding CompletedCommand}" />
@@ -44,13 +47,13 @@
                        ButtonAlignment="Underlying"
                        LeftButtonCommand="{Binding CompletedCommand}"></dui:AlertView>
         
-        <dui:AlertView Title="Test" />-->
+        <dui:AlertView Title="Test" />
         
         <dui:AlertView Title="Test asdk asksaopdkaspodka sodkasoidkasio djaiosdjsoid mjoisj doiasj doiasj doisajdoiasjdoiasjdoias jdoiasjdoiasjdoisajdosajdoiasjd aoisdjaoisdjasiodjas oidjsa"
                        Description="Hello"
                        ButtonAlignment="Underlying"
                        LeftButtonCommand="{Binding CompletedCommand}"
-                       LeftButtonText="STRE"/>
+                       LeftButtonText="STRE"/>-->
     
     </dui:VerticalStackLayout>
     

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -30,9 +30,11 @@
         
         <dui:AlertView Title="Hello! ASijdoaisjd "
                        LeftButtonText="Hello"
-                       LeftButtonCommand="{Binding CompletedCommand}"></dui:AlertView>
+                       ShowCloseButton="True"
+                       ></dui:AlertView>
         
         <dui:AlertView Title="Hello! ASijdoaisjd "
+                       ShowCloseButton="True"
                        Description="Ll"
                        LeftButtonText="Hello"
                        LeftButtonCommand="{Binding CompletedCommand}"></dui:AlertView>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml.cs
@@ -228,10 +228,7 @@ public partial class VetlePage
 
     private void Button_OnClicked(object sender, EventArgs e)
     {
-        /*var test = Platform.GetCurrentUIViewController();
-        
-        Console.WriteLine(test);*/
+        _ = Navigation.PushModalAsync(new NavigationPage(new VetleTestPage1()));
     }
 
-    
 }

--- a/src/app/Playground/VetleSamples/VetleTestPage1.xaml
+++ b/src/app/Playground/VetleSamples/VetleTestPage1.xaml
@@ -25,29 +25,16 @@
 
     </dui:ContentPage.ToolbarItems>
 
-    <Grid RowDefinitions="Auto, Auto, *"
-          Padding="{dui:Thickness Top=size_10}"
-          >
+    <dui:ScrollView>
+        <dui:VerticalStackLayout Padding="{dui:Padding page_margin_small}"
+                                 Spacing="{dui:Sizes size_2}">
         
-        <dui:SegmentedControl SelectionMode="Multi"
-                              IsVisible="{Binding Source={x:Reference Switch}, Path=IsToggled}">
-            <dui:SegmentedControl.ItemsSource>
-                <x:Array Type="{x:Type x:String}">
-                    <x:String>𝐁</x:String>
-                    <x:String>U̲</x:String>
-                    <x:String>𝘐</x:String>
-                </x:Array>
-            </dui:SegmentedControl.ItemsSource>
     
-        </dui:SegmentedControl>
+           
         
-        <dui:Switch x:Name="Switch" Grid.Row="1" />
         
-        <!--<dui:ListItem Title="test"
-                      VerticalOptions="Center"
-                      Grid.Row="2"
-                      Tapped="ListItem_OnTapped"></dui:ListItem>-->
     
-    </Grid>
+        </dui:VerticalStackLayout>
+    </dui:ScrollView>
 
 </dui:ContentSavePage>

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.Properties.cs
@@ -10,7 +10,7 @@ public partial class AlertView
         nameof(Title),
         typeof(string),
         typeof(AlertView),
-        propertyChanged: ((bindable, _, _) => ((AlertView)bindable).OnTitleChanged()));
+        propertyChanged: ((bindable, _, _) => ((AlertView)bindable).OnTitleOrDescriptionChanged()));
 
     /// <summary>
     /// The title of the alert.
@@ -25,7 +25,7 @@ public partial class AlertView
         nameof(Description),
         typeof(string),
         typeof(AlertView),
-        propertyChanged: ((bindable, _, _) => ((AlertView)bindable).OnDescriptionChanged()));
+        propertyChanged: ((bindable, _, _) => ((AlertView)bindable).OnTitleOrDescriptionChanged()));
 
     /// <summary>
     /// The description of the alert.
@@ -137,32 +137,6 @@ public partial class AlertView
         set => SetValue(RightButtonCommandParameterProperty, value);
     }
 
-    public static readonly BindableProperty ButtonAlignmentProperty = BindableProperty.Create(
-        nameof(ButtonAlignment),
-        typeof(ButtonAlignmentType),
-        typeof(AlertView),
-        defaultValue: ButtonAlignmentType.Auto,
-        propertyChanged: ((bindable, _, _) => ((AlertView)bindable).OnButtonAlignmentChanged()));
-
-    public ButtonAlignmentType ButtonAlignment
-    {
-        get => (ButtonAlignmentType)GetValue(ButtonAlignmentProperty);
-        set => SetValue(ButtonAlignmentProperty, value);
-    }
-
-    public static readonly BindableProperty TitleMaxLinesProperty = BindableProperty.Create(
-        nameof(TitleMaxLines),
-        typeof(int),
-        typeof(AlertView),
-        Label.MaxLinesProperty.DefaultValue);
-
-
-    public static readonly BindableProperty DescriptionMaxLinesProperty = BindableProperty.Create(
-        nameof(DescriptionMaxLines),
-        typeof(int),
-        typeof(AlertView),
-        Label.MaxLinesProperty.DefaultValue);
-
     public static readonly BindableProperty ShouldAnimateProperty = BindableProperty.Create(
         nameof(ShouldAnimate),
         typeof(bool),
@@ -170,24 +144,6 @@ public partial class AlertView
         true,
         propertyChanged: (bindable, _, _) => ((AlertView)bindable).OnShouldAnimateChanged());
     
-    /// <summary>
-    /// Determines how many lines the <see cref="Description"/> property can take up before it is truncated.
-    /// </summary>
-    public int DescriptionMaxLines
-    {
-        get => (int)GetValue(DescriptionMaxLinesProperty);
-        set => SetValue(DescriptionMaxLinesProperty, value);
-    }
-    
-    /// <summary>
-    /// Determines how many lines the <see cref="Title"/> property can take up before it is truncated.
-    /// </summary>
-    public int TitleMaxLines
-    {
-        get => (int)GetValue(TitleMaxLinesProperty);
-        set => SetValue(TitleMaxLinesProperty, value);
-    }
-
     /// <summary>
     /// Determines whether the alert should animate when it appears.
     /// </summary>

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.Properties.cs
@@ -21,6 +21,20 @@ public partial class AlertView
         set => SetValue(TitleProperty, value);
     }
 
+    public static readonly BindableProperty ShowCloseButtonProperty = BindableProperty.Create(
+        nameof(ShowCloseButton),
+        typeof(bool),
+        typeof(AlertView), propertyChanged: (bindable, _, _) => ((AlertView)bindable).OnShowCloseButtonChanged());
+
+    /// <summary>
+    /// If true, a close button will be shown in the top right corner of the alert.
+    /// </summary>
+    public bool ShowCloseButton
+    {
+        get => (bool)GetValue(ShowCloseButtonProperty);
+        set => SetValue(ShowCloseButtonProperty, value);
+    }
+
     public static readonly BindableProperty DescriptionProperty = BindableProperty.Create(
         nameof(Description),
         typeof(string),

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.cs
@@ -12,6 +12,7 @@ using Animation = DIPS.Mobile.UI.Effects.Animation.Animation;
 using Button = DIPS.Mobile.UI.Components.Buttons.Button;
 using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 using Image = DIPS.Mobile.UI.Components.Images.Image.Image;
+using ImageButton = DIPS.Mobile.UI.Components.Images.ImageButton.ImageButton;
 using Label = DIPS.Mobile.UI.Components.Labels.Label;
 
 namespace DIPS.Mobile.UI.Components.Alerting.Alert;
@@ -19,7 +20,8 @@ namespace DIPS.Mobile.UI.Components.Alerting.Alert;
 public partial class AlertView : Grid
 {
     private readonly HorizontalStackLayout m_buttonsContainer;
-    private Image? m_image;
+    private Image? m_icon;
+    private ImageButton? m_closeIcon;
     private Label m_titleAndDescriptionLabel;
 
     public AlertView()
@@ -48,8 +50,7 @@ public partial class AlertView : Grid
             HorizontalOptions = LayoutOptions.Start,
             VerticalOptions = LayoutOptions.Start,
             Spacing = Sizes.GetSize(SizeName.size_2),
-            IsVisible = false,
-            Margin = new Thickness(0, Sizes.GetSize(SizeName.size_2), 0, 0)
+            IsVisible = false
         };
     }
 
@@ -82,12 +83,12 @@ public partial class AlertView : Grid
         
         if (buttonsWillFit)
         {
-            m_buttonsContainer.Margin = new Thickness(Sizes.GetSize(SizeName.content_margin_small));
+            m_buttonsContainer.Margin = 0;
             this.Add(m_buttonsContainer, 2);
         }
         else
         {
-            m_buttonsContainer.Margin = new Thickness(0, Sizes.GetSize(SizeName.content_margin_small), 0, 0);
+            m_buttonsContainer.Margin = new Thickness(0, 0, Sizes.GetSize(SizeName.content_margin_small), 0);
             this.Add(m_buttonsContainer, 1, 1);
         }
     }
@@ -163,12 +164,9 @@ public partial class AlertView : Grid
                 Text = Description,
                 Style = Styles.GetSpanStyle(SpanStyle.Body100)
             });
-
-            if (m_image is not null)
-            {
-                m_image.VerticalOptions = LayoutOptions.Start;
-            }
         }
+        
+        OnIsLargeAlertDetermined();
 
         m_titleAndDescriptionLabel = new Label
         {
@@ -188,14 +186,33 @@ public partial class AlertView : Grid
         UpdateButtonAlignment();
     }
 
+    /// <summary>
+    /// The AlertView is large if it has a description, if it is large we want to align the icon and close button to the top of the alert
+    /// </summary>
+    private void OnIsLargeAlertDetermined()
+    {
+        if(!IsLargeAlert)
+            return;
+        
+        if (m_icon is not null)
+        {
+            m_icon.VerticalOptions = LayoutOptions.Start;
+        }
+
+        if (m_closeIcon is not null)
+        {
+            m_closeIcon.VerticalOptions = LayoutOptions.Start;
+        }
+    }
+
     private void OnIconChanged()
     {
-        if (Contains(m_image))
+        if (Contains(m_icon))
         {
-            Remove(m_image);
+            Remove(m_icon);
         }
         
-        m_image = new Image
+        m_icon = new Image
         {
             AutomationId = "Image".ToDUIAutomationId<AlertView>(),
             HeightRequest = Sizes.GetSize(SizeName.size_6),
@@ -204,9 +221,9 @@ public partial class AlertView : Grid
             Source = Icon
         };
         
-        m_image.SetBinding(Image.TintColorProperty, static (AlertView alertView) => alertView.IconColor, source: this);
+        m_icon.SetBinding(Image.TintColorProperty, static (AlertView alertView) => alertView.IconColor, source: this);
 
-        Add(m_image);
+        Add(m_icon);
     }
 
     private void OnShouldAnimateChanged()
@@ -259,5 +276,25 @@ public partial class AlertView : Grid
         {
             AlertViewService.OnAnimationTriggered -= Animate;
         }
+    }
+
+    private void OnShowCloseButtonChanged()
+    {
+        if (!ShowCloseButton)
+            return;
+
+        m_closeIcon = new ImageButton
+        {
+            AutomationId = "CloseImage".ToDUIAutomationId<AlertView>(),
+            Source = Icons.GetIcon(IconName.close_line),
+            HeightRequest = Sizes.GetSize(SizeName.size_5),
+            WidthRequest = Sizes.GetSize(SizeName.size_5),
+            HorizontalOptions = LayoutOptions.End,
+            TintColor = Colors.GetColor(ColorName.color_text_on_fill_information),
+            AdditionalHitBoxSize = Sizes.GetSize(SizeName.size_2),
+            Command = new Command(() => IsVisible = false)
+        };
+            
+        this.Add(m_closeIcon, 2);
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/ImageButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/ImageButton.cs
@@ -2,7 +2,6 @@
 using Microsoft.Maui.Platform;
 namespace DIPS.Mobile.UI.Components.Images.ImageButton;
 
-[Obsolete("Use Button with styles if possible")]
 public partial class ImageButton : Microsoft.Maui.Controls.ImageButton
 {
     //TODO: Fix when MAUI fixes: https://github.com/dotnet/maui/issues/18001

--- a/src/library/DIPS.Mobile.UI/Components/Labels/Android/MauiTextView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Labels/Android/MauiTextView.cs
@@ -51,7 +51,7 @@ public class MauiTextView : Microsoft.Maui.Platform.MauiTextView
 
     public void SetTruncatedText()
     {
-        if(!m_label.IsTruncated || string.IsNullOrEmpty(m_label.TruncatedText) || string.IsNullOrEmpty(Text))
+        if(!m_label.IsTruncated || string.IsNullOrEmpty(m_label.TruncatedText) || string.IsNullOrEmpty(GetTextFromLabel()))
             return;
 
         RemoveTextUntilNotTruncated();
@@ -75,12 +75,71 @@ public class MauiTextView : Microsoft.Maui.Platform.MauiTextView
             }
         }
         
-        m_label.FormattedText = new FormattedString { Spans =
+        // Preserve original formatting if FormattedText exists
+        if (m_label.FormattedText != null && m_label.FormattedText.Spans.Count > 0)
         {
-            new Span { Text = modifiedOriginalText, FontSize = m_label.FontSize, FontFamily = m_label.FontFamily },
-            new Span { Text = m_label.TruncatedText, FontSize = m_label.FontSize, FontFamily = m_label.FontFamily, TextColor = m_label.TruncatedTextColor } 
-        } };
-        
+            var newFormattedString = new FormattedString();
+            var currentLength = 0;
+            var targetLength = modifiedOriginalText?.Length ?? 0;
+            
+            // Recreate spans up to the truncation point, preserving original formatting
+            foreach (var originalSpan in m_label.FormattedText.Spans)
+            {
+                if (currentLength >= targetLength)
+                    break;
+                    
+                var spanText = originalSpan.Text ?? string.Empty;
+                var remainingLength = targetLength - currentLength;
+                
+                if (spanText.Length <= remainingLength)
+                {
+                    // Include the entire span
+                    newFormattedString.Spans.Add(new Span
+                    {
+                        Text = spanText,
+                        FontSize = originalSpan.FontSize,
+                        FontFamily = originalSpan.FontFamily,
+                        TextColor = originalSpan.TextColor,
+                        FontAttributes = originalSpan.FontAttributes,
+                        TextDecorations = originalSpan.TextDecorations,
+                        CharacterSpacing = originalSpan.CharacterSpacing,
+                        LineHeight = originalSpan.LineHeight
+                    });
+                    currentLength += spanText.Length;
+                }
+                else
+                {
+                    // Include partial span
+                    var truncatedSpanText = spanText.Substring(0, remainingLength);
+                    newFormattedString.Spans.Add(new Span
+                    {
+                        Text = truncatedSpanText,
+                        FontSize = originalSpan.FontSize,
+                        FontFamily = originalSpan.FontFamily,
+                        TextColor = originalSpan.TextColor,
+                        FontAttributes = originalSpan.FontAttributes,
+                        TextDecorations = originalSpan.TextDecorations,
+                        CharacterSpacing = originalSpan.CharacterSpacing,
+                        LineHeight = originalSpan.LineHeight
+                    });
+                    break;
+                }
+            }
+            
+            // Add the truncation text span
+            newFormattedString.Spans.Add(m_label.CreateTruncatedTextSpan(m_label.TruncatedText));
+            
+            m_label.FormattedText = newFormattedString;
+        }
+        else
+        {
+            // Fallback to simple text handling
+            m_label.FormattedText = new FormattedString { Spans =
+            {
+                new Span { Text = modifiedOriginalText, FontSize = m_label.FontSize, FontFamily = m_label.FontFamily },
+                m_label.CreateTruncatedTextSpan(m_label.TruncatedText) 
+            } };
+        }
     }
 
     public bool CheckIfTruncated(string? stringToCheck = null)

--- a/src/library/DIPS.Mobile.UI/Components/Labels/Label.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Labels/Label.Properties.cs
@@ -1,3 +1,4 @@
+using DIPS.Mobile.UI.Resources.Styles.Span;
 using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 
 namespace DIPS.Mobile.UI.Components.Labels;
@@ -31,12 +32,27 @@ public partial class Label
         get => (Color)GetValue(TruncatedTextColorProperty);
         set => SetValue(TruncatedTextColorProperty, value);
     }
+
+    /// <summary>
+    /// Sets the style of <see cref="TruncatedText"/>. If set, this will override <see cref="TruncatedTextFontFamily"/> and <see cref="TruncatedTextColor"/>
+    /// </summary>
+    public SpanStyle TruncatedTextStyle
+    {
+        get => (SpanStyle)GetValue(TruncatedTextStyleProperty);
+        set => SetValue(TruncatedTextStyleProperty, value);
+    }
     
     public static readonly BindableProperty TruncatedTextColorProperty = BindableProperty.Create(
         nameof(TruncatedTextColor),
         typeof(Color),
         typeof(Label),
         defaultValue: Colors.GetColor(ColorName.color_text_action));
+
+    public static readonly BindableProperty TruncatedTextStyleProperty = BindableProperty.Create(
+        nameof(TruncatedTextStyle),
+        typeof(SpanStyle),
+        typeof(Label),
+        defaultValue: SpanStyle.None);
     
     public static readonly BindableProperty TruncatedTextProperty = BindableProperty.Create(
         nameof(TruncatedText),

--- a/src/library/DIPS.Mobile.UI/Components/Labels/Label.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Labels/Label.cs
@@ -1,5 +1,6 @@
 using DIPS.Mobile.UI.Resources.Styles;
 using DIPS.Mobile.UI.Resources.Styles.Label;
+using DIPS.Mobile.UI.Resources.Styles.Span;
 
 namespace DIPS.Mobile.UI.Components.Labels;
 
@@ -24,5 +25,26 @@ public partial class Label : Microsoft.Maui.Controls.Label
         {
             this.InvalidateMeasure();
         }
+    }
+
+    /// <summary>
+    /// Applies style properties from a Style to a Span for truncated text
+    /// </summary>
+    internal Span CreateTruncatedTextSpan(string text)
+    {
+        var span = new Span { Text = text };
+
+        if (TruncatedTextStyle != SpanStyle.None)
+        {
+            span.Style = Styles.GetSpanStyle(TruncatedTextStyle);
+        }
+        else
+        {
+            span.FontSize = FontSize;
+            span.FontFamily = FontFamily;
+            span.TextColor = TruncatedTextColor;
+        }
+
+        return span;
     }
 }

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.Designer.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.Designer.cs
@@ -398,5 +398,59 @@ namespace DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings {
                 return ResourceManager.GetString("Accessibility_TapToChangeView", resourceCulture);
             }
         }
+        
+        internal static string Information {
+            get {
+                return ResourceManager.GetString("Information", resourceCulture);
+            }
+        }
+        
+        internal static string Error {
+            get {
+                return ResourceManager.GetString("Error", resourceCulture);
+            }
+        }
+        
+        internal static string Warning {
+            get {
+                return ResourceManager.GetString("Warning", resourceCulture);
+            }
+        }
+        
+        internal static string Success {
+            get {
+                return ResourceManager.GetString("Success", resourceCulture);
+            }
+        }
+        
+        internal static string Alert {
+            get {
+                return ResourceManager.GetString("Alert", resourceCulture);
+            }
+        }
+        
+        internal static string Accessibility_SwipeRightForActionButtons {
+            get {
+                return ResourceManager.GetString("Accessibility_SwipeRightForActionButtons", resourceCulture);
+            }
+        }
+        
+        internal static string Accessibility_SwipeRightForCloseButton {
+            get {
+                return ResourceManager.GetString("Accessibility_SwipeRightForCloseButton", resourceCulture);
+            }
+        }
+        
+        internal static string Accessibility_CloseAlert {
+            get {
+                return ResourceManager.GetString("Accessibility_CloseAlert", resourceCulture);
+            }
+        }
+        
+        internal static string Accessibility_TapToDismissAlert {
+            get {
+                return ResourceManager.GetString("Accessibility_TapToDismissAlert", resourceCulture);
+            }
+        }
     }
 }

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.en.resx
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.en.resx
@@ -188,4 +188,16 @@
     <data name="Accessibility_TapToChangeView" xml:space="preserve">
         <value>Tap to change tab</value>
     </data>
+    <data name="Information" xml:space="preserve">
+        <value>Information</value>
+    </data>
+    <data name="Error" xml:space="preserve">
+        <value>Error</value>
+    </data>
+    <data name="Warning" xml:space="preserve">
+        <value>Warning</value>
+    </data>
+    <data name="Success" xml:space="preserve">
+        <value>Success</value>
+    </data>
 </root>

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.resx
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.resx
@@ -195,4 +195,34 @@
     <data name="Accessibility_TapToChangeView" xml:space="preserve">
         <value>Trykk for å endre fane</value>
     </data>
+    <data name="Information" xml:space="preserve">
+        <value>Informasjon</value>
+    </data>
+    <data name="Error" xml:space="preserve">
+        <value>Feil</value>
+    </data>
+    <data name="Warning" xml:space="preserve">
+        <value>Advarsel</value>
+    </data>
+    <data name="Success" xml:space="preserve">
+        <value>Suksess</value>
+    </data>
+    <data name="Alert" xml:space="preserve">
+        <value>Varsel</value>
+    </data>
+    <data name="Button" xml:space="preserve">
+        <value>Knapp</value>
+    </data>
+    <data name="Accessibility_SwipeRightForActionButtons" xml:space="preserve">
+        <value>Dra til høyre for å få tilgang til handlingsknapper</value>
+    </data>
+    <data name="Accessibility_SwipeRightForCloseButton" xml:space="preserve">
+        <value>Dra til høyre for å få tilgang til lukkeknapp</value>
+    </data>
+    <data name="Accessibility_CloseAlert" xml:space="preserve">
+        <value>Lukk varsel</value>
+    </data>
+    <data name="Accessibility_TapToDismissAlert" xml:space="preserve">
+        <value>Trykk for å lukke dette varselet</value>
+    </data>
 </root>

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Alert/AlertTypeStyle.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Alert/AlertTypeStyle.cs
@@ -15,7 +15,7 @@ public class AlertTypeStyle
             },
             new Setter
             {
-                Property = VisualElement.BackgroundProperty,
+                Property = VisualElement.BackgroundColorProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_surface_information)
             },
             new Setter
@@ -37,7 +37,7 @@ public class AlertTypeStyle
             },
             new Setter
             {
-                Property = VisualElement.BackgroundProperty,
+                Property = VisualElement.BackgroundColorProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_surface_danger)
             },
             new Setter
@@ -59,7 +59,7 @@ public class AlertTypeStyle
             },
             new Setter
             {
-                Property = VisualElement.BackgroundProperty,
+                Property = VisualElement.BackgroundColorProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_surface_warning)
             },
             new Setter
@@ -80,7 +80,7 @@ public class AlertTypeStyle
             },
             new Setter
             {
-                Property = VisualElement.BackgroundProperty,
+                Property = VisualElement.BackgroundColorProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_surface_success)
             },
             new Setter

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Alert/AlertTypeStyle.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Alert/AlertTypeStyle.cs
@@ -32,7 +32,8 @@ public class AlertTypeStyle
         {
             new Setter
             {
-                Property = AlertView.IconProperty, Value = Icons.Icons.GetIcon(IconName.important_line)
+                Property = AlertView.IconProperty, 
+                Value = Icons.Icons.GetIcon(IconName.important_line)
             },
             new Setter
             {
@@ -51,13 +52,17 @@ public class AlertTypeStyle
     {
         Setters =
         {
-            new Setter {Property = AlertView.IconProperty, Value = Icons.Icons.GetIcon(IconName.alert_line)},
+            new Setter
+            {
+                Property = AlertView.IconProperty, 
+                Value = Icons.Icons.GetIcon(IconName.alert_line)
+            },
             new Setter
             {
                 Property = VisualElement.BackgroundProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_surface_warning)
             },
-            new Setter()
+            new Setter
             {
                 Property = AlertView.IconColorProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_icon_warning)
@@ -78,7 +83,7 @@ public class AlertTypeStyle
                 Property = VisualElement.BackgroundProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_surface_success)
             },
-            new Setter()
+            new Setter
             {
                 Property = AlertView.IconColorProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_icon_success)

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Label/LabelStyleResources.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Label/LabelStyleResources.cs
@@ -1,27 +1,28 @@
+using DIPS.Mobile.UI.Resources.Styles.Shared;
+
 namespace DIPS.Mobile.UI.Resources.Styles.Label;
 
 internal class LabelStyleResources
 {
+    private static readonly Dictionary<TextStyle, Style> s_sharedStyles = SharedStyleResources.GetStylesForType(typeof(Components.Labels.Label));
+    
     public static Dictionary<LabelStyle, Style> Styles { get; } = new()
     {
-        [LabelStyle.Body400] = LabelFontFamilyStyle.Body.ConcatenateWithStyle(LabelWeightStyle.FourHundred), 
-        [LabelStyle.Body300] = LabelFontFamilyStyle.Body.ConcatenateWithStyle(LabelWeightStyle.ThreeHundred), 
-        [LabelStyle.Body200] = LabelFontFamilyStyle.Body.ConcatenateWithStyle(LabelWeightStyle.TwoHundred), 
-        [LabelStyle.Body100] = LabelFontFamilyStyle.Body.ConcatenateWithStyle(LabelWeightStyle.OneHundred), 
-        
-        [LabelStyle.UI400] = LabelFontFamilyStyle.UI.ConcatenateWithStyle(LabelWeightStyle.FourHundred), 
-        [LabelStyle.UI300] = LabelFontFamilyStyle.UI.ConcatenateWithStyle(LabelWeightStyle.ThreeHundred), 
-        [LabelStyle.UI200] = LabelFontFamilyStyle.UI.ConcatenateWithStyle(LabelWeightStyle.TwoHundred), 
-        [LabelStyle.UI100] = LabelFontFamilyStyle.UI.ConcatenateWithStyle(LabelWeightStyle.OneHundred), 
-
-        [LabelStyle.Header1000] = LabelFontFamilyStyle.Header.ConcatenateWithStyle(LabelWeightStyle.OneThousand), 
-        [LabelStyle.Header900] = LabelFontFamilyStyle.Header.ConcatenateWithStyle(LabelWeightStyle.NineHundred), 
-        [LabelStyle.Header800] = LabelFontFamilyStyle.Header.ConcatenateWithStyle(LabelWeightStyle.EightHundred), 
-        [LabelStyle.Header700] = LabelFontFamilyStyle.Header.ConcatenateWithStyle(LabelWeightStyle.SevenHundred), 
-        [LabelStyle.Header600] = LabelFontFamilyStyle.Header.ConcatenateWithStyle(LabelWeightStyle.SixHundred), 
-        [LabelStyle.Header500] = LabelFontFamilyStyle.Header.ConcatenateWithStyle(LabelWeightStyle.FiveHundred),
-        
-        [LabelStyle.SectionHeader] = LabelFontFamilyStyle.UI.ConcatenateWithStyle(LabelWeightStyle.FourHundred)
+        [LabelStyle.None] = s_sharedStyles[TextStyle.None],
+        [LabelStyle.Body400] = s_sharedStyles[TextStyle.Body400],
+        [LabelStyle.Body300] = s_sharedStyles[TextStyle.Body300],
+        [LabelStyle.Body200] = s_sharedStyles[TextStyle.Body200],
+        [LabelStyle.Body100] = s_sharedStyles[TextStyle.Body100],
+        [LabelStyle.UI400] = s_sharedStyles[TextStyle.UI400],
+        [LabelStyle.UI300] = s_sharedStyles[TextStyle.UI300],
+        [LabelStyle.UI200] = s_sharedStyles[TextStyle.UI200],
+        [LabelStyle.UI100] = s_sharedStyles[TextStyle.UI100],
+        [LabelStyle.Header1000] = s_sharedStyles[TextStyle.Header1000],
+        [LabelStyle.Header900] = s_sharedStyles[TextStyle.Header900],
+        [LabelStyle.Header800] = s_sharedStyles[TextStyle.Header800],
+        [LabelStyle.Header700] = s_sharedStyles[TextStyle.Header700],
+        [LabelStyle.Header600] = s_sharedStyles[TextStyle.Header600],
+        [LabelStyle.Header500] = s_sharedStyles[TextStyle.Header500],
+        [LabelStyle.SectionHeader] = s_sharedStyles[TextStyle.SectionHeader]
     };
-   
 }

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Shared/SharedFontFamilyStyle.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Shared/SharedFontFamilyStyle.cs
@@ -1,0 +1,48 @@
+namespace DIPS.Mobile.UI.Resources.Styles.Shared;
+
+public class SharedFontFamilyStyle
+{
+    internal static Style GetBodyStyle(Type targetType) => new(targetType)
+    {
+        Setters =
+        {
+            new Setter
+            {
+                Property = GetFontFamilyProperty(targetType),
+                Value = "Body"
+            }
+        }
+    };
+    
+    internal static Style GetUIStyle(Type targetType) => new(targetType)
+    {
+        Setters =
+        {
+            new Setter
+            {
+                Property = GetFontFamilyProperty(targetType),
+                Value = "UI"
+            }
+        }
+    };
+    
+    internal static Style GetHeaderStyle(Type targetType) => new(targetType)
+    {
+        Setters =
+        {
+            new Setter
+            {
+                Property = GetFontFamilyProperty(targetType),
+                Value = "Header"
+            }
+        }
+    };
+
+    private static BindableProperty GetFontFamilyProperty(Type targetType)
+    {
+        if (targetType == typeof(Microsoft.Maui.Controls.Span))
+            return Microsoft.Maui.Controls.Span.FontFamilyProperty;
+        
+        return Microsoft.Maui.Controls.Label.FontFamilyProperty;
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Shared/SharedStyleResources.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Shared/SharedStyleResources.cs
@@ -1,0 +1,30 @@
+namespace DIPS.Mobile.UI.Resources.Styles.Shared;
+
+public static class SharedStyleResources
+{
+    public static Dictionary<TextStyle, Style> GetStylesForType(Type targetType)
+    {
+        return new Dictionary<TextStyle, Style>
+        {
+            [TextStyle.None] = new Style(targetType),
+            [TextStyle.Body400] = SharedFontFamilyStyle.GetBodyStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetFourHundredStyle(targetType)), 
+            [TextStyle.Body300] = SharedFontFamilyStyle.GetBodyStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetThreeHundredStyle(targetType)), 
+            [TextStyle.Body200] = SharedFontFamilyStyle.GetBodyStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetTwoHundredStyle(targetType)), 
+            [TextStyle.Body100] = SharedFontFamilyStyle.GetBodyStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetOneHundredStyle(targetType)), 
+            
+            [TextStyle.UI400] = SharedFontFamilyStyle.GetUIStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetFourHundredStyle(targetType)), 
+            [TextStyle.UI300] = SharedFontFamilyStyle.GetUIStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetThreeHundredStyle(targetType)), 
+            [TextStyle.UI200] = SharedFontFamilyStyle.GetUIStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetTwoHundredStyle(targetType)), 
+            [TextStyle.UI100] = SharedFontFamilyStyle.GetUIStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetOneHundredStyle(targetType)), 
+
+            [TextStyle.Header1000] = SharedFontFamilyStyle.GetHeaderStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetOneThousandStyle(targetType)), 
+            [TextStyle.Header900] = SharedFontFamilyStyle.GetHeaderStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetNineHundredStyle(targetType)), 
+            [TextStyle.Header800] = SharedFontFamilyStyle.GetHeaderStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetEightHundredStyle(targetType)), 
+            [TextStyle.Header700] = SharedFontFamilyStyle.GetHeaderStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetSevenHundredStyle(targetType)), 
+            [TextStyle.Header600] = SharedFontFamilyStyle.GetHeaderStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetSixHundredStyle(targetType)), 
+            [TextStyle.Header500] = SharedFontFamilyStyle.GetHeaderStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetFiveHundredStyle(targetType)),
+            
+            [TextStyle.SectionHeader] = SharedFontFamilyStyle.GetUIStyle(targetType).ConcatenateWithStyle(SharedWeightStyle.GetFourHundredStyle(targetType))
+        };
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Shared/SharedWeightStyle.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Shared/SharedWeightStyle.cs
@@ -1,0 +1,132 @@
+namespace DIPS.Mobile.UI.Resources.Styles.Shared;
+
+public class SharedWeightStyle
+{
+    internal static Style GetOneThousandStyle(Type targetType) => new(targetType)
+    {
+        Setters =
+        {
+            new Setter
+            {
+                Property = GetFontSizeProperty(targetType),
+                Value = 64
+            }
+        }
+    };
+    
+    internal static Style GetNineHundredStyle(Type targetType) => new(targetType)
+    {
+        Setters =
+        {
+            new Setter
+            {
+                Property = GetFontSizeProperty(targetType),
+                Value = 64
+            }
+        }
+    };
+    
+    internal static Style GetEightHundredStyle(Type targetType) => new(targetType)
+    {
+        Setters =
+        {
+            new Setter
+            {
+                Property = GetFontSizeProperty(targetType),
+                Value = 40
+            }
+        }
+    };
+    
+    internal static Style GetSevenHundredStyle(Type targetType) => new(targetType)
+    {
+        Setters =
+        {
+            new Setter
+            {
+                Property = GetFontSizeProperty(targetType),
+                Value = 32
+            }
+        }
+    };
+    
+    internal static Style GetSixHundredStyle(Type targetType) => new(targetType)
+    {
+        Setters =
+        {
+            new Setter
+            {
+                Property = GetFontSizeProperty(targetType),
+                Value = 24
+            }
+        }
+    };
+    
+    internal static Style GetFiveHundredStyle(Type targetType) => new(targetType)
+    {
+        Setters =
+        {
+            new Setter
+            {
+                Property = GetFontSizeProperty(targetType),
+                Value = 20
+            }
+        }
+    };
+    
+    internal static Style GetFourHundredStyle(Type targetType) => new(targetType)
+    {
+        Setters =
+        {
+            new Setter
+            {
+                Property = GetFontSizeProperty(targetType),
+                Value = 18
+            }
+        }
+    };
+    
+    internal static Style GetThreeHundredStyle(Type targetType) => new(targetType)
+    {
+        Setters =
+        {
+            new Setter
+            {
+                Property = GetFontSizeProperty(targetType),
+                Value = 16
+            }
+        }
+    };
+    
+    internal static Style GetTwoHundredStyle(Type targetType) => new(targetType)
+    {
+        Setters =
+        {
+            new Setter
+            {
+                Property = GetFontSizeProperty(targetType),
+                Value = 14
+            }
+        }
+    };
+    
+    internal static Style GetOneHundredStyle(Type targetType) => new(targetType)
+    {
+        Setters =
+        {
+            new Setter
+            {
+                Property = GetFontSizeProperty(targetType),
+                Value = 12
+            }
+        }
+    };
+
+    private static BindableProperty GetFontSizeProperty(Type targetType)
+    {
+        if (targetType == typeof(Microsoft.Maui.Controls.Span))
+            return Microsoft.Maui.Controls.Span.FontSizeProperty;
+        
+        return Microsoft.Maui.Controls.Label.FontSizeProperty;
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Shared/TextStyle.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Shared/TextStyle.cs
@@ -1,0 +1,21 @@
+namespace DIPS.Mobile.UI.Resources.Styles.Shared;
+
+public enum TextStyle
+{
+    None=0,
+    Body400=1,
+    Body300=2,
+    Body200=3,
+    Body100=4,
+    UI400=5,
+    UI300=6,
+    UI200=7,
+    UI100=8,
+    Header1000=9,
+    Header900=10,
+    Header800=11,
+    Header700=12,
+    Header600=13,
+    Header500=14,
+    SectionHeader=15
+}

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Span/SpanStyle.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Span/SpanStyle.cs
@@ -1,8 +1,8 @@
 using DIPS.Mobile.UI.Resources.Styles.Shared;
 
-namespace DIPS.Mobile.UI.Resources.Styles.Label;
+namespace DIPS.Mobile.UI.Resources.Styles.Span;
 
-public enum LabelStyle
+public enum SpanStyle
 {
     None = TextStyle.None,
     Body400 = TextStyle.Body400,

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Span/SpanStyleResources.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Span/SpanStyleResources.cs
@@ -1,0 +1,28 @@
+using DIPS.Mobile.UI.Resources.Styles.Shared;
+
+namespace DIPS.Mobile.UI.Resources.Styles.Span;
+
+internal class SpanStyleResources
+{
+    private static readonly Dictionary<TextStyle, Style> s_sharedStyles = SharedStyleResources.GetStylesForType(typeof(Microsoft.Maui.Controls.Span));
+    
+    public static Dictionary<SpanStyle, Style> Styles { get; } = new()
+    {
+        [SpanStyle.None] = s_sharedStyles[TextStyle.None],
+        [SpanStyle.Body400] = s_sharedStyles[TextStyle.Body400],
+        [SpanStyle.Body300] = s_sharedStyles[TextStyle.Body300],
+        [SpanStyle.Body200] = s_sharedStyles[TextStyle.Body200],
+        [SpanStyle.Body100] = s_sharedStyles[TextStyle.Body100],
+        [SpanStyle.UI400] = s_sharedStyles[TextStyle.UI400],
+        [SpanStyle.UI300] = s_sharedStyles[TextStyle.UI300],
+        [SpanStyle.UI200] = s_sharedStyles[TextStyle.UI200],
+        [SpanStyle.UI100] = s_sharedStyles[TextStyle.UI100],
+        [SpanStyle.Header1000] = s_sharedStyles[TextStyle.Header1000],
+        [SpanStyle.Header900] = s_sharedStyles[TextStyle.Header900],
+        [SpanStyle.Header800] = s_sharedStyles[TextStyle.Header800],
+        [SpanStyle.Header700] = s_sharedStyles[TextStyle.Header700],
+        [SpanStyle.Header600] = s_sharedStyles[TextStyle.Header600],
+        [SpanStyle.Header500] = s_sharedStyles[TextStyle.Header500],
+        [SpanStyle.SectionHeader] = s_sharedStyles[TextStyle.SectionHeader]
+    };
+}

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Styles.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Styles.cs
@@ -3,6 +3,7 @@ using DIPS.Mobile.UI.Resources.Styles.Button;
 using DIPS.Mobile.UI.Resources.Styles.Chip;
 using DIPS.Mobile.UI.Resources.Styles.InputField;
 using DIPS.Mobile.UI.Resources.Styles.Label;
+using DIPS.Mobile.UI.Resources.Styles.Span;
 using DIPS.Mobile.UI.Resources.Styles.Tag;
 
 namespace DIPS.Mobile.UI.Resources.Styles;
@@ -24,6 +25,11 @@ public static class Styles
     public static Style GetLabelStyle(LabelStyle style)
     {
         return LabelStyleResources.Styles.TryGetValue(style, out var labelStyle) ? labelStyle : new Style(typeof(View));
+    }
+
+    public static Style GetSpanStyle(SpanStyle style)
+    {
+        return SpanStyleResources.Styles.TryGetValue(style, out var spanStyle) ? spanStyle : new Style(typeof(View));
     }
 
     public static Style GetInputFieldStyle(InputFieldStyle style)

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/StylesExtension.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/StylesExtension.cs
@@ -3,6 +3,7 @@ using DIPS.Mobile.UI.Resources.Styles.Button;
 using DIPS.Mobile.UI.Resources.Styles.Chip;
 using DIPS.Mobile.UI.Resources.Styles.InputField;
 using DIPS.Mobile.UI.Resources.Styles.Label;
+using DIPS.Mobile.UI.Resources.Styles.Span;
 using DIPS.Mobile.UI.Resources.Styles.Tag;
 
 namespace DIPS.Mobile.UI.Resources.Styles
@@ -25,6 +26,11 @@ namespace DIPS.Mobile.UI.Resources.Styles
         /// </summary>
         public LabelStyle Label { get; set; }
         
+        /// <summary>
+        /// The <see cref="SpanStyle"/> to look for.
+        /// </summary>
+        public SpanStyle Span { get; set; }
+        
         public InputFieldStyle InputField { get; set; }
         public AlertStyle Alert { get; set; }
         
@@ -45,6 +51,11 @@ namespace DIPS.Mobile.UI.Resources.Styles
             if (Label != LabelStyle.None)
             {
                 return Styles.GetLabelStyle(Label);
+            }
+
+            if (Span != SpanStyle.None)
+            {
+                return Styles.GetSpanStyle(Span);
             }
 
             if (InputField != InputFieldStyle.None)


### PR DESCRIPTION
### Description of Change

- [AlertView] Optimized layout.
- [AlertView][BreakingChange] Removed `ButtonAlignment`, `TitleMaxLines` and `DescriptionMaxLines` properties.
- [AlertView] The component now corresponds to figma.
- [AlertView] Added comprehensive accessibility support with proper screen reader announcements and navigation.
- [Label] Fixed bug where Spans would lose formatting from FormattedText when `TruncatedText` was set.
- [Label] Added `TruncatedTextStyle` property with new `SpanStyle` enum to apply span styles to custom truncation text.
- [Styles] Added `SpanStyle` enum and styling system for spans, with shared style definitions between `LabelStyle` and `SpanStyle` for easier maintenance.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->