### PR TITLE
Make ModalNavigationRenderer public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [59.2.2]
+- [ContentPage] Made `ModalNavigationRenderer` public to allow consumer customization.
+
 ## [59.2.1]
 - Bump maui controls
 

--- a/src/library/DIPS.Mobile.UI/Components/Pages/iOS/ModalNavigationRenderer.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pages/iOS/ModalNavigationRenderer.cs
@@ -5,7 +5,7 @@ using UIKit;
 
 namespace DIPS.Mobile.UI.Components.Pages;
 
-internal class ModalNavigationRenderer : NavigationRenderer
+public class ModalNavigationRenderer : NavigationRenderer
 {
     protected override void OnElementChanged(VisualElementChangedEventArgs e)
     {

--- a/src/library/DIPS.Mobile.UI/Components/Pages/iOS/ModalNavigationRenderer.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pages/iOS/ModalNavigationRenderer.cs
@@ -5,6 +5,12 @@ using UIKit;
 
 namespace DIPS.Mobile.UI.Components.Pages;
 
+/// <summary>
+/// iOS navigation renderer for modal <see cref="NavigationPage"/> instances, providing status bar style updates based on the navigation bar background color.
+/// </summary>
+/// <remarks>
+/// Consumers can subclass this renderer and register their subclass as the <see cref="NavigationPage"/> handler to customize modal navigation behavior on iOS.
+/// </remarks>
 public class ModalNavigationRenderer : NavigationRenderer
 {
     protected override void OnElementChanged(VisualElementChangedEventArgs e)


### PR DESCRIPTION
### Description of Change

Made `ModalNavigationRenderer` public to allow consumers to subclass and customize the modal navigation renderer on iOS.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility