### PR TITLE
Fixed memory leak where modal pages with `ToolbarItems` were retained after dismissal when using `x:Name` on any element in the page or `Clicked` event on the `ToolbarItem`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [55.6.6]
+- Fixed memory leak where modal pages with `ToolbarItems` were retained after dismissal when using `x:Name` on any element in the page or `Clicked` event on the `ToolbarItem`.
+
 ## [55.6.5]
 - [BottomSheet][iOS] Fixed memory leak where the entire visual tree was retained after closing a BottomSheet
 

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
@@ -1,7 +1,6 @@
 using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.Internal.Logging;
 using DIPS.Mobile.UI.MemoryManagement;
-using Microsoft.Maui.Controls.Internals;
 using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 
 namespace DIPS.Mobile.UI.Components.Shell;

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
@@ -1,6 +1,7 @@
 using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.Internal.Logging;
 using DIPS.Mobile.UI.MemoryManagement;
+using Microsoft.Maui.Controls.Internals;
 using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 
 namespace DIPS.Mobile.UI.Components.Shell;
@@ -150,6 +151,7 @@ public partial class Shell : Microsoft.Maui.Controls.Shell
                 GarbageCollection.Print($"--- 🪟 Attempting to check for leaks in every page that has ever been opened in modal: {modalPage.Name}, number of pages: {modalPage.WeakPages.Count}");
                 
                 TryAutoDisconnectModalNavigationPageHandler(modalPage);
+                ClearToolbarItems(modalPage);
                 
                 // The object has already been garbage collected
                 if (!modalPage.IsAlive)
@@ -241,6 +243,29 @@ public partial class Shell : Microsoft.Maui.Controls.Shell
                 GarbageCollection.Print("🔧 Disconnecting handler manually...");
                 contentPage.DisconnectHandlers();
             }
+        }
+    }
+
+    /// <summary>
+    /// Clears ToolbarItems on modal pages to break the reference chain from native toolbar infrastructure
+    /// back to the page. Without this, the native navigation bar retains toolbar item handlers which root
+    /// the page, and any x:Name'd elements remain alive through the generated code-behind fields.
+    /// </summary>
+    private static void ClearToolbarItems(ModalPageReference modalPage)
+    {
+        GarbageCollection.Print("ℹ️ Clearing ToolbarItems...");
+        
+        foreach (var weakPage in modalPage.WeakPages)
+        {
+            if (weakPage.Target is Page page)
+            {
+                page.ToolbarItems.Clear();
+            }
+        }
+        
+        if (modalPage.Target is Page modalRoot)
+        { 
+            modalRoot.ToolbarItems.Clear();
         }
     }
 

--- a/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Shell/Shell.cs
@@ -250,6 +250,7 @@ public partial class Shell : Microsoft.Maui.Controls.Shell
     /// Clears ToolbarItems on modal pages to break the reference chain from native toolbar infrastructure
     /// back to the page. Without this, the native navigation bar retains toolbar item handlers which root
     /// the page, and any x:Name'd elements remain alive through the generated code-behind fields.
+    /// TODO: May remove this method when https://github.com/dotnet/maui/issues/34892 is merged
     /// </summary>
     private static void ClearToolbarItems(ModalPageReference modalPage)
     {


### PR DESCRIPTION
### Problem

Modal pages with `ToolbarItems` leak after dismissal. Two specific scenarios were identified:

1. **ToolbarItems + `x:Name`**: The entire visual content tree is retained
2. **ToolbarItems + `Clicked` event**: The page and its content are retained via the event subscription

#### Scenario 1: ToolbarItems + x:Name

| ToolbarItems | x:Name | Leaks? |
|---|---|---|
| ✅ | ✅ | **Yes** — entire content tree retained |
| ✅ | ❌ | No — content tree released (page shell leaks but is invisible to monitoring) |
| ❌ | ✅ | No — nothing roots the page, GC collects everything |

#### Scenario 2: ToolbarItems + Clicked event

Using the `Clicked` event instead of `Command` on a ToolbarItem causes a leak because the event subscription creates a strong reference from the ToolbarItem to the page (the handler is a method on the code-behind class).

### Root cause

When a modal is dismissed, .NET MAUI does not fully tear down the native navigation bar infrastructure. The native toolbar (iOS `UINavigationController` / Android `Toolbar`) retains references to the native toolbar button handlers, which hold a reference chain back to the page:

**x:Name chain:**

Native toolbar infrastructure → ToolbarItem handler → ToolbarItem → Page (via Parent property) → generated private field (from x:Name) → Grid/ScrollView/etc → entire content subtree

**Clicked event chain:**

Native toolbar infrastructure → ToolbarItem handler → ToolbarItem → Clicked event delegate → Page (event handler target) → content subtree

With `x:Name`, the XAML source generator creates a private field in the code-behind class (e.g. `private Grid ScrollView;`) that is never nulled. This field keeps the entire content tree reachable from the rooted page.

With `Clicked`, the event subscription is a strong reference from the ToolbarItem to the page. Since the ToolbarItem is rooted by the native toolbar, the page cannot be collected.

Normal (non-modal) navigation is unaffected because MAUI fully disconnects handlers for Shell-navigated pages, which releases all native references.

### Fix

Clear `ToolbarItems` on all pages inside a modal when it is popped. This is done in `Shell.TryResolvePoppedModalPages`, alongside the existing `TryAutoDisconnectModalNavigationPageHandler` call — following the same pattern we use for handler disconnection.

Clearing `ToolbarItems` breaks the root reference from native toolbar → ToolbarItem → Page, resolving both the `x:Name` and `Clicked` event leak scenarios.