### PR TITLE
[CustomTruncationLabel] Text will now change if changing MaxLines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [51.0.1]
-- Fix
+- [Android] Fix crash on startup.
+- [CustomTruncationLabel] Text will now change if changing MaxLines.
 
 ## [51.0.0]
 - Added `CustomTruncationLabel`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [51.0.1]
+- Fix
+
 ## [51.0.0]
 - Added `CustomTruncationLabel`.
 

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -26,17 +26,16 @@
         <ToolbarItem Text="Hello"></ToolbarItem>
     </dui:ContentPage.ToolbarItems>
 
-    <dui:VerticalStackLayout>
+    <dui:VerticalStackLayout Padding="{dui:Thickness Left=size_3, Top=size_10, Right=size_3}">
         
-        <dui:VerticalStackLayout>
-            <dui:Label Text="Small Alert - Information - With Button"
-                       Style="{dui:Styles Label=SectionHeader}" />
-            <dui:AlertView Title="Alert With Button aisdjoaisjdioajds asidoiasjdoiasj "
-                           Style="{dui:Styles Alert=Information}"
-                           LeftButtonText="Test"
-                           LeftButtonCommand="{Binding CancelCommand}"
-                           LeftButtonCommandParameter="Here's the info!" />
-        </dui:VerticalStackLayout>
+        <dui:Switch x:Name="Switch" />
+        
+        <Grid ColumnDefinitions="*, *">
+        <dui:CustomTruncationLabel Text="Hello asodoiajsdoia sjdoiasjdoi asjiodajs idojasiodjasodi ajsoidjasoidjoaisjdioasjdioajsidojasio"
+                                   LineBreakMode="TailTruncation"
+                                   TruncatedText="Lol"
+                                   MaxLines="{Binding Source={x:Reference Switch}, Path=IsToggled, Converter={dui:BoolToObjectConverter TrueObject={x:Int32 1}, FalseObject={x:Int32 2}}}" />
+        </Grid>
         
         <!--<dui:AlertView Title="You have unsaved changes"
                        LeftButtonText="Save"

--- a/src/library/DIPS.Mobile.UI/Components/Labels/Android/LabelHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Labels/Android/LabelHandler.cs
@@ -1,7 +1,4 @@
 using Android.Text;
-using AndroidX.AppCompat.Widget;
-using Microsoft.Maui.Platform;
-using MauiTextView = DIPS.Mobile.UI.Components.Labels.Android.MauiTextView;
 
 namespace DIPS.Mobile.UI.Components.Labels;
 
@@ -9,9 +6,7 @@ public partial class LabelHandler
 {
     private static partial void MapOverrideMaxLinesAndLineBreakMode(LabelHandler handler, Label label)
     {
-        var textView = handler.PlatformView as MauiTextView;
-
-        textView.Ellipsize = label.LineBreakMode switch
+        handler.PlatformView.Ellipsize = label.LineBreakMode switch
         {
             LineBreakMode.NoWrap => null,
             LineBreakMode.WordWrap => null,
@@ -19,11 +14,9 @@ public partial class LabelHandler
             LineBreakMode.HeadTruncation => TextUtils.TruncateAt.Start,
             LineBreakMode.TailTruncation => TextUtils.TruncateAt.End,
             LineBreakMode.MiddleTruncation => TextUtils.TruncateAt.Middle,
-            _ => textView.Ellipsize
+            _ => handler.PlatformView.Ellipsize
         };
 
-        textView.SetMaxLines(label.MaxLines);
+        handler.PlatformView.SetMaxLines(label.MaxLines);
     }
-
-    
 }

--- a/src/library/DIPS.Mobile.UI/Components/Labels/CustomTruncationLabel.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Labels/CustomTruncationLabel.cs
@@ -3,13 +3,13 @@ using DIPS.Mobile.UI.Resources.Styles.Span;
 
 namespace DIPS.Mobile.UI.Components.Labels;
 
-public partial class CustomTruncationLabel : Microsoft.Maui.Controls.Label
+public partial class CustomTruncationLabel : Label
 {
     public CustomTruncationLabel()
     {
         this.SetAppThemeColor(TextColorProperty, ColorName.color_text_default);
         MaxLines = int.MaxValue;
-        Style = Label.DefaultLabelStyle;
+        Style = DefaultLabelStyle;
     }
     
     private void OnTextChanged()


### PR DESCRIPTION
### Description of Change

There were several issues with last PR:
* Android tried to convert to wrong platformview, crashing the app.
* CustomTruncationLabel did not inherit from dui:Label.
* Text did not change when changing MaxLines.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->