### PR TITLE
[ScrollPicker][iOS] Fixed bug where `ScrollPicker` could not be used when residing in a modal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [51.3.2]
+- [ScrollPicker][iOS] Fixed bug where `ScrollPicker` could not be used when residing in a modal.
+
 ## [51.3.1]
 - [Chip][iOS] Increased hitbox on close button.
 

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -28,66 +28,8 @@
 
     <dui:VerticalStackLayout Padding="{dui:Thickness Left=size_3, Top=size_10, Right=size_3}">
         
-        <dui:AlertView Title="Hello this is vetle speakinga soidjoaisjdoiasjdoiasjsaioj asoidjasoij asdasdasdasdsa LOLOLO"
-                       
-                       />
+        <dui:ScrollPicker Components="{Binding ItemComponents}" />
         
-        <dui:CheckTruncatedLabel Text="Hello this is vetle speakinga soidjoaisjdoiasjdoiasjsaioj asoidjasoij asdasdasdasdsa LOLOLO"
-                                     MaxLines="2"
-                                     
-                                     Style="{dui:Styles Label=Header1000}"
-                                     TruncatedTextStyle="{dui:Styles Label=Header1000}"
-                                     />
-        
-        <dui:MultiItemsPicker VerticalOptions="Start"
-                              HorizontalOptions="Start"
-                              Placeholder="ok">
-            
-            <dui:MultiItemsPicker.ItemsSource>
-                <x:Array Type="{x:Type x:String}">
-                    <x:String>Item 1</x:String>
-                    <x:String>Item 2</x:String>
-                    <x:String>Item 3</x:String>
-                    
-                </x:Array>
-            </dui:MultiItemsPicker.ItemsSource>
-           
-            <!--<dui:MultiItemsPicker.BottomSheetPickerConfiguration>
-            <dui:BottomSheetPickerConfiguration Title="Select multiple">
-                <dui:BottomSheetPickerConfiguration.FooterTemplate>
-                    <DataTemplate>
-                        <dui:AlertView
-                            Title="Writing a lot of text here, a long text that should span across multiple lines to see if we can recreate thing"
-                            Style="{dui:Styles Alert=Information}"
-                            Margin="{dui:Margin Top=size_2, Bottom=size_2, Right=size_3, Left=size_3}" />
-                    </DataTemplate>
-                </dui:BottomSheetPickerConfiguration.FooterTemplate>
-            </dui:BottomSheetPickerConfiguration>
-            
-            </dui:MultiItemsPicker.BottomSheetPickerConfiguration>-->
-        </dui:MultiItemsPicker>
-        
-        <dui:Editor HasBorder="True" BackgroundColor="Red" />
-        <dui:Entry />
-        
-        <!--<dui:AlertView Title="You have unsaved changes"
-                       LeftButtonText="Save"
-                       ButtonAlignment="Auto"
-                       LeftButtonCommand="{Binding CompletedCommand}" />
-        
-        <dui:AlertView Title="Test asidoasoidjoaisjd asoidjsaoidjasiodjai askld masoid masoiso"
-                       LeftButtonText="Yo"
-                       ButtonAlignment="Underlying"
-                       LeftButtonCommand="{Binding CompletedCommand}"></dui:AlertView>
-        
-        <dui:AlertView Title="Test" />
-        
-        <dui:AlertView Title="Test asdk asksaopdkaspodka sodkasoidkasio djaiosdjsoid mjoisj doiasj doiasj doisajdoiasjdoiasjdoias jdoiasjdoiasjdoisajdosajdoiasjd aoisdjaoisdjasiodjas oidjsa"
-                       Description="Hello"
-                       ButtonAlignment="Underlying"
-                       LeftButtonCommand="{Binding CompletedCommand}"
-                       LeftButtonText="STRE"/>-->
-    
     </dui:VerticalStackLayout>
     
     

--- a/src/app/Playground/VetleSamples/VetlePageViewModel.cs
+++ b/src/app/Playground/VetleSamples/VetlePageViewModel.cs
@@ -1,8 +1,10 @@
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Windows.Input;
 using DIPS.Mobile.UI.Components.Alerting.Dialog;
 using DIPS.Mobile.UI.Components.Loading.StateView;
+using DIPS.Mobile.UI.Components.Pickers.ScrollPicker.Component;
 using DIPS.Mobile.UI.Components.Sorting;
 using DIPS.Mobile.UI.Components.VoiceVisualizer;
 using DIPS.Mobile.UI.MVVM;
@@ -89,7 +91,40 @@ public class VetlePageViewModel : ViewModel
         GroupedTest = [new(["Test"]), new(TestStrings.ToList())];
 
         _ = GenerateRandomWords();
+        
+        var currentWeek = GetCurrentWeek();
+        var test = Enumerable.Range(1, GetNumberOfWeeksInCurrentYear() - 1).ToList();
+        var nullableItems = new StandardScrollPickerComponent<int>(test, currentWeek, OnSelectedItemChanged, true, true);
+        ItemComponents = [nullableItems];
     }
+    
+    private static int GetCurrentWeek()
+    {
+        var dfi = DateTimeFormatInfo.CurrentInfo;
+        var date = DateTime.Now;
+        var cal = dfi.Calendar;
+        return cal.GetWeekOfYear(date, dfi.CalendarWeekRule, dfi.FirstDayOfWeek);
+    }
+    
+    private static int GetNumberOfWeeksInCurrentYear()
+    {
+        var dfi = DateTimeFormatInfo.CurrentInfo;
+        var date1 = new DateTime(DateTime.Now.Year, 12, 31);
+        var cal = dfi.Calendar;
+        return cal.GetWeekOfYear(date1, dfi.CalendarWeekRule, dfi.FirstDayOfWeek);
+    }
+    
+    private async void OnSelectedItemChanged(int obj)
+    {
+        if (obj == -1)
+        {
+            await Task.Delay(1000);
+            ItemComponents[0].SetSelectedIndex(2);
+            ItemComponents[0].InvalidateData();
+        }
+    }
+    
+    public List<IScrollPickerComponent> ItemComponents { get; set; }
 
     private async Task GenerateRandomWords()
     {

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/iOS/ScrollPickerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/iOS/ScrollPickerHandler.cs
@@ -72,13 +72,10 @@ public partial class ScrollPickerHandler : ViewHandler<ScrollPicker, UIView>
 
     private void OnTapped(Chip chip)
     {
-        if (PlatformView.Window.RootViewController is not {} rootViewController)
-            return;
-        
         m_scrollPickerViewController = new ScrollPickerViewController();
         m_scrollPickerViewController.Setup(chip, m_scrollPickerViewModel, OnClear);
         
-        _ = rootViewController.PresentViewControllerAsync(m_scrollPickerViewController, true);
+        _ = Platform.GetCurrentUIViewController()?.PresentViewControllerAsync(m_scrollPickerViewController, true);
     }
 
     private void OnClear()


### PR DESCRIPTION
### Description of Change

There was an issue when fetching the root controller. It always fetched ShellFlyoutRenderer. Now we actually fetch the current UIViewController

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->