### PR TITLE
Updated CameraX API to 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [59.1.3]
-- [Camera][Android] Fixed crash caused by CameraX upgrade to 1.6.1: zoom state cast failure due to CameraPipe backend migration. Uses `JavaCast<IZoomState>()` instead of direct C# cast for cross-proxy interface compatibility.
+- [Camera][Android] Updated CameraX dependencies from 1.4.1 to 1.6.1, fixing crash on startup due to breaking interface change in `ImageAnalysis.IAnalyzer`.
 
 ## [59.1.2]
 - [CollectionView][Android] Fixed keyboard dismiss not working when items are loaded after the page is shown (delayed binding).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [59.1.3]
+- [Camera][Android] Fixed crash caused by CameraX upgrade to 1.6.1: zoom state cast failure due to CameraPipe backend migration. Uses `JavaCast<IZoomState>()` instead of direct C# cast for cross-proxy interface compatibility.
+
 ## [59.1.2]
 - [CollectionView][Android] Fixed keyboard dismiss not working when items are loaded after the page is shown (delayed binding).
 - [CollectionView][Android] Fixed programmatic scroll (e.g. when loading items) incorrectly dismissing keyboard.

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,10 +20,10 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.12" />
     <PackageVersion Include="Xamarin.Google.MLKit.BarcodeScanning" Version="117.3.0" />
-    <PackageVersion Include="Xamarin.AndroidX.Camera.View" Version="1.4.1" />
-    <PackageVersion Include="Xamarin.AndroidX.Camera.Camera2" Version="1.4.1" />
-    <PackageVersion Include="Xamarin.AndroidX.Tracing.Tracing" Version="1.3.0.1" />
-    <PackageVersion Include="Xamarin.AndroidX.Tracing.Tracing.Ktx" Version="1.3.0.1" />
+    <PackageVersion Include="Xamarin.AndroidX.Camera.View" Version="1.6.1" />
+    <PackageVersion Include="Xamarin.AndroidX.Camera.Camera2" Version="1.6.1" />
+    <PackageVersion Include="Xamarin.AndroidX.Tracing.Tracing" Version="1.3.0.3" />
+    <PackageVersion Include="Xamarin.AndroidX.Tracing.Tracing.Ktx" Version="1.3.0.3" />
   </ItemGroup>
   <!-- Unit tests -->
   <ItemGroup>

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/Android/ImageAnalyzer.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/Android/ImageAnalyzer.cs
@@ -1,4 +1,5 @@
 using AndroidX.Camera.Core;
+using Size = Android.Util.Size;
 
 namespace DIPS.Mobile.UI.API.Camera.BarcodeScanning.Android;
 
@@ -16,4 +17,10 @@ public class ImageAnalyzer : Java.Lang.Object, ImageAnalysis.IAnalyzer
     {
         m_analyze.Invoke(p0);
     }
+    // See:
+    // https://github.com/dotnet/android-libraries/issues/767
+    // https://github.com/dotnet/android/pull/9656
+#pragma warning disable CS8603 // Possible null reference return.
+    public global::Android.Util.Size DefaultTargetResolution => null;
+#pragma warning restore CS8603 // Possible null reference return.
 }

--- a/src/library/DIPS.Mobile.UI/API/Camera/Preview/CameraPreview.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Preview/CameraPreview.cs
@@ -125,7 +125,10 @@ public partial class CameraPreview : ContentView
         m_topToolbarContainer.HeightRequest = topToolbarHeight;
         m_bottomToolbarContainer.HeightRequest = Math.Max(totalLetterBoxHeight - topToolbarHeight, 0);
 
-        CameraZoomView!.Margin = new Thickness(0, 0, 0, Sizes.GetSize(SizeName.content_margin_small) + m_bottomToolbarContainer.HeightRequest);
+        if (CameraZoomView is not null)
+        {
+            CameraZoomView.Margin = new Thickness(0, 0, 0, Sizes.GetSize(SizeName.content_margin_small) + m_bottomToolbarContainer.HeightRequest);
+        }
         PreviewView.TranslationY -= topToolbarHeight;
 
         m_hasSetToolbarHeights = true;

--- a/src/library/DIPS.Mobile.UI/API/Camera/Shared/Android/CameraFragment.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Shared/Android/CameraFragment.cs
@@ -8,7 +8,6 @@ using Android.Hardware.Display;
 using Android.Runtime;
 using Android.Views;
 using AndroidX.Camera.Core;
-using AndroidX.Camera.Core.Internal;
 using AndroidX.Camera.Core.ResolutionSelector;
 using AndroidX.Camera.Lifecycle;
 using AndroidX.Camera.Video;
@@ -296,7 +295,8 @@ public abstract class CameraFragment : Fragment
 
     private void OnScaled(float scaleRatio)
     {
-        if (Camera?.CameraInfo.ZoomState.Value is not AndroidX.Camera.Core.Internal.ImmutableZoomState zoomState)
+        var zoomState = Camera?.CameraInfo.ZoomState.Value?.JavaCast<IZoomState>();
+        if (zoomState is null)
             return;
 
         var desiredZoomRatio = zoomState.ZoomRatio * scaleRatio;
@@ -313,7 +313,7 @@ public abstract class CameraFragment : Fragment
         m_cameraPreview?.CameraZoomView?.OnPinchToZoom(desiredZoomRatio);
     }
 
-    private ImmutableZoomState? ZoomState => Camera?.CameraInfo.ZoomState.Value as ImmutableZoomState; 
+    private IZoomState? ZoomState => Camera?.CameraInfo.ZoomState.Value?.JavaCast<IZoomState>(); 
     
     private void AddZoomView()
     {


### PR DESCRIPTION
### Description of Change

Update CameraX dependencies from 1.4.1 to 1.6.1, fixing a crash on startup caused by a breaking interface change in `ImageAnalysis.IAnalyzer` ([dotnet/android-libraries#767](https://github.com/dotnet/android-libraries/issues/767)).

**Changes:**
- **`ImageAnalyzer`**: Added `DefaultTargetResolution` property override required by the updated `ImageAnalysis.IAnalyzer` interface contract
- **`CameraFragment`**: Replaced internal `ImmutableZoomState` cast with `JavaCast<IZoomState>()` for CameraPipe compatibility (CameraX 1.6.0 migrated to CameraPipe backend, changing internal proxy types)
- **`CameraPreview`**: Added null guard on `CameraZoomView.Margin` in `SetToolbarHeights`
- **`Directory.Packages.props`**: Bumped `Xamarin.AndroidX.Camera.View`/`Camera2` from 1.4.1 → 1.6.1 and `Xamarin.AndroidX.Tracing` from 1.3.0.1 → 1.3.0.3

<details>
<summary><b>📋 CameraX Camera2 / Camera Core changelog (1.4.1 → 1.6.1)</b></summary>

#### Version 1.6.1 — May 06, 2026
- Fixed a compilation error "Cannot access class `ListenableFuture`" when using CameraX 1.6.0.

#### Version 1.6.0 — March 25, 2026
1. **Migrated to CameraPipe** — CameraX now uses `CameraPipe`, the same high-performance stack powering the Pixel camera app.
2. **Media3 Muxer Integration** — Enhanced video processing performance and crash resilience for `VideoCapture`.
3. **Feature Group improvement** — Check if a group of features (e.g. CameraX Extensions or slow motion) is supported before binding to lifecycle.
- Fixed a crash on upcoming **Android 17** devices due to unknown dynamic range mode. **Must use ≥1.5.2 or ≥1.6.0 to avoid this crash.**
- Fixed inconsistent feature group results with `PREVIEW_STABILIZATION` and `VideoCapture`.
- Fixed glitchy video on Samsung Galaxy S6.

#### Version 1.5.0 — September 10, 2025
- High-speed and slow-motion recording (120/240 fps).
- `SessionConfig` and `FeatureGroup` API.
- **minSdk moved from API 21 to API 23.**

#### Version 1.5.1 — October 08, 2025
- Support `CameraEffect` in concurrent camera composition mode.
- Fixed `UseCases` losing target rotation on recreation.
- Improved `CameraXViewfinder` stability on older API levels by defaulting to `TextureView`.

#### Version 1.5.2 — December 4, 2025
- Fixed crash due to `IllegalArgumentException: Dynamic range profile cannot be converted` on Android 17+.

</details>

<details>
<summary><b>📋 CameraX Camera View changelog (1.4.1 → 1.6.1)</b></summary>

Camera View follows the same version as Camera Core from 1.5.0 onwards. All changes listed above for Camera Core / Camera2 apply equally to the Camera View package.

</details>

<details>
<summary><b>📋 AndroidX Tracing changelog (1.3.0.1 → 1.3.0.3)</b></summary>

Transitive dependency bump required by CameraX 1.6.1. No user-facing changes — binding version alignment only.

</details>

### Todos
- [x] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility


Fixes #866  