### PR TITLE
[iOS] Automatically set compliance when in App Store Connect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [52.0.2]
+- [iOS] Automatically set compliance when in App Store Connect.
+
 ## [52.0.1]
 - [Layout][Android] Fix bug where setting `Stroke` would not appear visually sometimes.
 

--- a/src/app/Components/Platforms/iOS/Info.plist
+++ b/src/app/Components/Platforms/iOS/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleIdentifier</key>
 	<string>com.dipsas.components</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>MinimumOSVersion</key>
 	<string>14.1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -34,12 +34,17 @@
                    Margin="{dui:Thickness Left=size_3, Right=size_3}" />
     
     
-    <dui:ListItem Title="Helllo"
-                  
-                  dui:Layout.Stroke="{dui:Colors color_border_default}"
-                  dui:Touch.Command="{Binding CancelCommand}"
-                  Margin="{dui:Thickness size_3}"
-                  ></dui:ListItem>
+    <Grid HeightRequest="50"
+          WidthRequest="50"
+          BackgroundColor="Red"
+          
+          
+          dui:Touch.Command="{Binding CancelCommand}"
+          dui:Layout.StrokeThickness="10"
+          dui:Layout.Stroke="{dui:Colors color_palette_green_900}">
+        
+        
+        </Grid>
     
     </VerticalStackLayout>
     

--- a/src/library/DIPS.Mobile.UI/Effects/Layout/Android/LayoutPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Layout/Android/LayoutPlatformEffect.cs
@@ -10,16 +10,16 @@ namespace DIPS.Mobile.UI.Effects.Layout;
 
 public partial class LayoutPlatformEffect
 {
-    private Drawable? _originalBackground;
-    private Drawable? _originalForeground;
+    private Drawable? m_originalBackground;
+    private Drawable? m_originalForeground;
 
     private partial void PlatformOnAttached(CornerRadius? cornerRadius, Color? stroke)
     {
         if (Control == null)
             return;
 
-        _originalBackground = Control.Background;
-        _originalForeground = Control.Foreground;
+        m_originalBackground = Control.Background;
+        m_originalForeground = Control.Foreground;
 
         var strokeThickness = Layout.GetStrokeThickness(Element);
 
@@ -54,7 +54,7 @@ public partial class LayoutPlatformEffect
         if (Control == null)
             return;
 
-        Control.Background = _originalBackground;
-        Control.Foreground = _originalForeground;
+        Control.Background = m_originalBackground;
+        Control.Foreground = m_originalForeground;
     }
 }


### PR DESCRIPTION
### Description of Change

When this key is set we no longer need to manually click something in App Store Connect to make it so its published to internal testing.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->