### PR TITLE
Fix Design Token Resource Generation

### DIFF
--- a/build/AwesomeBuildsystem/Helpers/WriteToFileHelper.csx
+++ b/build/AwesomeBuildsystem/Helpers/WriteToFileHelper.csx
@@ -37,7 +37,19 @@ public static class WriteToFileHelper
         //Remove enums
         foreach (var enumToRemove in enumsToRemove)
         {
-            enumContent = RemoveTextFromContentWithCommas(enumContent, () => enums.FirstOrDefault(s => s.Contains(enumToRemove)));
+            // Use more precise matching to avoid partial matches (e.g., "clock_line" matching "lock_line")
+            enumContent = RemoveTextFromContentWithCommas(enumContent, () => {
+                return enums.FirstOrDefault(s => {
+                    var trimmed = s.Trim();
+                    // Extract the enum name (before the '=')
+                    if (trimmed.Contains("="))
+                    {
+                        var enumName = trimmed.Substring(0, trimmed.IndexOf('=')).Trim();
+                        return enumName == enumToRemove;
+                    }
+                    return false;
+                });
+            });
         }
 
         //Insert generated comment


### PR DESCRIPTION
### Problem
SVG files could exist in the library but be missing from `IconResources.cs` and `IconName.cs` when no file changes were detected. Additionally, string matching used `.Contains()` which could cause partial name matches.

### Solution
- Added validation in `DesignTokenApplier.csx` to detect and automatically add missing entries
- Improved string matching in `WriteToFileHelper.csx` to use exact name comparison instead of `.Contains()`

### Impact
Ensures design token resources remain consistent and complete, preventing missing entries in generated files.