### PR TITLE
[ItemPicker] Ensure that selection don't get randomly reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [56.0.2]
+- [iOS][ItemPicker] Fixed bug where selected item could reset randomly
+
 ## [56.0.1]
 - [Android][Camera] Moved shutter animation from shutter button press to when the image capture has started
 - [Android][Camera] Added a hint to keep the camera still for devices that don't support Zero-Shutter-Lag

--- a/src/app/Playground/EirikSamples/EirikPage.xaml
+++ b/src/app/Playground/EirikSamples/EirikPage.xaml
@@ -10,7 +10,9 @@
     <dui:ContentPage.BindingContext>
         <eirikSamples:EirikPageViewModel />
     </dui:ContentPage.BindingContext>
-    <dui:SaveView IsSaving="{Binding IsSaving}"
-                  IsSavingCompleted="{Binding IsSavingCompleted}"
-                  Command="{Binding SaveCommand}"/>
+    <dui:ListItem Title="Test">
+        <dui:ItemPicker ItemsSource="{Binding Items}"
+                        SelectedItem="{Binding SelectedItem}"
+                        Mode="BottomSheet"/>
+    </dui:ListItem>
 </dui:ContentPage>

--- a/src/app/Playground/EirikSamples/EirikPageViewModel.cs
+++ b/src/app/Playground/EirikSamples/EirikPageViewModel.cs
@@ -37,6 +37,36 @@ public class EirikPageViewModel : ViewModel
     }
 
     public ICommand SaveCommand { get; }
+    
+    public string SelectedItem
+    {
+        get;
+        set => RaiseWhenSet(ref field, value);
+    }
+
+    public List<string> Items { get; } =
+    [
+        "Item 1",
+        "Item 2",
+        "Item 3",
+        "Item 4",
+        "Item 5",
+        "Item 6",
+        "Item 7",
+        "Item 8",
+        "Item 9",
+        "Item 10",
+        "Item 11",
+        "Item 12",
+        "Item 13",
+        "Item 14",
+        "Item 15",
+        "Item 16",
+        "Item 17",
+        "Item 18",
+        "Item 19",
+        "Item 20",
+    ];
 }
 
 public class GroupedStrings : ObservableCollection<string>

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -138,6 +138,8 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             if (m_hasPickedItem) return;
             if (tappedObject.BindingContext is not SelectableItemViewModel selectableListItem) return;
             if (m_itemPicker.ItemsSource == null) return;
+            
+            m_hasPickedItem = true;
 
             object? theSelectedItem = null;
             foreach (var item in m_itemPicker.ItemsSource)
@@ -170,7 +172,6 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                 return;
             }
 
-            m_hasPickedItem = true;
             m_itemPicker.SelectedItem = theSelectedItem;
         }
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -169,6 +169,8 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                 return;
             }
             
+            m_hasPickedItem = true;
+            
             if (!selectableListItem.IsSelected)
             {
                 return;

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -139,6 +139,8 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             if (tappedObject.BindingContext is not SelectableItemViewModel selectableListItem) return;
             if (m_itemPicker.ItemsSource == null) return;
             
+            m_hasPickedItem = true;
+            
             object? theSelectedItem = null;
             foreach (var item in m_itemPicker.ItemsSource)
             {
@@ -161,7 +163,6 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                 {
                     // Workaround: As IsSelected has a two-way binding, we must guard in case setting this property
                     // triggers the bound command again. The binding must remain two-way to enable consumer selectable view
-                    m_hasPickedItem = true;
                     selectableListItem.IsSelected = true;
                     m_hasPickedItem = false;
                 }
@@ -169,14 +170,12 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                 return;
             }
             
-            m_hasPickedItem = true;
-            
             if (!selectableListItem.IsSelected)
             {
+                m_hasPickedItem = false;
                 return;
             }
 
-            m_hasPickedItem = true;
             m_itemPicker.SelectedItem = theSelectedItem;
         }
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -174,6 +174,7 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                 return;
             }
 
+            m_hasPickedItem = true;
             m_itemPicker.SelectedItem = theSelectedItem;
         }
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -18,7 +18,8 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
         private readonly CollectionView m_collectionView;
         
         private SelectableItemViewModel? m_freeTextItem;
-        
+        private bool m_hasPickedItem;
+
         public ItemPickerBottomSheet(ItemPicker itemPicker)
         {
             m_itemPicker = itemPicker;
@@ -134,6 +135,7 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
 
         private void ItemWasPicked(BindableObject tappedObject)
         {
+            if (m_hasPickedItem) return;
             if (tappedObject.BindingContext is not SelectableItemViewModel selectableListItem) return;
             if (m_itemPicker.ItemsSource == null) return;
 
@@ -168,6 +170,7 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                 return;
             }
 
+            m_hasPickedItem = true;
             m_itemPicker.SelectedItem = theSelectedItem;
         }
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -139,8 +139,6 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             if (tappedObject.BindingContext is not SelectableItemViewModel selectableListItem) return;
             if (m_itemPicker.ItemsSource == null) return;
             
-            m_hasPickedItem = true;
-
             object? theSelectedItem = null;
             foreach (var item in m_itemPicker.ItemsSource)
             {
@@ -161,6 +159,7 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                 //Make sure people can not visually deselect the radio button
                 if (!selectableListItem.IsSelected)
                 {
+                    m_hasPickedItem = true;
                     selectableListItem.IsSelected = true;
                 }
                 
@@ -172,6 +171,7 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                 return;
             }
 
+            m_hasPickedItem = true;
             m_itemPicker.SelectedItem = theSelectedItem;
         }
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -129,8 +129,20 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             var radioButtonListItem = new RadioButtonListItem {HasBottomDivider = true};
             radioButtonListItem.SetBinding(ListItem.TitleProperty, static (SelectableItemViewModel selectableItemViewModel) => selectableItemViewModel.DisplayName);
             radioButtonListItem.SetBinding(RadioButtonListItem.IsSelectedProperty, static (SelectableItemViewModel selectableItemViewModel) => selectableItemViewModel.IsSelected);
-            radioButtonListItem.SelectedCommand = new Command(() => ItemWasPicked(radioButtonListItem));
+            radioButtonListItem.Command = new Command(() => RadioButtonListItemWasPicked(radioButtonListItem));
             return radioButtonListItem;
+        }
+
+        private void RadioButtonListItemWasPicked(RadioButtonListItem radioButtonListItem)
+        {
+            if (radioButtonListItem.IsSelected)
+            {
+                return;
+            }
+            
+            radioButtonListItem.IsSelected = !radioButtonListItem.IsSelected;
+            
+            ItemWasPicked(radioButtonListItem);
         }
 
         private void ItemWasPicked(BindableObject tappedObject)
@@ -139,7 +151,7 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             if (tappedObject.BindingContext is not SelectableItemViewModel selectableListItem) return;
             if (m_itemPicker.ItemsSource == null) return;
             
-            m_hasPickedItem = true;
+            // m_hasPickedItem = true;
             
             object? theSelectedItem = null;
             foreach (var item in m_itemPicker.ItemsSource)

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -129,7 +129,7 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             var radioButtonListItem = new RadioButtonListItem {HasBottomDivider = true};
             radioButtonListItem.SetBinding(ListItem.TitleProperty, static (SelectableItemViewModel selectableItemViewModel) => selectableItemViewModel.DisplayName);
             radioButtonListItem.SetBinding(RadioButtonListItem.IsSelectedProperty, static (SelectableItemViewModel selectableItemViewModel) => selectableItemViewModel.IsSelected);
-            radioButtonListItem.Command = new Command(() => ItemWasPicked(radioButtonListItem));
+            radioButtonListItem.SelectedCommand = new Command(() => ItemWasPicked(radioButtonListItem));
             return radioButtonListItem;
         }
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -129,7 +129,7 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             var radioButtonListItem = new RadioButtonListItem {HasBottomDivider = true};
             radioButtonListItem.SetBinding(ListItem.TitleProperty, static (SelectableItemViewModel selectableItemViewModel) => selectableItemViewModel.DisplayName);
             radioButtonListItem.SetBinding(RadioButtonListItem.IsSelectedProperty, static (SelectableItemViewModel selectableItemViewModel) => selectableItemViewModel.IsSelected);
-            radioButtonListItem.SelectedCommand = new Command(() => ItemWasPicked(radioButtonListItem));
+            radioButtonListItem.Command = new Command(() => ItemWasPicked(radioButtonListItem));
             return radioButtonListItem;
         }
 
@@ -159,8 +159,11 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                 //Make sure people can not visually deselect the radio button
                 if (!selectableListItem.IsSelected)
                 {
+                    // Workaround: As IsSelected has a two-way binding, we must guard in case setting this property
+                    // triggers the bound command again. The binding must remain two-way to enable consumer selectable view
                     m_hasPickedItem = true;
                     selectableListItem.IsSelected = true;
+                    m_hasPickedItem = false;
                 }
                 
                 return;
@@ -171,7 +174,6 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                 return;
             }
 
-            m_hasPickedItem = true;
             m_itemPicker.SelectedItem = theSelectedItem;
         }
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/ItemPicker/ItemPickerBottomSheet.cs
@@ -18,7 +18,6 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
         private readonly CollectionView m_collectionView;
         
         private SelectableItemViewModel? m_freeTextItem;
-        private bool m_hasPickedItem;
 
         public ItemPickerBottomSheet(ItemPicker itemPicker)
         {
@@ -129,6 +128,7 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             var radioButtonListItem = new RadioButtonListItem {HasBottomDivider = true};
             radioButtonListItem.SetBinding(ListItem.TitleProperty, static (SelectableItemViewModel selectableItemViewModel) => selectableItemViewModel.DisplayName);
             radioButtonListItem.SetBinding(RadioButtonListItem.IsSelectedProperty, static (SelectableItemViewModel selectableItemViewModel) => selectableItemViewModel.IsSelected);
+            // Override command to ensure that ItemWasPicked don't get called on property changed
             radioButtonListItem.Command = new Command(() => RadioButtonListItemWasPicked(radioButtonListItem));
             return radioButtonListItem;
         }
@@ -147,11 +147,8 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
 
         private void ItemWasPicked(BindableObject tappedObject)
         {
-            if (m_hasPickedItem) return;
             if (tappedObject.BindingContext is not SelectableItemViewModel selectableListItem) return;
             if (m_itemPicker.ItemsSource == null) return;
-            
-            // m_hasPickedItem = true;
             
             object? theSelectedItem = null;
             foreach (var item in m_itemPicker.ItemsSource)
@@ -173,10 +170,7 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
                 //Make sure people can not visually deselect the radio button
                 if (!selectableListItem.IsSelected)
                 {
-                    // Workaround: As IsSelected has a two-way binding, we must guard in case setting this property
-                    // triggers the bound command again. The binding must remain two-way to enable consumer selectable view
                     selectableListItem.IsSelected = true;
-                    m_hasPickedItem = false;
                 }
                 
                 return;
@@ -184,7 +178,6 @@ namespace DIPS.Mobile.UI.Components.Pickers.ItemPicker
             
             if (!selectableListItem.IsSelected)
             {
-                m_hasPickedItem = false;
                 return;
             }
 


### PR DESCRIPTION
### Description of Change
The way `RadioButtonListItem` is set up handles updates to the `IsSelected` property by always invoking the `SelectedCommand`. This caused issues in `ItemPickerBottomSheet`, as we had to manually reset the `IsSelected` property if the user tried to deselect it. This could cause recycled elements in the list to call the command a second time with the deselected element, causing it to get selected again.

The solution was to override the `Command` property on `RadioButtonListItem` usage in `ItemPickerBottomSheet`, to ensure that the item selected routine don't get called when a selectable item gets selected/deselected programmatically from within itself.