### PR TITLE
[ScrollPicker][iOS] Fixed bug where `ScrollPicker` could not be used when residing in a modal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [45.9.11]
+- [ScrollPicker][iOS] Fixed bug where `ScrollPicker` could not be used when residing in a modal.
+
 ## [45.9.10]
 - [Chip][iOS] Added back removed tint logic.
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/iOS/ScrollPickerHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ScrollPicker/iOS/ScrollPickerHandler.cs
@@ -72,13 +72,10 @@ public partial class ScrollPickerHandler : ViewHandler<ScrollPicker, UIView>
 
     private void OnTapped(Chip chip)
     {
-        if (PlatformView.Window.RootViewController is not {} rootViewController)
-            return;
-        
         m_scrollPickerViewController = new ScrollPickerViewController();
         m_scrollPickerViewController.Setup(chip, m_scrollPickerViewModel, OnClear);
         
-        _ = rootViewController.PresentViewControllerAsync(m_scrollPickerViewController, true);
+        _ = Platform.GetCurrentUIViewController()?.PresentViewControllerAsync(m_scrollPickerViewController, true);
     }
 
     private void OnClear()


### PR DESCRIPTION
### Description of Change

CP from main

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->