### PR TITLE
[Tag] Fix wrong margin on tag without icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [49.9.7]
+- Fix wrong margin on tag without icon
+
 ## [49.9.6]
 - Update color resources
 - Revert changes that broke navigationlistitem with icon

--- a/src/library/DIPS.Mobile.UI/Components/Tag/Tag.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Tag/Tag.cs
@@ -16,8 +16,6 @@ public partial class Tag : Grid
         Padding = Sizes.GetSize(SizeName.size_half);
         UI.Effects.Layout.Layout.SetCornerRadius(this, Sizes.GetSize(SizeName.size_half));
         
-        ColumnSpacing = Sizes.GetSize(SizeName.size_1);
-        
         HorizontalOptions = LayoutOptions.Start;
 
         CreateIcon();
@@ -29,6 +27,7 @@ public partial class Tag : Grid
         var icon = new Images.Image.Image
         {
             HeightRequest = Sizes.GetSize(SizeName.size_4), WidthRequest = Sizes.GetSize(SizeName.size_4),
+            Margin = new Thickness(){Right = Sizes.GetSize(SizeName.size_1)}
         };
         
         icon.SetBinding(Image.SourceProperty, static (Tag tag) => tag.Icon, source: this);


### PR DESCRIPTION
### Description of Change

When tag has no icon, column spacing was still applied to the tag, making the margin on the left of the tab too big. Therefore applied margin right to the icon, instead of using column spacing.

### Todos
- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->