### PR TITLE
Vhv/bug 693425 extend chip close hitbox size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [45.9.9]
-- [Chip][iOS] Increased hitbox on chip close button on IOS
+- [Chip][iOS] Increased hitbox on close button.
 
 ## [45.9.8] 
 - Resources was updated from DIPS.Mobile.DesignTokens

--- a/src/library/DIPS.Mobile.UI/Components/Chips/iOS/Chip.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/iOS/Chip.cs
@@ -14,13 +14,25 @@ public partial class Chip
     private Label m_titleLabel;
     private Border m_border;
     private Grid m_container;
+    
+    private readonly double m_defaultContainerColumnSpacing = 
+        Sizes.GetSize(SizeName.content_margin_xsmall);
+    
+    private readonly Thickness m_defaultContainerPadding = 
+        new (Sizes.GetSize(SizeName.content_margin_small), Sizes.GetSize(SizeName.content_margin_xsmall));    
+    
+    private readonly Thickness m_containerPaddingWhenClosable = 
+        new (Sizes.GetSize(SizeName.content_margin_medium), 0, 0, 0);    
+    
+    private readonly Thickness m_titlePaddingWhenClosable = 
+        new (0, Sizes.GetSize(SizeName.content_margin_xsmall));
 
     internal void ConstructView()
     {
         m_container = new Grid
         {
-            ColumnSpacing = Sizes.GetSize(SizeName.content_margin_xsmall),
-            Padding = new Thickness(Sizes.GetSize(SizeName.content_margin_small), Sizes.GetSize(SizeName.content_margin_xsmall)),
+            ColumnSpacing = m_defaultContainerColumnSpacing,
+            Padding = m_defaultContainerPadding,
             ColumnDefinitions = 
             [
                 new ColumnDefinition(GridLength.Auto), 
@@ -174,9 +186,11 @@ public partial class Chip
         
         if (propertyName.Equals(nameof(IsCloseable)))
         {
-            m_container.Padding = new Thickness(Sizes.GetSize(SizeName.content_margin_medium), 0, 0, 0);
-            m_container.ColumnSpacing = 0;
-            m_titleLabel.Padding = new Thickness(0, Sizes.GetSize(SizeName.content_margin_xsmall));
+            m_container.Padding = IsCloseable ? m_containerPaddingWhenClosable : m_defaultContainerPadding;
+                
+            m_container.ColumnSpacing = IsCloseable ? 0 : m_defaultContainerColumnSpacing;
+            
+            m_titleLabel.Padding = IsCloseable ? m_titlePaddingWhenClosable : Thickness.Zero;
         }
     }
 


### PR DESCRIPTION
### Description of Change

Increased hitbox of close button on Chip on IOS to expand to the edges of the chip.

The hitbox now covers this area:
<img width="391" height="433" alt="image" src="https://github.com/user-attachments/assets/5a9a68ff-776d-4337-99fe-cfe83cdc306d" />


### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
PR targeting patch/3.9.3 branch for Arena Mobile patch 3.9.3.
-->