### PR TITLE
InvertedBoolConverter now supports nullable bools.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [51.4.0]
+- InvertedBoolConverter now supports nullable bools.
+
 ## [51.3.4]
 - Fixed LoadingOverlay not functioning properly.
 

--- a/src/library/DIPS.Mobile.UI/Converters/ValueConverters/InvertedBoolConverter.cs
+++ b/src/library/DIPS.Mobile.UI/Converters/ValueConverters/InvertedBoolConverter.cs
@@ -29,7 +29,8 @@ namespace DIPS.Mobile.UI.Converters.ValueConverters
         /// <returns></returns>
         public object Convert(object? value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null || !bool.TryParse(value.ToString(), out var booleanValue))
+            value ??= false;
+            if (!bool.TryParse(value.ToString(), out var booleanValue))
             {
                 throw new XamlParseException("Value has to be of type boolean").WithXmlLineInfo(m_serviceProvider);
             }

--- a/src/tests/unittests/Converters/ValueConverters/InvertedBoolConverterTests.cs
+++ b/src/tests/unittests/Converters/ValueConverters/InvertedBoolConverterTests.cs
@@ -25,8 +25,7 @@ namespace DIPS.Mobile.UI.UnitTests.Converters.ValueConverters
         [InlineData("Not a bool")]
         [InlineData(0)]
         [InlineData(0.1)]
-        [InlineData(null)]
-        public void Convert_ValueIsNull_XamlParseExceptionThrown(object value)
+        public void Convert_InvalidInput_XamlParseExceptionThrown(object value)
         {
             Action act = () => m_invertedBoolConverter.Convert(value, null!, null!, null!);
 
@@ -40,6 +39,13 @@ namespace DIPS.Mobile.UI.UnitTests.Converters.ValueConverters
         {
             var result = m_invertedBoolConverter.ConvertBack(value, null!, null!, null!);
             result.Should().Be(value);
+        }
+        
+        [Fact]
+        public void Convert_NullValue_ReturnsTrue()
+        {
+            var result = m_invertedBoolConverter.Convert(null, null!, null!, null!);
+            result.Should().Be(false);
         }
     }
 }

--- a/src/tests/unittests/Converters/ValueConverters/InvertedBoolConverterTests.cs
+++ b/src/tests/unittests/Converters/ValueConverters/InvertedBoolConverterTests.cs
@@ -45,7 +45,7 @@ namespace DIPS.Mobile.UI.UnitTests.Converters.ValueConverters
         public void Convert_NullValue_ReturnsTrue()
         {
             var result = m_invertedBoolConverter.Convert(null, null!, null!, null!);
-            result.Should().Be(false);
+            result.Should().Be(true);
         }
     }
 }


### PR DESCRIPTION
### Description of Change

If the consumer sends a null value to the converter, it threw an exception and the app crashed. Nullable bools is not great, but the converter should handle it.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->