### PR TITLE
[Alert] Fix accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [54.2.4]
+- [Alert] Fixed accessibility
+
 ## [54.2.3]
 - [Touch] Added IsButtonTraitEnabledProperty to allow consumer to disable button trait on Touch effect.
 - [MultiLineInputField][SingleLineInputField] Enhanced accessability, screen reader now announces the value of the field and that it is an input field, and all buttons are available in navigation

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.Properties.cs
@@ -220,6 +220,18 @@ public partial class AlertView
         get => (Color)GetValue(StrokeProperty);
         set => SetValue(StrokeProperty, value);
     }   
+    
+    internal static readonly BindableProperty AlertTypeProperty = BindableProperty.Create(
+        nameof(AlertType),
+        typeof(string),
+        typeof(AlertView),
+        propertyChanged: (bindable, _, newValue) => ((AlertView)bindable).UpdateAccessibility());
+
+    internal string AlertType
+    {
+        get => (string)GetValue(AlertTypeProperty);
+        set => SetValue(AlertTypeProperty, value);
+    } 
 }
 
 public enum AlertTitleTruncationMode

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.cs
@@ -254,36 +254,6 @@ public partial class AlertView : Grid
         }
     }
 
-    private AlertStyle GetCurrentAlertType()
-    {
-        // Infer alert type from the icon property value set by the style
-        var iconSource = Icon?.ToString();
-        
-        if (iconSource != null)
-        {
-            if (iconSource.Contains("important_line"))
-                return AlertStyle.Error;
-            if (iconSource.Contains("alert_line"))
-                return AlertStyle.Warning;
-            if (iconSource.Contains("check_circle_line"))
-                return AlertStyle.Success;
-            if (iconSource.Contains("information_line"))
-                return AlertStyle.Information;
-        }
-        
-        // Fallback: check background color
-        var backgroundColor = BackgroundColor;
-        if (Equals(backgroundColor, Colors.GetColor(ColorName.color_surface_danger)))
-            return AlertStyle.Error;
-        if (Equals(backgroundColor, Colors.GetColor(ColorName.color_surface_warning)))
-            return AlertStyle.Warning;
-        if (Equals(backgroundColor, Colors.GetColor(ColorName.color_surface_success)))
-            return AlertStyle.Success;
-            
-        // Default to Information
-        return AlertStyle.Information;
-    }
-
     private void UpdateAccessibility()
     {
         // Make the container non-focusable to allow navigation to child elements
@@ -293,18 +263,17 @@ public partial class AlertView : Grid
         if (m_titleAndDescriptionLabel != null)
         {
             SemanticProperties.SetDescription(m_titleAndDescriptionLabel, GetAccessibilityDescription());
-            SemanticProperties.SetHeadingLevel(m_titleAndDescriptionLabel, SemanticHeadingLevel.Level2);
         }
     }
 
     private string GetAccessibilityDescription()
     {
-        var alertTypeName = GetAlertTypeName();
+        var alertTypeName = AlertType;
         var description = $"{alertTypeName}";
         
         if (!string.IsNullOrEmpty(Title))
         {
-            description += $". {Title}";
+            description += $". {Title}. {DUILocalizedStrings.Header}";
         }
         
         if (!string.IsNullOrEmpty(Description))
@@ -313,18 +282,6 @@ public partial class AlertView : Grid
         }
         
         return description;
-    }
-
-    private string GetAlertTypeName()
-    {
-        return GetCurrentAlertType() switch
-        {
-            AlertStyle.Information => DUILocalizedStrings.Information,
-            AlertStyle.Error => DUILocalizedStrings.Error,
-            AlertStyle.Warning => DUILocalizedStrings.Warning,
-            AlertStyle.Success => DUILocalizedStrings.Success,
-            _ => DUILocalizedStrings.Alert
-        };
     }
 
     /// <summary>

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.Designer.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.Designer.cs
@@ -506,5 +506,11 @@ namespace DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings {
                 return ResourceManager.GetString("Dictation", resourceCulture);
             }
         }
+        
+        internal static string Header {
+            get {
+                return ResourceManager.GetString("Header", resourceCulture);
+            }
+        }
     }
 }

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.en.resx
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.en.resx
@@ -242,4 +242,7 @@
     <data name="Dictation" xml:space="preserve">
         <value>Dictation</value>
     </data>
+    <data name="Header" xml:space="preserve">
+        <value>Header</value>
+    </data>
 </root>

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.resx
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.resx
@@ -249,4 +249,7 @@
     <data name="Dictation" xml:space="preserve">
         <value>Diktering</value>
     </data>
+    <data name="Header" xml:space="preserve">
+        <value>Overskrift</value>
+    </data>
 </root>

--- a/src/library/DIPS.Mobile.UI/Resources/Styles/Alert/AlertTypeStyle.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/Styles/Alert/AlertTypeStyle.cs
@@ -1,4 +1,5 @@
 using DIPS.Mobile.UI.Components.Alerting.Alert;
+using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
 
 namespace DIPS.Mobile.UI.Resources.Styles.Alert;
 
@@ -32,6 +33,11 @@ public class AlertTypeStyle
             {
                 Property = AlertView.TextColorProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_text_on_surface_information)
+            },
+            new Setter
+            {
+                Property = AlertView.AlertTypeProperty,
+                Value = DUILocalizedStrings.Information
             }
         }
     };
@@ -64,6 +70,11 @@ public class AlertTypeStyle
             {
                 Property = AlertView.TextColorProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_text_on_surface_danger)
+            },
+            new Setter
+            {
+                Property = AlertView.AlertTypeProperty,
+                Value = DUILocalizedStrings.Error
             }
         }
     };
@@ -96,6 +107,11 @@ public class AlertTypeStyle
             {
                 Property = AlertView.TextColorProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_text_on_surface_warning)
+            },
+            new Setter
+            {
+                Property = AlertView.AlertTypeProperty,
+                Value = DUILocalizedStrings.Warning
             }
         }
     };
@@ -128,6 +144,11 @@ public class AlertTypeStyle
             {
                 Property = AlertView.TextColorProperty,
                 Value = Colors.Colors.GetColor(ColorName.color_text_on_surface_success)
+            },
+            new Setter
+            {
+                Property = AlertView.AlertTypeProperty,
+                Value = DUILocalizedStrings.Success
             }
         }
     };


### PR DESCRIPTION
### Description of Change

Earlier all alerts were read as information, since at the time the semantic description was set, the alert type was not updated correctly yet. Implemented an internal bindable property for the alert type, that is set by the style, and when it changes the semantic description is updated.

Previously, both the title and description were read before the header annotation were read. AC states that it should say header after the title and before the description. Since the title and description is spans inside one label, this was solved by directly appending the header text after the title text when semantic description is set.