### PR TITLE
Fixed LoadingOverlay creation when handler is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [51.3.4]
+- Fixed LoadingOverlay not functioning properly.
+
 ## [51.3.3]
 - [Android] Update nuget packages to support 16kb page sizes.
 

--- a/src/library/DIPS.Mobile.UI/Components/Loading/LoadingOverlay/LoadingOverlay.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Loading/LoadingOverlay/LoadingOverlay.Properties.cs
@@ -4,9 +4,9 @@ namespace DIPS.Mobile.UI.Components.Loading.LoadingOverlay;
 
 public partial class LoadingOverlay
 {
-    public View Content
+    public View? Content
     {
-        get => (View)GetValue(ContentProperty);
+        get => (View?)GetValue(ContentProperty);
         set => SetValue(ContentProperty, value);
     }
 

--- a/src/library/DIPS.Mobile.UI/Components/Loading/LoadingOverlay/LoadingOverlay.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Loading/LoadingOverlay/LoadingOverlay.cs
@@ -63,21 +63,23 @@ public partial class LoadingOverlay : Grid
             return;
         
         Insert(0, Content);
+        _ = OnIsBusyChanged();
     }
 
     private async Task OnIsBusyChanged()
     {
-        if (IsBusy)
+        if (Handler is null) return;
+        if (IsBusy && m_overlay is null)
         {
             m_overlay = CreateOverlay();
             m_overlay.Opacity = 0;
             Add(m_overlay);
             _ = m_overlay.FadeTo(1);
-            _ = Content.FadeTo(ContentFadeOutValue);
+            _ = Content?.FadeTo(ContentFadeOutValue);
         }
         else if(m_overlay is not null)
         {
-            _ = Content.FadeTo(1);
+            _ = Content?.FadeTo(1);
             await m_overlay.FadeTo(0);
             m_overlay.DisconnectHandlers();
             Remove(m_overlay);


### PR DESCRIPTION
### Description of Change

In certain cases LoadingOverlay Text and ContentFadeOutValue did not work since Handler on LoadingOverlay was null when initializing

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->