### PR TITLE
[Android][MultiItemsPicker] Fixed issue where ToString of the MultiItemsPicker would be visible if footer on the BottomSheet were not set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [51.2.1] 
+- [Android][MultiItemsPicker] Fixed issue where ToString of the MultiItemsPicker would be visible if footer on the BottomSheet were not set.
+
 ## [51.2.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -39,6 +39,37 @@
                                      TruncatedTextStyle="{dui:Styles Label=Header1000}"
                                      />
         
+        <dui:MultiItemsPicker VerticalOptions="Start"
+                              HorizontalOptions="Start"
+                              Placeholder="ok">
+            
+            <dui:MultiItemsPicker.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>Item 1</x:String>
+                    <x:String>Item 2</x:String>
+                    <x:String>Item 3</x:String>
+                    
+                </x:Array>
+            </dui:MultiItemsPicker.ItemsSource>
+           
+            <!--<dui:MultiItemsPicker.BottomSheetPickerConfiguration>
+            <dui:BottomSheetPickerConfiguration Title="Select multiple">
+                <dui:BottomSheetPickerConfiguration.FooterTemplate>
+                    <DataTemplate>
+                        <dui:AlertView
+                            Title="Writing a lot of text here, a long text that should span across multiple lines to see if we can recreate thing"
+                            Style="{dui:Styles Alert=Information}"
+                            Margin="{dui:Margin Top=size_2, Bottom=size_2, Right=size_3, Left=size_3}" />
+                    </DataTemplate>
+                </dui:BottomSheetPickerConfiguration.FooterTemplate>
+            </dui:BottomSheetPickerConfiguration>
+            
+            </dui:MultiItemsPicker.BottomSheetPickerConfiguration>-->
+        </dui:MultiItemsPicker>
+        
+        <dui:Editor HasBorder="True" BackgroundColor="Red" />
+        <dui:Entry />
+        
         <!--<dui:AlertView Title="You have unsaved changes"
                        LeftButtonText="Save"
                        ButtonAlignment="Auto"

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/MultiItemsPicker/MultiItemsPickerBottomSheet.cs
@@ -38,11 +38,11 @@ internal class MultiItemsPickerBottomSheet : BottomSheet
         
         collectionView.SetBinding(ItemsView.ItemsSourceProperty, static (MultiItemsPickerBottomSheet multiItemsPickerBottomSheet) => multiItemsPickerBottomSheet.Items, source: this);
         
-        collectionView.SetBinding(StructuredItemsView.FooterProperty, static (MultiItemsPickerBottomSheet multiItemsPickerBottomSheet) => multiItemsPickerBottomSheet.BindingContext, source: this);
-        collectionView.FooterTemplate = m_multiItemsPicker.BottomSheetPickerConfiguration.FooterTemplate;
-        
-        collectionView.SetBinding(StructuredItemsView.FooterProperty, static (MultiItemsPicker itemPicker) => itemPicker.BindingContext, source: m_multiItemsPicker);
-        collectionView.FooterTemplate = m_multiItemsPicker.BottomSheetPickerConfiguration.FooterTemplate;
+        if (m_multiItemsPicker.BottomSheetPickerConfiguration.FooterTemplate is not null)
+        {
+            collectionView.SetBinding(StructuredItemsView.FooterProperty, static (MultiItemsPicker itemPicker) => itemPicker.BindingContext, source: m_multiItemsPicker);
+            collectionView.FooterTemplate = m_multiItemsPicker.BottomSheetPickerConfiguration.FooterTemplate;
+        }
         
         Content = ItemPickerBottomSheet.CreateContentControlForActivityIndicator(collectionView, m_multiItemsPicker.BottomSheetPickerConfiguration);
 

--- a/src/library/DIPS.Mobile.UI/Components/TextFields/Editor/Editor.cs
+++ b/src/library/DIPS.Mobile.UI/Components/TextFields/Editor/Editor.cs
@@ -11,5 +11,6 @@ public partial class Editor : Microsoft.Maui.Controls.Editor
         FontSize = 16;
         TextColor = Colors.GetColor(ColorName.color_text_default);
         Keyboard = Keyboard.Text;
+        BackgroundColor = Colors.GetColor(ColorName.color_fill_default);
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/TextFields/Editor/Editor.cs
+++ b/src/library/DIPS.Mobile.UI/Components/TextFields/Editor/Editor.cs
@@ -11,6 +11,5 @@ public partial class Editor : Microsoft.Maui.Controls.Editor
         FontSize = 16;
         TextColor = Colors.GetColor(ColorName.color_text_default);
         Keyboard = Keyboard.Text;
-        BackgroundColor = Colors.GetColor(ColorName.color_fill_default);
     }
 }


### PR DESCRIPTION
### Description of Change

If the footer was not set, this would be shown: 
<img width="798" height="888" alt="image" src="https://github.com/user-attachments/assets/482742b7-c879-4858-8b6b-51d086dead3f" />


### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->