### PR TITLE
Fix reversed context menu item order on iOS BottomToolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [59.1.4]
+- [ContextMenu][iOS] Fixed context menu items appearing in reversed order when displayed from a ToolbarButton in BottomToolbar.
+
 ## [59.1.3]
 - [Camera][Android] Updated CameraX dependencies from 1.4.1 to 1.6.1, fixing crash on startup due to breaking interface change in `ImageAnalysis.IAnalyzer`.
 

--- a/src/library/DIPS.Mobile.UI/Components/Toolbar/iOS/ToolbarHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Toolbar/iOS/ToolbarHandler.cs
@@ -226,7 +226,7 @@ public partial class ToolbarHandler : ViewHandler<Toolbar, UIToolbar>
         if (hasMenu)
         {
             var menuItems = ContextMenuHelper.CreateMenuItems(toolbarButton.Menu!.ItemsSource!, toolbarButton.Menu);
-            var uiMenu = UIMenu.Create(menuItems.Select(kvp => kvp.Value).ToArray());
+            var uiMenu = UIMenu.Create(menuItems.Select(kvp => kvp.Value).Reverse().ToArray());
 
             if (hasIcon)
             {
@@ -241,7 +241,7 @@ public partial class ToolbarHandler : ViewHandler<Toolbar, UIToolbar>
             void RebuildMenu()
             {
                 var updatedMenuItems = ContextMenuHelper.CreateMenuItems(toolbarButton.Menu!.ItemsSource!, toolbarButton.Menu);
-                var updatedUiMenu = UIMenu.Create(updatedMenuItems.Select(kvp => kvp.Value).ToArray());
+                var updatedUiMenu = UIMenu.Create(updatedMenuItems.Select(kvp => kvp.Value).Reverse().ToArray());
                 item.Menu = updatedUiMenu;
             }
 


### PR DESCRIPTION
Context menu items displayed from a `ToolbarButton` in `BottomToolbar` appeared in reversed order on iOS compared to Android. 

When a `UIBarButtonItem` presents its menu from a bottom toolbar, iOS automatically reverses the element order (likely to place the "primary" action closest to the user's thumb). This does not happen with `UIButton.Menu` (Pressed mode) or `UIContextMenuInteraction` (LongPressed mode), which is why other context menus are unaffected.

Fixed by reversing the array passed to `UIMenu.Create()` in `ToolbarHandler`, so iOS's automatic reversal results in the correct XAML-defined order.

Fixes DIPSDev/Arena.Mobile#1417

### Todos
- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility