### PR TITLE
685916 Fix shutter animation timing on image capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [55.0.1]
+- [Android][Camera] Moved shutter animation from shutter button press to when the image capture has started
+- [Android][Camera] Added a hint to keep the camera still for devices that don't support Zero-Shutter-Lag
+
 ## [56.0.0]
 - Upgrade .NET MAUI to 10.0.51.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [55.0.1]
+## [56.0.1]
 - [Android][Camera] Moved shutter animation from shutter button press to when the image capture has started
 - [Android][Camera] Added a hint to keep the camera still for devices that don't support Zero-Shutter-Lag
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCapture.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCapture.cs
@@ -17,17 +17,6 @@ namespace DIPS.Mobile.UI.API.Camera.ImageCapturing;
 
 public partial class ImageCapture : CameraFragment
 {
-    private readonly Label m_keepCameraStillHint = new()
-    {
-        VerticalOptions = LayoutOptions.End,
-        HorizontalOptions = LayoutOptions.Center,
-        Text = DUILocalizedStrings.KeepCameraStill,
-        Style = Styles.GetLabelStyle(LabelStyle.Body300),
-        TextColor = Colors.White,
-        BackgroundColor = Microsoft.Maui.Graphics.Color.FromRgba(0, 0, 0, 0.5),
-        Padding = new Thickness(12, 6)
-    };
-    
 #nullable disable
     private AndroidX.Camera.Core.ImageCapture m_cameraCaptureUseCase;
 #nullable enable

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCapture.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCapture.cs
@@ -54,7 +54,10 @@ public partial class ImageCapture : CameraFragment
     {
         if (Context is null)
             return;
-        
+
+        CancelAnyActiveImageProcessing();
+        m_captureProcessingCts = new CancellationTokenSource();
+
         m_cameraCaptureUseCase.FlashMode = FlashActive
             ? AndroidX.Camera.Core.ImageCapture.FlashModeOn
             : AndroidX.Camera.Core.ImageCapture.FlashModeOff;
@@ -75,6 +78,8 @@ public partial class ImageCapture : CameraFragment
 
     private partial async Task PlatformStop()
     {
+        CancelAnyActiveImageProcessing();
+
         m_imageCaptureCallback?.Dispose();
         m_imageCaptureCallback = null;
 
@@ -101,36 +106,49 @@ public partial class ImageCapture : CameraFragment
 
     private async void ProcessImageAndGoToConfirmState(IImageProxy imageProxy)
     {
-        var imageData = ImageUtil.JpegImageToJpegByteArray(imageProxy);
-        var bitmap = imageProxy.ToBitmap();
+        var cancellationToken = m_captureProcessingCts?.Token ?? CancellationToken.None;
 
-        using var imageMemoryStream = new MemoryStream(imageData);
-        var exif = new ExifInterface(imageMemoryStream);
+        try
+        {
+            var imageData = ImageUtil.JpegImageToJpegByteArray(imageProxy);
+            var bitmap = imageProxy.ToBitmap();
 
-        var orientationDegree = exif.ToTrueOrientationDegree();
-        var imageTransformation = new ImageTransformation(orientationDegree, orientationDegree.ToString());
-        var thumbnail = await TryGetThumbnail(exif, imageTransformation);
+            using var imageMemoryStream = new MemoryStream(imageData);
+            var exif = new ExifInterface(imageMemoryStream);
 
-        var tuple = await CapturedImage.RotateBitmapImageBasedOnOrientation(imageTransformation, bitmap);
+            var orientationDegree = exif.ToTrueOrientationDegree();
+            var imageTransformation = new ImageTransformation(orientationDegree, orientationDegree.ToString());
+            
+            var thumbnail = await TryGetThumbnail(exif, imageTransformation, cancellationToken);
+            var tuple = await CapturedImage.RotateBitmapImageBasedOnOrientation(imageTransformation, bitmap, cancellationToken);
 
-        imageData = tuple.Item1;
-        bitmap = tuple.Item2;
-        
-        var capturedImage = new CapturedImage(imageData, bitmap, thumbnail.Item1, thumbnail.Item2, imageProxy, imageTransformation);
-        
-        GoToConfirmState(capturedImage);
+            imageData = tuple.Item1;
+            bitmap = tuple.Item2;
+
+            var capturedImage = new CapturedImage(imageData, bitmap, thumbnail.Item1, thumbnail.Item2, imageProxy, imageTransformation);
+
+            GoToConfirmState(capturedImage);
+        }
+        catch (OperationCanceledException)
+        {
+            // Camera was stopped while processing the captured image, for example if the user canceled capture.
+        }
+        catch (Exception e)
+        {
+            PlatformOnCameraFailed(new CameraException("ProcessImageFailed", e));
+        }
     }
 
-    private async Task<(byte[], Bitmap)> TryGetThumbnail(ExifInterface exif, ImageTransformation transformation)
+    private async Task<(byte[], Bitmap)> TryGetThumbnail(ExifInterface exif, ImageTransformation transformation, CancellationToken cancellationToken = default)
     {
         if (!exif.HasThumbnail)
             return (null!, null!);
 
         var bitmapImage = exif.ThumbnailBitmap;
-        if (bitmapImage == null) 
+        if (bitmapImage == null)
             return (null!, null!);
-        
-        return (await CapturedImage.RotateBitmapImageBasedOnOrientationAsByteArray(transformation, bitmapImage));
+
+        return await CapturedImage.RotateBitmapImageBasedOnOrientationAsByteArray(transformation, bitmapImage, cancellationToken);
     }
 
     private void AddKeepCameraStillHint()

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCapture.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCapture.cs
@@ -17,6 +17,8 @@ public partial class ImageCapture : CameraFragment
     private AndroidX.Camera.Core.ImageCapture m_cameraCaptureUseCase;
 #nullable enable
 
+    private ImageCaptureCallback? m_imageCaptureCallback;
+
     private partial Task PlatformStart(ImageCaptureSettings imageCaptureSettings, CameraFailed cameraFailedDelegate)
     {
         var resolutionSelectorBuilder = new ResolutionSelector.Builder()
@@ -57,21 +59,25 @@ public partial class ImageCapture : CameraFragment
             ? AndroidX.Camera.Core.ImageCapture.FlashModeOn
             : AndroidX.Camera.Core.ImageCapture.FlashModeOff;
         
-        var imageCaptureCallback = new ImageCaptureCallback(
+        m_imageCaptureCallback?.Dispose();
+        m_imageCaptureCallback = new ImageCaptureCallback(
             onCaptureStarted: () => SimulateCameraShutter(false),
             onImageCaptureFailed: InvokeOnImageCaptureFailed,
             onImageCaptured: ProcessImageAndGoToConfirmState);
-        
+
         if (CameraInfo?.IsZslSupported != true && m_cameraPreview is not null)
         {
             AddKeepCameraStillHint();
         }
-        
-        m_cameraCaptureUseCase?.TakePicture(ContextCompat.GetMainExecutor(Context), imageCaptureCallback);
+
+        m_cameraCaptureUseCase?.TakePicture(ContextCompat.GetMainExecutor(Context), m_imageCaptureCallback);
     }
 
     private partial async Task PlatformStop()
     {
+        m_imageCaptureCallback?.Dispose();
+        m_imageCaptureCallback = null;
+
         await base.TryStop();
     }
 
@@ -150,49 +156,5 @@ public partial class ImageCapture : CameraFragment
 
     private partial void PlatformOnCameraFailed(CameraException cameraException) =>
         OnCameraFailed<ImageCapture>(cameraException);
-}
-
-internal class ImageCaptureCallback(
-    Action onCaptureStarted, 
-    Action<IImageProxy> onImageCaptured,
-    Action<ImageCaptureException> onImageCaptureFailed
-    ) : AndroidX.Camera.Core.ImageCapture.OnImageCapturedCallback
-{
-    private Action<IImageProxy>? m_invokeOnImageCaptured = onImageCaptured;
-
-    /// <summary>
-    /// Called when the camera hardware has started exposing the sensor.
-    /// Use this to display shutter animation or similar feedback.
-    ///
-    /// </summary>
-    /// <remarks>
-    /// From docs:
-    /// " For a regular capture request, this callback is invoked right as the capture of a frame begins, so it is the
-    /// most appropriate time for playing a shutter sound, or triggering UI indicators of capture. "
-    /// </remarks>
-    public override void OnCaptureStarted()
-    {
-        onCaptureStarted.Invoke();
-        base.OnCaptureStarted();
-    }
-
-    public override void OnError(ImageCaptureException exception)
-    {
-        onImageCaptureFailed.Invoke(exception);
-        base.OnError(exception);
-    }
-
-    public override void OnCaptureSuccess(IImageProxy image)
-    {
-        m_invokeOnImageCaptured?.Invoke(image);
-        base.OnCaptureSuccess(image);
-        image?.Close();
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        m_invokeOnImageCaptured = null;
-        base.Dispose(disposing);
-    }
 }
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCapture.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCapture.cs
@@ -6,10 +6,6 @@ using AndroidX.Camera.Core.ResolutionSelector;
 using AndroidX.Core.Content;
 using DIPS.Mobile.UI.API.Camera.ImageCapturing.Settings;
 using DIPS.Mobile.UI.API.Camera.Shared.Android;
-using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
-using DIPS.Mobile.UI.Resources.Styles;
-using DIPS.Mobile.UI.Resources.Styles.Label;
-using Colors = Microsoft.Maui.Graphics.Colors;
 using ExifInterface = AndroidX.ExifInterface.Media.ExifInterface;
 using Size = Android.Util.Size;
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCapture.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCapture.cs
@@ -1,5 +1,4 @@
 using Android.Graphics;
-using Android.Hardware.Camera2;
 using Android.Views;
 using AndroidX.Camera.Core;
 using AndroidX.Camera.Core.Internal.Utils;
@@ -7,6 +6,10 @@ using AndroidX.Camera.Core.ResolutionSelector;
 using AndroidX.Core.Content;
 using DIPS.Mobile.UI.API.Camera.ImageCapturing.Settings;
 using DIPS.Mobile.UI.API.Camera.Shared.Android;
+using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
+using DIPS.Mobile.UI.Resources.Styles;
+using DIPS.Mobile.UI.Resources.Styles.Label;
+using Colors = Microsoft.Maui.Graphics.Colors;
 using ExifInterface = AndroidX.ExifInterface.Media.ExifInterface;
 using Size = Android.Util.Size;
 
@@ -14,6 +17,17 @@ namespace DIPS.Mobile.UI.API.Camera.ImageCapturing;
 
 public partial class ImageCapture : CameraFragment
 {
+    private readonly Label m_keepCameraStillHint = new()
+    {
+        VerticalOptions = LayoutOptions.End,
+        HorizontalOptions = LayoutOptions.Center,
+        Text = DUILocalizedStrings.KeepCameraStill,
+        Style = Styles.GetLabelStyle(LabelStyle.Body300),
+        TextColor = Colors.White,
+        BackgroundColor = Microsoft.Maui.Graphics.Color.FromRgba(0, 0, 0, 0.5),
+        Padding = new Thickness(12, 6)
+    };
+    
 #nullable disable
     private AndroidX.Camera.Core.ImageCapture m_cameraCaptureUseCase;
 #nullable enable
@@ -36,29 +50,39 @@ public partial class ImageCapture : CameraFragment
         }
             
         var resolutionSelector = resolutionSelectorBuilder.Build();
-            
+        
         m_cameraCaptureUseCase = new AndroidX.Camera.Core.ImageCapture.Builder()
             .SetResolutionSelector(resolutionSelector)
+            // CaptureModeZeroShutterLag is only supported on some devices, but will fall back to
+            // CAPTURE_MODE_MINIMIZE_LATENCY if it isn't supported. If needed in the future, you can check
+            // if the device supports it via AndroidX.Camera.Core.ImageCapture.Camera.CameraInfo.IsZslSupported
+            .SetCaptureMode(AndroidX.Camera.Core.ImageCapture.CaptureModeZeroShutterLag)
             .Build();
-
+        
         // Add listener to receive updates.
         return base.SetupCameraAndTryStartUseCase(m_cameraPreview, m_cameraCaptureUseCase, resolutionSelector, cameraFailedDelegate);
     }
 
     private partial void PlatformCapturePhoto()
     {
-        if (Context is null) 
+        if (Context is null)
             return;
-
-        _ = OnBeforeCapture();
         
         m_cameraCaptureUseCase.FlashMode = FlashActive
             ? AndroidX.Camera.Core.ImageCapture.FlashModeOn
             : AndroidX.Camera.Core.ImageCapture.FlashModeOff;
-         
-        CameraProvider?.Unbind(PreviewUseCase);
-        m_cameraCaptureUseCase?.TakePicture(ContextCompat.GetMainExecutor(Context),
-            new ImageCaptureCallback(OnImageCaptured, InvokeOnImageCaptureFailed));
+        
+        var imageCaptureCallback = new ImageCaptureCallback(
+            onCaptureStarted: () => SimulateCameraShutter(false),
+            onImageCaptureFailed: InvokeOnImageCaptureFailed,
+            onImageCaptured: ProcessImageAndGoToConfirmState);
+        
+        if (CameraInfo?.IsZslSupported != true && m_cameraPreview is not null)
+        {
+            AddKeepCameraStillHint();
+        }
+        
+        m_cameraCaptureUseCase?.TakePicture(ContextCompat.GetMainExecutor(Context), imageCaptureCallback);
     }
 
     private partial async Task PlatformStop()
@@ -84,13 +108,14 @@ public partial class ImageCapture : CameraFragment
     {
     }
 
-    private async void OnImageCaptured(IImageProxy imageProxy)
+    private async void ProcessImageAndGoToConfirmState(IImageProxy imageProxy)
     {
         var imageData = ImageUtil.JpegImageToJpegByteArray(imageProxy);
         var bitmap = imageProxy.ToBitmap();
-        
+
         using var imageMemoryStream = new MemoryStream(imageData);
         var exif = new ExifInterface(imageMemoryStream);
+
         var orientationDegree = exif.ToTrueOrientationDegree();
         var imageTransformation = new ImageTransformation(orientationDegree, orientationDegree.ToString());
         var thumbnail = await TryGetThumbnail(exif, imageTransformation);
@@ -117,6 +142,13 @@ public partial class ImageCapture : CameraFragment
         return (await CapturedImage.RotateBitmapImageBasedOnOrientationAsByteArray(transformation, bitmapImage));
     }
 
+    private void AddKeepCameraStillHint()
+    {
+        m_keepCameraStillHint.Margin = new Thickness(0, 0, 0, m_cameraPreview.BottomOverlayOffset);
+        
+        m_cameraPreview?.AddViewToRoot(m_keepCameraStillHint, usePreviewViewTranslation: false);
+    }
+
     private static int GetOrientationMetadata(ExifInterface exif)
     {
         exif.SetAttribute(ExifInterface.TagOrientation, string.Empty);
@@ -136,15 +168,32 @@ public partial class ImageCapture : CameraFragment
 }
 
 internal class ImageCaptureCallback(
-    Action<IImageProxy> invokeOnImageCaptured,
-    Action<ImageCaptureException> invokeOnImageCaptureFailed)
-    : AndroidX.Camera.Core.ImageCapture.OnImageCapturedCallback
+    Action onCaptureStarted, 
+    Action<IImageProxy> onImageCaptured,
+    Action<ImageCaptureException> onImageCaptureFailed
+    ) : AndroidX.Camera.Core.ImageCapture.OnImageCapturedCallback
 {
-    private Action<IImageProxy>? m_invokeOnImageCaptured = invokeOnImageCaptured;
+    private Action<IImageProxy>? m_invokeOnImageCaptured = onImageCaptured;
+
+    /// <summary>
+    /// Called when the camera hardware has started exposing the sensor.
+    /// Use this to display shutter animation or similar feedback.
+    ///
+    /// </summary>
+    /// <remarks>
+    /// From docs:
+    /// " For a regular capture request, this callback is invoked right as the capture of a frame begins, so it is the
+    /// most appropriate time for playing a shutter sound, or triggering UI indicators of capture. "
+    /// </remarks>
+    public override void OnCaptureStarted()
+    {
+        onCaptureStarted.Invoke();
+        base.OnCaptureStarted();
+    }
 
     public override void OnError(ImageCaptureException exception)
     {
-        invokeOnImageCaptureFailed.Invoke(exception);
+        onImageCaptureFailed.Invoke(exception);
         base.OnError(exception);
     }
 
@@ -154,8 +203,6 @@ internal class ImageCaptureCallback(
         base.OnCaptureSuccess(image);
         image?.Close();
     }
-    
-    
 
     protected override void Dispose(bool disposing)
     {
@@ -163,3 +210,4 @@ internal class ImageCaptureCallback(
         base.Dispose(disposing);
     }
 }
+

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCaptureCallback.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCaptureCallback.cs
@@ -1,0 +1,64 @@
+using AndroidX.Camera.Core;
+
+namespace DIPS.Mobile.UI.API.Camera.ImageCapturing;
+
+internal class ImageCaptureCallback : AndroidX.Camera.Core.ImageCapture.OnImageCapturedCallback
+{
+    private Action? m_onCaptureStarted;
+    private Action<IImageProxy>? m_onImageCaptured;
+    private Action<ImageCaptureException>? m_onImageCaptureFailed;
+
+    public ImageCaptureCallback(
+        Action onCaptureStarted,
+        Action<IImageProxy> onImageCaptured,
+        Action<ImageCaptureException> onImageCaptureFailed)
+    {
+        m_onCaptureStarted = onCaptureStarted;
+        m_onImageCaptured = onImageCaptured;
+        m_onImageCaptureFailed = onImageCaptureFailed;
+    }
+
+    /// <summary>
+    /// Called when the camera hardware has started exposing the sensor.
+    /// Use this to display shutter animation or similar feedback.
+    ///
+    /// </summary>
+    /// <remarks>
+    /// From docs:
+    /// " For a regular capture request, this callback is invoked right as the capture of a frame begins, so it is the
+    /// most appropriate time for playing a shutter sound, or triggering UI indicators of capture. "
+    /// </remarks>
+    public override void OnCaptureStarted()
+    {
+        m_onCaptureStarted?.Invoke();
+        base.OnCaptureStarted();
+    }
+
+    public override void OnError(ImageCaptureException exception)
+    {
+        m_onImageCaptureFailed?.Invoke(exception);
+        base.OnError(exception);
+        ClearDelegates();
+    }
+
+    public override void OnCaptureSuccess(IImageProxy image)
+    {
+        m_onImageCaptured?.Invoke(image);
+        base.OnCaptureSuccess(image);
+        image?.Close();
+        ClearDelegates();
+    }
+
+    private void ClearDelegates()
+    {
+        m_onCaptureStarted = null;
+        m_onImageCaptured = null;
+        m_onImageCaptureFailed = null;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        ClearDelegates();
+        base.Dispose(disposing);
+    }
+}

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCaptureCallback.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCaptureCallback.cs
@@ -27,6 +27,9 @@ internal class ImageCaptureCallback : AndroidX.Camera.Core.ImageCapture.OnImageC
     /// From docs:
     /// " For a regular capture request, this callback is invoked right as the capture of a frame begins, so it is the
     /// most appropriate time for playing a shutter sound, or triggering UI indicators of capture. "
+    /// <para>
+    /// See <see href="https://developer.android.com/reference/android/hardware/camera2/CameraCaptureSession.CaptureCallback#onCaptureStarted(android.hardware.camera2.CameraCaptureSession,%20android.hardware.camera2.CaptureRequest,%20long,%20long)">Android documentation</see>.
+    /// </para>
     /// </remarks>
     public override void OnCaptureStarted()
     {

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/CapturedImage.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/CapturedImage.cs
@@ -139,23 +139,25 @@ public class CapturedImage
         return new CapturedImage(rotatedImageBytes ?? [], rotatedImageBitmap!, rotatedThumbnailBytes, rotatedThumbnailBitmap, ImageProxy, new ImageTransformation(newOrientationDegree, newOrientationDegree.ToString()));
     }
 
-    private static async Task<(Bitmap? rotatedImageBitmap, byte[]? rotatedImageBytes)> RotateBitmap(Bitmap? bitmap, float degrees)
+    private static async Task<(Bitmap? rotatedImageBitmap, byte[]? rotatedImageBytes)> RotateBitmap(Bitmap? bitmap, float degrees, CancellationToken cancellationToken = default)
     {
         if (bitmap is null)
             return (null!, null);
-        
+
+        cancellationToken.ThrowIfCancellationRequested();
+
         var matrix = new Matrix();
         matrix.PostRotate(degrees);
-    
+
         var rotatedImageBitmap =
             Bitmap.CreateBitmap(bitmap, 0, 0, bitmap.Width, bitmap.Height, matrix, true);
-    
+
         using var rotatedMemoryStream = new MemoryStream();
-        await rotatedImageBitmap.CompressAsync(Bitmap.CompressFormat.Jpeg!, 95, rotatedMemoryStream);
+        await rotatedImageBitmap.CompressAsync(Bitmap.CompressFormat.Jpeg!, 95, rotatedMemoryStream).WaitAsync(cancellationToken);
         return (rotatedImageBitmap, rotatedMemoryStream.ToArray());
     }
 
-    internal static async Task<(byte[], Bitmap)> RotateBitmapImageBasedOnOrientationAsByteArray(ImageTransformation transformation, Bitmap bitmapImage)
+    internal static async Task<(byte[], Bitmap)> RotateBitmapImageBasedOnOrientationAsByteArray(ImageTransformation transformation, Bitmap bitmapImage, CancellationToken cancellationToken = default)
     {
         var rotationDegrees = transformation.OrientationDegree switch
         {
@@ -164,13 +166,15 @@ public class CapturedImage
             OrientationDegree.Orientation270 => 0,
             _ => 90
         };
-        
-        var (rotatedBitmap, rotatedBytes) = await RotateBitmap(bitmapImage, rotationDegrees);
+
+        var (rotatedBitmap, rotatedBytes) = await RotateBitmap(bitmapImage, rotationDegrees, cancellationToken);
         return (rotatedBytes, rotatedBitmap);
     }
     
-    internal static async Task<(byte[], Bitmap)> RotateBitmapImageBasedOnOrientation(ImageTransformation transformation, Bitmap bitmapImage)
+    internal static async Task<(byte[], Bitmap)> RotateBitmapImageBasedOnOrientation(ImageTransformation transformation, Bitmap bitmapImage, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var matrix = new Matrix();
         var rotationDegrees = transformation.OrientationDegree switch
         {
@@ -179,14 +183,14 @@ public class CapturedImage
             OrientationDegree.Orientation270 => 0,
             _ => 90
         };
-        
+
         matrix.PostRotate(rotationDegrees);
-        
+
         var rotatedBitmap =
             Bitmap.CreateBitmap(bitmapImage, 0, 0, bitmapImage.Width, bitmapImage.Height, matrix, true);
-        
+
         using var rotatedMemoryStream = new MemoryStream();
-        await rotatedBitmap.CompressAsync(Bitmap.CompressFormat.Jpeg!, 95, rotatedMemoryStream);
+        await rotatedBitmap.CompressAsync(Bitmap.CompressFormat.Jpeg!, 95, rotatedMemoryStream).WaitAsync(cancellationToken);
         return (rotatedMemoryStream.ToArray(), rotatedBitmap);
     }
     

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.ConfirmState.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.ConfirmState.cs
@@ -15,6 +15,9 @@ public partial class ImageCapture : IConfirmStateObserver
 
     private void GoToConfirmState(CapturedImage capturedImage)
     {
+        if (m_cameraPreview is null)
+            throw new InvalidOperationException($"{nameof(GoToConfirmState)} was called after the camera preview was torn down.");
+
         m_currentlyCapturedImage = capturedImage;
 
         m_cameraPreview.RemoveViewFromRoot(m_confirmImageWrapper);

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.ConfirmState.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.ConfirmState.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using DIPS.Mobile.UI.API.Camera.ImageCapturing.Observers;
 using DIPS.Mobile.UI.API.Camera.ImageCapturing.Settings;
 using Image = DIPS.Mobile.UI.Components.Images.Image.Image;
@@ -12,10 +13,10 @@ public partial class ImageCapture : IConfirmStateObserver
     private Grid m_confirmImageWrapper;
 #nullable enable
 
-    private async void GoToConfirmState(CapturedImage capturedImage)
+    private void GoToConfirmState(CapturedImage capturedImage)
     {
         m_currentlyCapturedImage = capturedImage;
-        
+
         m_cameraPreview.RemoveViewFromRoot(m_confirmImageWrapper);
         m_confirmImage = new Image
         {
@@ -23,10 +24,12 @@ public partial class ImageCapture : IConfirmStateObserver
             InputTransparent = true
         };
         m_confirmImageWrapper = new Grid { Children = { m_confirmImage }, InputTransparent = true };
-        m_cameraPreview.AddViewToRoot(m_confirmImageWrapper, 3, true);
         
-        // We need to add a slight delay, because the camera preview will be black for a short moment if we don't, because the image is not yet loaded - "simulating a shutter effect", 
-        await Task.Delay(10);
+        // Makes sure the preview stays visible until the image has loaded, preventing a
+        // black flash that occurs when the preview is hidden before the image is rendered.
+        m_confirmImage.PropertyChanged += HidePreviewAfterImageLoaded;
+
+        m_cameraPreview.AddViewToRoot(m_confirmImageWrapper, 3, true);
 
         if (m_cameraPreview.CameraZoomView is not null)
         {
@@ -34,11 +37,24 @@ public partial class ImageCapture : IConfirmStateObserver
         }
 
         m_cameraPreview.RemoveViewFromRoot(m_activityIndicator);
-        m_cameraPreview.GoToConfirmingState();
+        m_cameraPreview.RemoveViewFromRoot(m_keepCameraStillHint);
         m_topToolbarView.GoToConfirmState(m_currentlyCapturedImage, this);
         m_bottomToolbarView.GoToConfirmState(this);
+        m_cameraPreview.GoToConfirmingState();
 
         _ = PlatformStop();
+    }
+
+    private void HidePreviewAfterImageLoaded(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != Microsoft.Maui.Controls.Image.IsLoadingProperty.PropertyName)
+            return;
+
+        if (sender is not Microsoft.Maui.Controls.Image { IsLoading: false } image)
+            return;
+
+        image.PropertyChanged -= HidePreviewAfterImageLoaded;
+        m_cameraPreview.HidePreview();
     }
 
     void IConfirmStateObserver.OnEditButtonTapped()

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.ConfirmState.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.ConfirmState.cs
@@ -57,6 +57,10 @@ public partial class ImageCapture : IConfirmStateObserver
             return;
 
         image.PropertyChanged -= HidePreviewAfterImageLoaded;
+
+        if (m_cameraPreview is null)                                                                                                              
+            return;
+        
         m_cameraPreview.HidePreview();
     }
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.EditState.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.EditState.cs
@@ -29,15 +29,29 @@ public partial class ImageCapture : IImageEditStateObserver
     {
         if(!m_rotatingImageTcs?.Task.IsCompleted ?? false)
             return;
-            
-        m_confirmImage.Rotation = 0;
-        GoToConfirmState(m_rotatedImage!);
+
+        try
+        {
+            m_confirmImage.Rotation = 0;
+            GoToConfirmState(m_rotatedImage!);
+        }
+        catch (Exception e)
+        {
+            PlatformOnCameraFailed(new CameraException("OnSaveButtonTapped", e));
+        }
     }
 
     void IImageEditStateObserver.OnCancelButtonTapped()
     {
-        m_confirmImage.Rotation = 0;
-        GoToConfirmState(m_currentlyCapturedImage!);
+        try
+        {
+            m_confirmImage.Rotation = 0;
+            GoToConfirmState(m_currentlyCapturedImage!);
+        }
+        catch (Exception e)
+        {
+            PlatformOnCameraFailed(new CameraException("OnCancelButtonTapped", e));
+        }
     }
 
     async Task IImageEditStateObserver.OnRotateButtonTapped(bool clockwise)

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.cs
@@ -41,6 +41,8 @@ public partial class ImageCapture : ICameraUseCase
     private ImageCaptureTopToolbarView m_topToolbarView;
     private ImageCaptureBottomToolbarView m_bottomToolbarView;
 #nullable enable
+
+    private CancellationTokenSource? m_captureProcessingCts;
     
     public async Task Start(CameraPreview cameraPreview, DidCaptureImage onImageCapturedDelegate, CameraFailed cameraFailedDelegate, Action<ImageCaptureSettings>? configure = null)
     {
@@ -135,6 +137,7 @@ public partial class ImageCapture : ICameraUseCase
     {
         try
         {
+            CancelAnyActiveImageProcessing();
             PlatformStop();
             m_cameraPreview = null;
             m_onImageCapturedDelegate = null;
@@ -143,6 +146,19 @@ public partial class ImageCapture : ICameraUseCase
         {
             Log(e.Message);
         }
+    }
+    
+    public void Stop()
+    {
+        ResetAllVisuals();
+        PlatformStop();
+    }
+
+    private void CancelAnyActiveImageProcessing()
+    {
+        m_captureProcessingCts?.Cancel();
+        m_captureProcessingCts?.Dispose();
+        m_captureProcessingCts = null;
     }
 
     internal void InvokeOnImageCaptured(CapturedImage capturedImage)

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.cs
@@ -6,6 +6,9 @@ using DIPS.Mobile.UI.API.Camera.Preview;
 using DIPS.Mobile.UI.API.Camera.Shared;
 using DIPS.Mobile.UI.API.Vibration;
 using DIPS.Mobile.UI.Internal.Logging;
+using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
+using DIPS.Mobile.UI.Resources.Styles;
+using DIPS.Mobile.UI.Resources.Styles.Label;
 using ActivityIndicator = DIPS.Mobile.UI.Components.Loading.ActivityIndicator;
 using Colors = Microsoft.Maui.Graphics.Colors;
 
@@ -18,6 +21,17 @@ public partial class ImageCapture : ICameraUseCase
         VerticalOptions = LayoutOptions.Center,
         HorizontalOptions = LayoutOptions.Center,
         IsRunning = true
+    };
+    
+    private readonly Label m_keepCameraStillHint = new()
+    {
+        VerticalOptions = LayoutOptions.End,
+        HorizontalOptions = LayoutOptions.Center,
+        Text = DUILocalizedStrings.KeepCameraStill,
+        Style = Styles.GetLabelStyle(LabelStyle.Body300),
+        TextColor = Colors.White,
+        BackgroundColor = Microsoft.Maui.Graphics.Color.FromRgba(0, 0, 0, 0.5),
+        Padding = new Thickness(12, 6)
     };
     
 #nullable disable

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.cs
@@ -5,11 +5,9 @@ using DIPS.Mobile.UI.API.Camera.Permissions;
 using DIPS.Mobile.UI.API.Camera.Preview;
 using DIPS.Mobile.UI.API.Camera.Shared;
 using DIPS.Mobile.UI.API.Vibration;
-using DIPS.Mobile.UI.Components.Alerting.Dialog;
 using DIPS.Mobile.UI.Internal.Logging;
-using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
 using ActivityIndicator = DIPS.Mobile.UI.Components.Loading.ActivityIndicator;
-using Image = DIPS.Mobile.UI.Components.Images.Image.Image;
+using Colors = Microsoft.Maui.Graphics.Colors;
 
 namespace DIPS.Mobile.UI.API.Camera.ImageCapturing;
 
@@ -67,17 +65,20 @@ public partial class ImageCapture : ICameraUseCase
         m_cameraPreview?.SetToolbarHeights(previewViewHeight);
         m_imageCaptureSettings.CameraInfo.CurrentCameraResolution = cameraResolution;
     }
-    
+
     /// <summary>
     /// This is called when user has pressed the capture button, waiting for captured image to be processed
     /// </summary>
-    private async Task OnBeforeCapture()
+    private async Task SimulateCameraShutter(bool addActivityIndicator = true)
     {
         var blackBox = new BoxView { BackgroundColor = Microsoft.Maui.Graphics.Colors.Black, Opacity = 0 };
 
         VibrationService.SelectionChanged();
         
-        m_cameraPreview?.AddViewToRoot(m_activityIndicator, usePreviewViewTranslation: true);
+        if (addActivityIndicator)
+        {
+            m_cameraPreview?.AddViewToRoot(m_activityIndicator, usePreviewViewTranslation: false);
+        }
         
         m_cameraPreview?.AddViewToRoot(blackBox);
         
@@ -104,7 +105,9 @@ public partial class ImageCapture : ICameraUseCase
         m_cameraPreview.RemoveTopToolbarView(m_topToolbarView);
         m_cameraPreview.RemoveBottomToolbarView(m_bottomToolbarView);
         m_cameraPreview.RemoveViewFromRoot(m_activityIndicator);
+        m_cameraPreview.RemoveViewFromRoot(m_keepCameraStillHint);
         m_cameraPreview.RemoveViewFromRoot(m_confirmImage);
+        
         if (m_cameraPreview.CameraZoomView != null)
         {
             m_cameraPreview.CameraZoomView.Opacity = 0;
@@ -126,12 +129,6 @@ public partial class ImageCapture : ICameraUseCase
         {
             Log(e.Message);
         }
-    }
-
-    public void Stop()
-    {
-        ResetAllVisuals();
-        PlatformStop();
     }
 
     internal void InvokeOnImageCaptured(CapturedImage capturedImage)

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/iOS/ImageCapture.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/iOS/ImageCapture.cs
@@ -111,7 +111,7 @@ public partial class ImageCapture : CameraSession
         m_photoCaptureDelegate = new PhotoCaptureDelegate(PhotoCaptured, PlatformOnCameraFailed, () =>
         {
             m_isProcessingPhoto = true;
-            _ = OnBeforeCapture();
+            _ = SimulateCameraShutter();
         });
         
         UpdateCaptureOrientation(UIDevice.CurrentDevice.Orientation.ToAVCaptureVideoOrientation());

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/iOS/ImageCapture.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/iOS/ImageCapture.cs
@@ -62,25 +62,32 @@ public partial class ImageCapture : CameraSession
     private void PhotoCaptured(AVCapturePhoto photo)
     {
         m_isProcessingPhoto = false;
-        
+
         m_photoCaptureDelegate?.Dispose();
         m_photoCaptureDelegate = null;
-        
-        if (photo.FileDataRepresentation != null && m_imageCaptureSettings != null)
+
+        try
         {
-            var rotatedImage = CapturedImage.RotateCgImageToPortrait(photo.CGImageRepresentation!, photo.Properties.Orientation.ToUIImageOrientation());
-            var rotatedImageBytes = rotatedImage.Item1.AsJPEG(.8f)?.ToArray() ?? [];
-            
-            var rotatedThumbnail = GetThumbnail(rotatedImageBytes);
-            
-            var correctOrientationDegree = photo.Properties.Orientation.ToUIImageOrientation().ToTrueOrientationDegree();
-            
-            GoToConfirmState(new CapturedImage(rotatedImage.Item1.AsJPEG(.8f)?.ToArray() ?? [],
-                    rotatedThumbnail.Item1,
-                    rotatedImage.Item2,
-                    rotatedThumbnail.Item2,
-                    photo, 
-                    new ImageTransformation(correctOrientationDegree, correctOrientationDegree.ToString())));
+            if (photo.FileDataRepresentation != null && m_imageCaptureSettings != null)
+            {
+                var rotatedImage = CapturedImage.RotateCgImageToPortrait(photo.CGImageRepresentation!, photo.Properties.Orientation.ToUIImageOrientation());
+                var rotatedImageBytes = rotatedImage.Item1.AsJPEG(.8f)?.ToArray() ?? [];
+
+                var rotatedThumbnail = GetThumbnail(rotatedImageBytes);
+
+                var correctOrientationDegree = photo.Properties.Orientation.ToUIImageOrientation().ToTrueOrientationDegree();
+
+                GoToConfirmState(new CapturedImage(rotatedImage.Item1.AsJPEG(.8f)?.ToArray() ?? [],
+                        rotatedThumbnail.Item1,
+                        rotatedImage.Item2,
+                        rotatedThumbnail.Item2,
+                        photo,
+                        new ImageTransformation(correctOrientationDegree, correctOrientationDegree.ToString())));
+            }
+        }
+        catch (Exception e)
+        {
+            PlatformOnCameraFailed(new CameraException("PhotoCaptured", e));
         }
     }
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/Preview/CameraPreview.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Preview/CameraPreview.cs
@@ -63,7 +63,7 @@ public partial class CameraPreview : ContentView
         
         m_topToolbarContainer = new Grid
         {
-            VerticalOptions = LayoutOptions.Start, 
+            VerticalOptions = LayoutOptions.Start,
             BackgroundColor = Colors.Transparent,
         };
 
@@ -113,8 +113,25 @@ public partial class CameraPreview : ContentView
 
         CameraZoomView!.Margin = new Thickness(0, 0, 0, Sizes.GetSize(SizeName.content_margin_small) + m_bottomToolbarContainer.HeightRequest);
         PreviewView.TranslationY -= m_topToolbarContainer.HeightRequest;
-        
+
         m_hasSetToolbarHeights = true;
+    }
+
+    /// <summary>
+    /// Bottom margin to use for overlay views that should sit above the bottom toolbar
+    /// (shutter button) and the zoom controls, with a small gap above the zoom buttons.
+    /// Only valid after <see cref="SetToolbarHeights"/> has been called.
+    /// </summary>
+    internal double BottomOverlayOffset
+    {
+        get
+        {
+            var zoomHeight = CameraZoomView?.Height ?? 0;
+            return m_bottomToolbarContainer.HeightRequest
+                   + Sizes.GetSize(SizeName.content_margin_small)
+                   + zoomHeight
+                   + Sizes.GetSize(SizeName.content_margin_small);
+        }
     }
     
     internal void AddFocusIndicator(float percentX, float percentY)
@@ -279,8 +296,6 @@ public partial class CameraPreview : ContentView
 
     public void GoToConfirmingState()
     {
-        PreviewView.IsVisible = false;
-
         if (m_indicator is not null)
         {
             if (m_grid != null && m_grid.Remove(m_indicator))
@@ -288,6 +303,14 @@ public partial class CameraPreview : ContentView
                 m_indicator.DisconnectHandlers();
             }
         }
+    }
+
+    /// <summary>
+    /// Hides the camera preview.
+    /// </summary>
+    internal void HidePreview()
+    {
+        PreviewView.IsVisible = false;
     }
 
     public void GoToStreamingState()

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.Designer.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.Designer.cs
@@ -548,5 +548,11 @@ namespace DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings {
                 return ResourceManager.GetString("Of", resourceCulture);
             }
         }
+        
+        internal static string KeepCameraStill {
+            get {
+                return ResourceManager.GetString("KeepCameraStill", resourceCulture);
+            }
+        }
     }
 }

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.en.resx
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.en.resx
@@ -263,4 +263,7 @@
     <data name="Of" xml:space="preserve">
         <value>{0} of {1}</value>
     </data>
+    <data name="KeepCameraStill" xml:space="preserve">
+        <value>Hold camera still…</value>
+    </data>
 </root>

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.resx
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.resx
@@ -270,4 +270,7 @@
     <data name="Of" xml:space="preserve">
         <value>{0} av {1}</value>
     </data>
+    <data name="KeepCameraStill" xml:space="preserve">
+        <value>Hold kameraet stille...</value>
+    </data>
 </root>


### PR DESCRIPTION
### Description of Change

[Android][Camera] Moved shutter animation from shutter button press to when the image capture has started, as recommended by android docs.
[Android][Camera] Added a hint to keep the camera still for devices that don't support Zero-Shutter-Lag

### Todos
- [X] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->