### PR TITLE
[Android] Update nuget packages to support 16kb page sizes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [51.2.0]
+## [51.3.3]
 - [Android] Update nuget packages to support 16kb page sizes.
 
 ## [51.3.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [51.2.0]
+- [Android] Update nuget packages to support 16kb page sizes.
+
 ## [51.3.2]
 - [ScrollPicker][iOS] Fixed bug where `ScrollPicker` could not be used when residing in a modal.
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -10,15 +10,15 @@
     <PackageVersion Include="LightInject" Version="6.6.4" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.100" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
-    <PackageVersion Include="SkiaSharp.Extended.UI.Maui" Version="2.0.0-preview.92" />
+    <PackageVersion Include="SkiaSharp.Extended.UI.Maui" Version="3.0.0-preview.18" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <!-- Android -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'">
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.12" />
     <PackageVersion Include="Xamarin.Google.MLKit.BarcodeScanning" Version="117.3.0" />
-    <PackageVersion Include="Xamarin.AndroidX.Camera.View" Version="1.3.4.3" />
-    <PackageVersion Include="Xamarin.AndroidX.Camera.Camera2" Version="1.3.4.3" />
+    <PackageVersion Include="Xamarin.AndroidX.Camera.View" Version="1.4.1" />
+    <PackageVersion Include="Xamarin.AndroidX.Camera.Camera2" Version="1.4.1" />
   </ItemGroup>
   <!-- Unit tests -->
   <ItemGroup>

--- a/src/app/Components/ComponentsSamples/Chips/ChipsSamples.xaml
+++ b/src/app/Components/ComponentsSamples/Chips/ChipsSamples.xaml
@@ -38,9 +38,6 @@
                       IsCloseable="True"
                       HorizontalOptions="Start"
                       VerticalOptions="Start"
-                      Color="{dui:Colors color_primary_80}"
-                      TitleColor="{dui:Colors color_system_white}"
-                      CloseButtonColor="{dui:Colors color_system_white}"
                       Tapped="Chip_OnTapped"
                       CloseTapped="Chip_OnCloseTapped" />
         </HorizontalStackLayout>

--- a/src/library/DIPS.Mobile.UI/API/Camera/Shared/Android/CameraFragment.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Shared/Android/CameraFragment.cs
@@ -122,7 +122,9 @@ public abstract class CameraFragment : Fragment
         PreviewUseCase = new AndroidX.Camera.Core.Preview.Builder()
             .SetResolutionSelector(resolutionSelector)
             .Build();
-        PreviewUseCase.SetSurfaceProvider(PreviewView?.SurfaceProvider);
+        
+        var cameraExecutor = Executors.NewSingleThreadExecutor() ?? throw new Exception($"Unable to retrieve {nameof(IExecutorService)}");
+        PreviewUseCase.SetSurfaceProvider(cameraExecutor, PreviewView?.SurfaceProvider);
         
         await WaitForPreviewViewToInitialize();
 


### PR DESCRIPTION
### Description of Change

Skiasharp and the camera packages did not support 16kb page sizes, they are now updated to do so.

For more information: https://developer.android.com/guide/practices/page-sizes
TL;DR: Android 16 only uses 16kb page sizes for apps (Use more memory, better performance etc). We have to support 16kb page sizes to be able to deploy to Android 16 devices.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->