### PR TITLE
Improved Android RemoveFocusOnScroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [59.1.2]
+- [CollectionView][Android] Fixed keyboard dismiss not working when items are loaded after the page is shown (delayed binding).
+- [CollectionView][Android] Fixed programmatic scroll (e.g. when loading items) incorrectly dismissing keyboard.
+- [CollectionView][Android] Now clears focus from the active input field when keyboard is dismissed by scrolling.
+
 ## [59.1.1]
 - [CollectionView] Fixed `RemoveFocusOnScroll` on Android: uses `OnScrolled` with `ScrollStateDragging` check instead of `OnScrollStateChanged` to reliably dismiss keyboard in all view hierarchies. Also clears focus from the active input field.
 - [ScrollView] Fixed `RemoveFocusOnScroll` on Android: replaced MAUI `Scrolled` event with native touch+scroll listeners to only dismiss keyboard on user-initiated drags, not layout-induced scrolls. Also clears focus from the active input field.

--- a/src/app/Playground/VetleSamples/CollectionViewTests/CollectionViewTests.xaml
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/CollectionViewTests.xaml
@@ -28,7 +28,13 @@
                                 Tapped="ScrollViewSearchBarOutside"
                                 HasBottomDivider="True" />
         <dui:NavigationListItem Title="ScrollView: SearchBar inside"
-                                Tapped="ScrollViewSearchBarInside" />
+                                Tapped="ScrollViewSearchBarInside"
+                                HasBottomDivider="True" />
+        <dui:NavigationListItem Title="Delayed: SearchBar in Header"
+                                Tapped="DelayedSearchBarInHeader"
+                                HasBottomDivider="True" />
+        <dui:NavigationListItem Title="Delayed: SearchBar in Header + RefreshView"
+                                Tapped="DelayedSearchBarInHeaderWithRefresh" />
     </dui:VerticalStackLayout>
     
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/CollectionViewTests/CollectionViewTests.xaml
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/CollectionViewTests.xaml
@@ -12,6 +12,11 @@
         <dui:NavigationListItem Title="Grouped CollectionView"
                                 Tapped="GroupedCollectionView"
                                 HasBottomDivider="True" />
+        
+        <Label Text="Focus Cases" 
+               FontAttributes="Bold" 
+               Padding="16,24,16,8" />
+        
         <dui:NavigationListItem Title="SearchBar outside, no RefreshView"
                                 Tapped="SearchBarOutside"
                                 HasBottomDivider="True" />
@@ -24,17 +29,20 @@
         <dui:NavigationListItem Title="SearchBar in Header + RefreshView"
                                 Tapped="SearchBarInHeaderWithRefresh"
                                 HasBottomDivider="True" />
-        <dui:NavigationListItem Title="ScrollView: SearchBar outside"
-                                Tapped="ScrollViewSearchBarOutside"
-                                HasBottomDivider="True" />
-        <dui:NavigationListItem Title="ScrollView: SearchBar inside"
-                                Tapped="ScrollViewSearchBarInside"
-                                HasBottomDivider="True" />
         <dui:NavigationListItem Title="Delayed: SearchBar in Header"
                                 Tapped="DelayedSearchBarInHeader"
                                 HasBottomDivider="True" />
         <dui:NavigationListItem Title="Delayed: SearchBar in Header + RefreshView"
-                                Tapped="DelayedSearchBarInHeaderWithRefresh" />
+                                Tapped="DelayedSearchBarInHeaderWithRefresh"
+                                HasBottomDivider="True" />
+        <dui:NavigationListItem Title="Observable Add: SearchBar in Header"
+                                Tapped="ObservableAddSearchBarInHeader"
+                                HasBottomDivider="True" />
+        <dui:NavigationListItem Title="ScrollView: SearchBar outside"
+                                Tapped="ScrollViewSearchBarOutside"
+                                HasBottomDivider="True" />
+        <dui:NavigationListItem Title="ScrollView: SearchBar inside"
+                                Tapped="ScrollViewSearchBarInside" />
     </dui:VerticalStackLayout>
     
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/CollectionViewTests/CollectionViewTests.xaml.cs
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/CollectionViewTests.xaml.cs
@@ -56,4 +56,9 @@ public partial class CollectionViewTests
     {
         Shell.Current.Navigation.PushAsync(new RemoveFocusOnScrollPage(wrapInRefreshView: true, searchBarInHeader: true, delayedBinding: true));
     }
+
+    private void ObservableAddSearchBarInHeader(object sender, EventArgs e)
+    {
+        Shell.Current.Navigation.PushAsync(new RemoveFocusOnScrollPage(wrapInRefreshView: false, searchBarInHeader: true, incrementalAdd: true));
+    }
 }

--- a/src/app/Playground/VetleSamples/CollectionViewTests/CollectionViewTests.xaml.cs
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/CollectionViewTests.xaml.cs
@@ -46,4 +46,14 @@ public partial class CollectionViewTests
     {
         Shell.Current.Navigation.PushAsync(new RemoveFocusOnScrollScrollViewPage(searchBarInScrollView: true));
     }
+
+    private void DelayedSearchBarInHeader(object sender, EventArgs e)
+    {
+        Shell.Current.Navigation.PushAsync(new RemoveFocusOnScrollPage(wrapInRefreshView: false, searchBarInHeader: true, delayedBinding: true));
+    }
+
+    private void DelayedSearchBarInHeaderWithRefresh(object sender, EventArgs e)
+    {
+        Shell.Current.Navigation.PushAsync(new RemoveFocusOnScrollPage(wrapInRefreshView: true, searchBarInHeader: true, delayedBinding: true));
+    }
 }

--- a/src/app/Playground/VetleSamples/CollectionViewTests/RemoveFocusOnScrollPage.cs
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/RemoveFocusOnScrollPage.cs
@@ -11,12 +11,13 @@ namespace Playground.VetleSamples.CollectionViewTests;
 
 public class RemoveFocusOnScrollPage : ContentPage
 {
-    public RemoveFocusOnScrollPage(bool wrapInRefreshView, bool searchBarInHeader, bool delayedBinding = false)
+    public RemoveFocusOnScrollPage(bool wrapInRefreshView, bool searchBarInHeader, bool delayedBinding = false, bool incrementalAdd = false)
     {
         var parts = new List<string>();
         parts.Add(searchBarInHeader ? "SearchBar in Header" : "SearchBar outside");
         if (wrapInRefreshView) parts.Add("RefreshView");
         if (delayedBinding) parts.Add("Delayed");
+        if (incrementalAdd) parts.Add("Observable Add");
         Title = string.Join(" + ", parts);
 
         var searchBar = new SearchBar
@@ -48,6 +49,7 @@ public class RemoveFocusOnScrollPage : ContentPage
             collectionView.ItemsSource = items;
         }
 
+        
         if (searchBarInHeader)
         {
             collectionView.Header = searchBar;
@@ -85,6 +87,22 @@ public class RemoveFocusOnScrollPage : ContentPage
         if (delayedBinding)
         {
             _ = LoadItemsAsync(collectionView);
+        }
+
+        if (incrementalAdd)
+        {
+            var items = (ObservableCollection<string>)collectionView.ItemsSource;
+            var count = items.Count;
+            collectionView.Footer = new Button
+            {
+                Text = "Add Item",
+                Margin = new Thickness(16),
+                Command = new Command(() =>
+                {
+                    count++;
+                    items.Add($"Added item {count}");
+                })
+            };
         }
     }
 

--- a/src/app/Playground/VetleSamples/CollectionViewTests/RemoveFocusOnScrollPage.cs
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/RemoveFocusOnScrollPage.cs
@@ -11,16 +11,13 @@ namespace Playground.VetleSamples.CollectionViewTests;
 
 public class RemoveFocusOnScrollPage : ContentPage
 {
-    public RemoveFocusOnScrollPage(bool wrapInRefreshView, bool searchBarInHeader)
+    public RemoveFocusOnScrollPage(bool wrapInRefreshView, bool searchBarInHeader, bool delayedBinding = false)
     {
         var parts = new List<string>();
         parts.Add(searchBarInHeader ? "SearchBar in Header" : "SearchBar outside");
         if (wrapInRefreshView) parts.Add("RefreshView");
+        if (delayedBinding) parts.Add("Delayed");
         Title = string.Join(" + ", parts);
-
-        var items = new ObservableCollection<string>();
-        for (var i = 1; i <= 200; i++)
-            items.Add($"Item {i}");
 
         var searchBar = new SearchBar
         {
@@ -29,7 +26,6 @@ public class RemoveFocusOnScrollPage : ContentPage
 
         var collectionView = new CollectionView
         {
-            ItemsSource = items,
             RemoveFocusOnScroll = true,
             ItemTemplate = new DataTemplate(() =>
             {
@@ -43,6 +39,14 @@ public class RemoveFocusOnScrollPage : ContentPage
                 return label;
             })
         };
+
+        if (!delayedBinding)
+        {
+            var items = new ObservableCollection<string>();
+            for (var i = 1; i <= 200; i++)
+                items.Add($"Item {i}");
+            collectionView.ItemsSource = items;
+        }
 
         if (searchBarInHeader)
         {
@@ -77,5 +81,19 @@ public class RemoveFocusOnScrollPage : ContentPage
                 }
             };
         }
+
+        if (delayedBinding)
+        {
+            _ = LoadItemsAsync(collectionView);
+        }
+    }
+
+    private static async Task LoadItemsAsync(CollectionView collectionView)
+    {
+        await Task.Delay(1000);
+        var items = new ObservableCollection<string>();
+        for (var i = 1; i <= 200; i++)
+            items.Add($"Item {i}");
+        collectionView.ItemsSource = items;
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/Android/CollectionViewHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/Android/CollectionViewHandler.cs
@@ -87,7 +87,6 @@ public partial class CollectionViewHandler
     {
         m_keyboardDismissOnScrollListener = new KeyboardDismissOnScrollListener();
         PlatformView.AddOnScrollListener(m_keyboardDismissOnScrollListener);
-        PlatformView.AddOnItemTouchListener(m_keyboardDismissOnScrollListener);
         m_listenerRegisteredOn = PlatformView;
     }
 
@@ -99,7 +98,6 @@ public partial class CollectionViewHandler
         if (m_listenerRegisteredOn != null)
         {
             m_listenerRegisteredOn.RemoveOnScrollListener(m_keyboardDismissOnScrollListener);
-            m_listenerRegisteredOn.RemoveOnItemTouchListener(m_keyboardDismissOnScrollListener);
         }
         
         m_keyboardDismissOnScrollListener = null;

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/Android/CollectionViewHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/Android/CollectionViewHandler.cs
@@ -17,6 +17,7 @@ namespace DIPS.Mobile.UI.Components.Lists;
 public partial class CollectionViewHandler
 {
     private KeyboardDismissOnScrollListener? m_keyboardDismissOnScrollListener;
+    private RecyclerView? m_listenerRegisteredOn;
     
     protected override RecyclerView CreatePlatformView()
     {
@@ -62,30 +63,52 @@ public partial class CollectionViewHandler
         if (virtualView is not CollectionView collectionView)
             return;
 
-        // Remove any existing listener first
-        if (handler.m_keyboardDismissOnScrollListener != null)
-        {
-            handler.PlatformView.RemoveOnScrollListener(handler.m_keyboardDismissOnScrollListener);
-            handler.PlatformView.RemoveOnItemTouchListener(handler.m_keyboardDismissOnScrollListener);
-            handler.m_keyboardDismissOnScrollListener = null;
-        }
+        handler.RemoveKeyboardDismissListener();
 
         if (collectionView.RemoveFocusOnScroll)
         {
-            handler.m_keyboardDismissOnScrollListener = new KeyboardDismissOnScrollListener();
-            handler.PlatformView.AddOnScrollListener(handler.m_keyboardDismissOnScrollListener);
-            handler.PlatformView.AddOnItemTouchListener(handler.m_keyboardDismissOnScrollListener);
+            handler.AddKeyboardDismissListener();
         }
+    }
+    
+    partial void OnItemsSourceMapped()
+    {
+        if (VirtualView is not CollectionView { RemoveFocusOnScroll: true })
+            return;
+        
+        // MAUI's MauiRecyclerView.UpdateItemsSource() calls ClearOnScrollListeners(),
+        // which removes ALL scroll listeners — including ours.
+        // This runs via AppendToMapping, guaranteeing it executes AFTER MAUI's mapper.
+        RemoveKeyboardDismissListener();
+        AddKeyboardDismissListener();
+    }
+
+    private void AddKeyboardDismissListener()
+    {
+        m_keyboardDismissOnScrollListener = new KeyboardDismissOnScrollListener();
+        PlatformView.AddOnScrollListener(m_keyboardDismissOnScrollListener);
+        PlatformView.AddOnItemTouchListener(m_keyboardDismissOnScrollListener);
+        m_listenerRegisteredOn = PlatformView;
+    }
+
+    private void RemoveKeyboardDismissListener()
+    {
+        if (m_keyboardDismissOnScrollListener == null)
+            return;
+        
+        if (m_listenerRegisteredOn != null)
+        {
+            m_listenerRegisteredOn.RemoveOnScrollListener(m_keyboardDismissOnScrollListener);
+            m_listenerRegisteredOn.RemoveOnItemTouchListener(m_keyboardDismissOnScrollListener);
+        }
+        
+        m_keyboardDismissOnScrollListener = null;
+        m_listenerRegisteredOn = null;
     }
 
     protected override void DisconnectHandler(RecyclerView platformView)
     {
-        if (m_keyboardDismissOnScrollListener != null)
-        {
-            platformView.RemoveOnScrollListener(m_keyboardDismissOnScrollListener);
-            platformView.RemoveOnItemTouchListener(m_keyboardDismissOnScrollListener);
-            m_keyboardDismissOnScrollListener = null;
-        }
+        RemoveKeyboardDismissListener();
         
         base.DisconnectHandler(platformView);
     }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/Android/KeyboardDismissOnScrollListener.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/Android/KeyboardDismissOnScrollListener.cs
@@ -1,44 +1,25 @@
-using Android.Views;
 using Android.Views.InputMethods;
 using AndroidX.RecyclerView.Widget;
 
 namespace DIPS.Mobile.UI.Components.Lists;
 
-internal class KeyboardDismissOnScrollListener : RecyclerView.OnScrollListener, RecyclerView.IOnItemTouchListener
+internal class KeyboardDismissOnScrollListener : RecyclerView.OnScrollListener
 {
-    private bool m_isUserTouching;
     private bool m_hasHiddenKeyboard;
 
-    public bool OnInterceptTouchEvent(RecyclerView rv, MotionEvent e)
+    public override void OnScrollStateChanged(RecyclerView recyclerView, int newState)
     {
-        switch (e.Action)
-        {
-            case MotionEventActions.Down:
-                m_isUserTouching = true;
-                break;
-            case MotionEventActions.Up:
-            case MotionEventActions.Cancel:
-                m_isUserTouching = false;
-                m_hasHiddenKeyboard = false;
-                break;
-        }
+        base.OnScrollStateChanged(recyclerView, newState);
 
-        return false;
-    }
-
-    public void OnTouchEvent(RecyclerView rv, MotionEvent e)
-    {
-    }
-
-    public void OnRequestDisallowInterceptTouchEvent(bool disallowIntercept)
-    {
+        if (newState == RecyclerView.ScrollStateIdle)
+            m_hasHiddenKeyboard = false;
     }
 
     public override void OnScrolled(RecyclerView recyclerView, int dx, int dy)
     {
         base.OnScrolled(recyclerView, dx, dy);
 
-        if (!m_isUserTouching || m_hasHiddenKeyboard || dy == 0)
+        if (recyclerView.ScrollState == RecyclerView.ScrollStateIdle || m_hasHiddenKeyboard || dy == 0)
             return;
 
         m_hasHiddenKeyboard = true;

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/Android/KeyboardDismissOnScrollListener.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/Android/KeyboardDismissOnScrollListener.cs
@@ -1,36 +1,38 @@
-using Android.Views.InputMethods;
 using AndroidX.RecyclerView.Widget;
+using DIPS.Mobile.UI.Extensions.Android;
 
 namespace DIPS.Mobile.UI.Components.Lists;
 
 internal class KeyboardDismissOnScrollListener : RecyclerView.OnScrollListener
 {
     private bool m_hasHiddenKeyboard;
+    private bool m_userIsScrolling;
 
     public override void OnScrollStateChanged(RecyclerView recyclerView, int newState)
     {
         base.OnScrollStateChanged(recyclerView, newState);
 
-        if (newState == RecyclerView.ScrollStateIdle)
-            m_hasHiddenKeyboard = false;
+        switch (newState)
+        {
+            case RecyclerView.ScrollStateDragging:
+                m_userIsScrolling = true;
+                break;
+            case RecyclerView.ScrollStateIdle:
+                m_userIsScrolling = false;
+                m_hasHiddenKeyboard = false;
+                break;
+        }
     }
 
     public override void OnScrolled(RecyclerView recyclerView, int dx, int dy)
     {
         base.OnScrolled(recyclerView, dx, dy);
 
-        if (recyclerView.ScrollState == RecyclerView.ScrollStateIdle || m_hasHiddenKeyboard || dy == 0)
+        if (!m_userIsScrolling || m_hasHiddenKeyboard || dy == 0)
             return;
 
         m_hasHiddenKeyboard = true;
 
-        var activity = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
-        var focusedView = activity?.CurrentFocus;
-        if (focusedView == null)
-            return;
-
-        var imm = activity!.GetSystemService(global::Android.Content.Context.InputMethodService) as InputMethodManager;
-        imm?.HideSoftInputFromWindow(focusedView.WindowToken, HideSoftInputFlags.None);
-        focusedView.ClearFocus();
+        KeyboardHelper.HideKeyboardAndClearFocus(recyclerView);
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/Android/KeyboardDismissOnScrollListener.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/Android/KeyboardDismissOnScrollListener.cs
@@ -1,7 +1,6 @@
 using Android.Views;
 using Android.Views.InputMethods;
 using AndroidX.RecyclerView.Widget;
-using Microsoft.Maui.Platform;
 
 namespace DIPS.Mobile.UI.Components.Lists;
 
@@ -44,18 +43,13 @@ internal class KeyboardDismissOnScrollListener : RecyclerView.OnScrollListener, 
 
         m_hasHiddenKeyboard = true;
 
-        var context = recyclerView.Context;
-        if (context == null)
+        var activity = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
+        var focusedView = activity?.CurrentFocus;
+        if (focusedView == null)
             return;
 
-        var imm = context.GetSystemService(global::Android.Content.Context.InputMethodService) as InputMethodManager;
-        imm?.HideSoftInputFromWindow(recyclerView.WindowToken, HideSoftInputFlags.None);
-        
-        // Clear focus from the currently focused view (e.g. SearchBar)
-        // Temporarily block descendants from receiving focus so ClearFocus doesn't just re-focus another child
-        var previousFocusability = recyclerView.DescendantFocusability;
-        recyclerView.DescendantFocusability = DescendantFocusability.BlockDescendants;
-        recyclerView.FindFocus()?.ClearFocus();
-        recyclerView.DescendantFocusability = previousFocusability;
+        var imm = activity!.GetSystemService(global::Android.Content.Context.InputMethodService) as InputMethodManager;
+        imm?.HideSoftInputFromWindow(focusedView.WindowToken, HideSoftInputFlags.None);
+        focusedView.ClearFocus();
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/CollectionViewHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/CollectionViewHandler.cs
@@ -8,16 +8,28 @@ namespace DIPS.Mobile.UI.Components.Lists;
 
 public partial class CollectionViewHandler : CollectionViewHandlerImpl
 {
+
     public CollectionViewHandler() : base(CollectionViewPropertyMapper)
     {
+        // Run after MAUI's MapItemsSource, which calls ClearOnScrollListeners()
+        // and removes all scroll listeners — including ours.
+        // AppendToMapping guarantees this runs AFTER the base mapper.
+         CollectionViewPropertyMapper.AppendToMapping(
+            nameof(Microsoft.Maui.Controls.ItemsView.ItemsSource),
+            static (CollectionViewHandler handler, Microsoft.Maui.Controls.CollectionView _) =>
+            {
+                handler.OnItemsSourceMapped();
+            });
     }
 
-    public static readonly PropertyMapper CollectionViewPropertyMapper = new PropertyMapper<Microsoft.Maui.Controls.CollectionView, CollectionViewHandler>(Mapper)
+    public static readonly PropertyMapper<Microsoft.Maui.Controls.CollectionView, CollectionViewHandler> CollectionViewPropertyMapper = new PropertyMapper<Microsoft.Maui.Controls.CollectionView, CollectionViewHandler>(Mapper)
     {
         [nameof(CollectionView.ShouldBounce)] = MapShouldBounce,
         [nameof(CollectionView.RemoveFocusOnScroll)] = MapRemoveFocusOnScroll
     };
 
+    partial void OnItemsSourceMapped();
+    
     private static partial void MapShouldBounce(CollectionViewHandler handler, Microsoft.Maui.Controls.CollectionView virtualView);
     
     private static partial void MapRemoveFocusOnScroll(CollectionViewHandler handler, Microsoft.Maui.Controls.CollectionView virtualView);

--- a/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/Android/KeyboardDismissOnScrollListener.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/Android/KeyboardDismissOnScrollListener.cs
@@ -37,20 +37,13 @@ internal class ScrollViewKeyboardDismissOnScrollListener : Java.Lang.Object, AVi
 
         m_hasHiddenKeyboard = true;
 
-        var context = v.Context;
-        if (context == null)
+        var activity = Platform.CurrentActivity;
+        var focusedView = activity?.CurrentFocus;
+        if (focusedView == null)
             return;
 
-        var imm = context.GetSystemService(global::Android.Content.Context.InputMethodService) as InputMethodManager;
-        imm?.HideSoftInputFromWindow(v.WindowToken, HideSoftInputFlags.None);
-        
-        // Clear focus from the currently focused view (e.g. SearchBar)
-        if (v is ViewGroup viewGroup)
-        {
-            var previousFocusability = viewGroup.DescendantFocusability;
-            viewGroup.DescendantFocusability = DescendantFocusability.BlockDescendants;
-            viewGroup.FindFocus()?.ClearFocus();
-            viewGroup.DescendantFocusability = previousFocusability;
-        }
+        var imm = activity!.GetSystemService(global::Android.Content.Context.InputMethodService) as InputMethodManager;
+        imm?.HideSoftInputFromWindow(focusedView.WindowToken, HideSoftInputFlags.None);
+        focusedView.ClearFocus();
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/Android/KeyboardDismissOnScrollListener.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/Android/KeyboardDismissOnScrollListener.cs
@@ -1,5 +1,5 @@
 using Android.Views;
-using Android.Views.InputMethods;
+using DIPS.Mobile.UI.Extensions.Android;
 using AView = Android.Views.View;
 
 namespace DIPS.Mobile.UI.Components.Lists;
@@ -37,13 +37,6 @@ internal class ScrollViewKeyboardDismissOnScrollListener : Java.Lang.Object, AVi
 
         m_hasHiddenKeyboard = true;
 
-        var activity = Platform.CurrentActivity;
-        var focusedView = activity?.CurrentFocus;
-        if (focusedView == null)
-            return;
-
-        var imm = activity!.GetSystemService(global::Android.Content.Context.InputMethodService) as InputMethodManager;
-        imm?.HideSoftInputFromWindow(focusedView.WindowToken, HideSoftInputFlags.None);
-        focusedView.ClearFocus();
+        KeyboardHelper.HideKeyboardAndClearFocus(v);
     }
 }

--- a/src/library/DIPS.Mobile.UI/Extensions/Android/KeyboardHelper.cs
+++ b/src/library/DIPS.Mobile.UI/Extensions/Android/KeyboardHelper.cs
@@ -1,0 +1,54 @@
+using Android.Views;
+using Android.Views.InputMethods;
+using AView = Android.Views.View;
+
+namespace DIPS.Mobile.UI.Extensions.Android;
+
+/// <summary>
+/// Android utilities for managing the soft keyboard.
+/// </summary>
+public static class KeyboardHelper
+{
+    /// <summary>
+    /// Hides the soft keyboard and clears focus from the currently focused view.
+    /// Does nothing if the keyboard is not currently visible.
+    /// <para>
+    /// Uses <see cref="InputMethodManager.IsAcceptingText"/> to detect keyboard visibility
+    /// instead of <c>Activity.CurrentFocus</c>, which is often <c>null</c> in .NET MAUI.
+    /// </para>
+    /// <para>
+    /// When the <paramref name="view"/> is a <see cref="ViewGroup"/> (e.g. RecyclerView, ScrollView),
+    /// descendant focusability is temporarily blocked before clearing focus. This prevents Android
+    /// from cycling focus back to the same input field.
+    /// </para>
+    /// </summary>
+    /// <param name="view">
+    /// The view whose window token is used to hide the keyboard.
+    /// If the view is a <see cref="ViewGroup"/>, focus traversal is also scoped to this group
+    /// to find and clear the focused child.
+    /// </param>
+    public static void HideKeyboardAndClearFocus(AView view)
+    {
+        var activity = Platform.CurrentActivity;
+        if (activity == null)
+            return;
+
+        var imm = activity.GetSystemService(global::Android.Content.Context.InputMethodService) as InputMethodManager;
+        if (imm is not { IsAcceptingText: true })
+            return;
+
+        imm.HideSoftInputFromWindow(view.WindowToken, HideSoftInputFlags.None);
+
+        if (view is ViewGroup viewGroup)
+        {
+            var previousFocusability = viewGroup.DescendantFocusability;
+            viewGroup.DescendantFocusability = DescendantFocusability.BlockDescendants;
+            viewGroup.FindFocus()?.ClearFocus();
+            viewGroup.DescendantFocusability = previousFocusability;
+        }
+        else
+        {
+            activity.Window?.DecorView.FindFocus()?.ClearFocus();
+        }
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Extensions/Android/KeyboardHelper.cs
+++ b/src/library/DIPS.Mobile.UI/Extensions/Android/KeyboardHelper.cs
@@ -41,14 +41,19 @@ public static class KeyboardHelper
 
         if (view is ViewGroup viewGroup)
         {
-            var previousFocusability = viewGroup.DescendantFocusability;
-            viewGroup.DescendantFocusability = DescendantFocusability.BlockDescendants;
-            viewGroup.FindFocus()?.ClearFocus();
-            viewGroup.DescendantFocusability = previousFocusability;
+            // First try to find and clear focus among descendants (e.g. search bar in header)
+            var focusedChild = viewGroup.FindFocus();
+            if (focusedChild != null)
+            {
+                var previousFocusability = viewGroup.DescendantFocusability;
+                viewGroup.DescendantFocusability = DescendantFocusability.BlockDescendants;
+                focusedChild.ClearFocus();
+                viewGroup.DescendantFocusability = previousFocusability;
+                return;
+            }
         }
-        else
-        {
-            activity.Window?.DecorView.FindFocus()?.ClearFocus();
-        }
+
+        // Focused view is outside the provided view (or view is not a ViewGroup) — search from root
+        activity.Window?.DecorView.FindFocus()?.ClearFocus();
     }
 }


### PR DESCRIPTION
### Description of Change

- Fixed keyboard dismiss not working when items are loaded after the page is shown (delayed binding).
- Fixed programmatic scroll (e.g. when loading items) incorrectly dismissing keyboard.
- Now clears focus from the active input field when keyboard is dismissed by scrolling.

### Todos
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->