### PR TITLE
[BottomSheet][iOS] Fixed memory leak where the entire visual tree was retained after closing a BottomSheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [55.6.5]
+- [BottomSheet][iOS] Fixed memory leak where the entire visual tree was retained after closing a BottomSheet
+
 ## [55.6.4]
 - Fixed multiple memory leaks across components: unsubscribed events in `BottomSheetHandler`, `BaseDatePickerHandler`, `BaseNullableDatePicker`, `TabView`, `Shell`, `SkeletonView`, `SegmentedControl`, `StateView`, `ItemPicker`, `SearchPage`, `ScrollPickerHandler`, `FloatingNavigationButton`, `GalleryBottomSheet`, and `SystemMessage`
 

--- a/src/app/Playground/VetleSamples/NavigationListItemLeakBottomSheet.xaml
+++ b/src/app/Playground/VetleSamples/NavigationListItemLeakBottomSheet.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<dui:BottomSheet xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:dui="http://dips.com/mobile.ui"
+                 x:Class="Playground.VetleSamples.NavigationListItemLeakBottomSheet"
+                 Title="Memory Leak Repro">
+
+    <dui:ScrollView Padding="16">
+        <dui:VerticalStackLayout x:Name="ItemsLayout"
+                                 dui:Layout.AutoHideLastDivider="True">
+            <dui:NavigationListItem Title="Item 1"
+                                    HasBottomDivider="True" />
+            <dui:NavigationListItem Title="Item 2"
+                                    HasBottomDivider="True" />
+            <dui:NavigationListItem Title="Item 3"
+                                    HasBottomDivider="True" />
+            <dui:NavigationListItem Title="Item 4"
+                                    HasBottomDivider="True" />
+            <dui:NavigationListItem Title="Item 5"
+                                    HasBottomDivider="True" />
+        </dui:VerticalStackLayout>
+    </dui:ScrollView>
+</dui:BottomSheet>

--- a/src/app/Playground/VetleSamples/NavigationListItemLeakBottomSheet.xaml.cs
+++ b/src/app/Playground/VetleSamples/NavigationListItemLeakBottomSheet.xaml.cs
@@ -1,0 +1,9 @@
+namespace Playground.VetleSamples;
+
+public partial class NavigationListItemLeakBottomSheet
+{
+    public NavigationListItemLeakBottomSheet()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/iOS/BottomSheetNavigationBarHelper.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/iOS/BottomSheetNavigationBarHelper.cs
@@ -120,5 +120,8 @@ internal class BottomSheetNavigationBarHelper
         {
             m_bottomSheet.BottomSheetHeaderBehavior.PropertyChanged -= OnHeaderBehaviorPropertyChanged;
         }
+        
+        m_navigationItem.RightBarButtonItem = null;
+        m_navigationItem.LeftBarButtonItem = null;
     }
 }


### PR DESCRIPTION
The leak was introduced in #821 (native iOS navigation bar for BottomSheet).

### Fix
Clear `RightBarButtonItem` and `LeftBarButtonItem` on the `UINavigationItem` in `BottomSheetNavigationBarHelper.Dispose()`, breaking the reference chain and allowing the entire visual tree to be garbage collected.

### Changed files
- `BottomSheetNavigationBarHelper.cs` — null out bar button items in `Dispose()`