### PR TITLE
[iOS][Chip] Fix accessibility

### DIFF
--- a/src/library/DIPS.Mobile.UI/Components/Chips/Chip.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/Chip.cs
@@ -33,9 +33,6 @@ public partial class Chip : ContentView
 
     private void OnIsToggledChanged()
     {
-#if __IOS__
-        SetSemanticDescription();
-#endif
         if (!IsToggled)
         {
             if (m_buttonToggleStyle is not null)

--- a/src/library/DIPS.Mobile.UI/Components/Chips/iOS/Chip.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/iOS/Chip.cs
@@ -180,6 +180,7 @@ public partial class Chip
         if (IsToggleable)
         {
             IsToggled = !IsToggled;
+            SetSemanticDescription();
             SendTapped();
         }
         else if (didTouchCloseButton)


### PR DESCRIPTION
### Description of Change

Problem: Screen reader did not announce that a chip was a button, and it did not say if a chip was toggled. This worked by default on android.

Solution: Fixed this by adding it to the semantic description.  

On android I found a bug on chip, that if it is closable, it will not set focus on the close icon. Tried to fix, but as this is a native component there were not much to do. Maybe it is improved in material design 3?

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [X] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->