### PR TITLE
[CameraPreview] Removed manual safe-area padding on iOS and set `SafeAreaEdges.None` on internal containers so the top toolbar renders correctly on both modal and regular shell pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [60.0.2]
+## [60.0.1]
 - [CameraPreview] Removed manual safe-area padding on iOS and set `SafeAreaEdges.None` on internal containers so the top toolbar renders correctly on both modal and regular shell pages.
 
 ## [60.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
+## [60.0.2]
+- [CameraPreview] Removed manual safe-area padding on iOS and set `SafeAreaEdges.None` on internal containers so the top toolbar renders correctly on both modal and regular shell pages.
+
 ## [60.0.0]
 - [BarcodeScanner] Fixed the scanner not resuming barcode detection after pause/resume.
-- [BarcodeScanner] **BREAKING**: Replaced `BarcodeScannerStartOptions.ScanRectangle` (`BarcodeScanRectangleOptions`) and `BarcodeDetectionTime` with `BarcodeScannerStartOptions.Strategy` of type `BarcodeScanStrategy`. Use `TimerBarcodeScanStrategy { DetectionTime }` for timer-based confirmation without an overlay, or `ScanRectangleBarcodeScanStrategy { WidthFraction, HeightFraction, BracketsTravelDuration, FormingDuration }` for the animated scan rectangle overlay. The default strategy is `TimerBarcodeScanStrategy` (500 ms).
-- [CameraPreview] **BREAKING**: Removed `IsInFullscreen`. The preview always applies safe-area padding on iOS.
+- [BarcodeScanner] **BREAKING**: Replaced `BarcodeScannerStartOptions.ScanRectangle` (`BarcodeScanRectangleOptions`) and `BarcodeDetectionTime` with `BarcodeScannerStartOptions.Strategy` of type `BarcodeScanStrategy`. Use `TimerBarcodeScanStrategy { DetectionTime }` for timer-based confirmation without an overlay, or `ScanRectangleBarcodeScanStrategy { WidthFraction, HeightFraction, BracketsTravelDuration, FormingDuration }` for the animated scan rectangle overlay. The default strategy is `TimerBarcodeScanStrategy` (500 ms).- [CameraPreview] **BREAKING**: Removed `IsInFullscreen`. The preview always applies safe-area padding on iOS.
 
 ## [59.2.2]
 - [ContentPage] Made `ModalNavigationRenderer` public to allow consumer customization.

--- a/src/app/Playground/EirikSamples/BarcodeScanResumeRepro.xaml.cs
+++ b/src/app/Playground/EirikSamples/BarcodeScanResumeRepro.xaml.cs
@@ -1,6 +1,7 @@
 using DIPS.Mobile.UI.API.Camera;
 using DIPS.Mobile.UI.API.Camera.BarcodeScanning;
 using DIPS.Mobile.UI.Components.BottomSheets;
+using DIPS.Mobile.UI.Resources.Sizes;
 
 namespace Playground.EirikSamples;
 
@@ -52,6 +53,23 @@ public partial class BarcodeScanResumeRepro
                     HeightFraction = 0.3f
                 }
             });
+
+            // Add top content — simulates a patient banner like SamplingPatientScanRepro
+            var patientBanner = new Frame
+            {
+                BackgroundColor = Color.FromArgb("#333333"),
+                CornerRadius = 8,
+                Padding = new Thickness(12, 8),
+                Margin = new Thickness(Sizes.GetSize(SizeName.size_3), 0),
+                VerticalOptions = LayoutOptions.Start,
+                Content = new Label
+                {
+                    Text = "Ola Nordmann \u2014 01019012345",
+                    TextColor = Microsoft.Maui.Graphics.Colors.White,
+                    FontSize = 14,
+                }
+            };
+            CameraPreview.AddTopToolbarView(patientBanner);
         }
         catch (Exception ex)
         {

--- a/src/app/Playground/MainPage.xaml
+++ b/src/app/Playground/MainPage.xaml
@@ -29,6 +29,8 @@
                                     Tapped="GoToBarcodeScanResumeRepro" />
             <dui:NavigationListItem Title="Barcode Resume Repro (Modal)"
                                     Tapped="GoToBarcodeScanResumeReproModal" />
+            <dui:NavigationListItem Title="Sampling Patient Scan Repro (Modal)"
+                                    Tapped="GoToSamplingPatientScanRepro" />
             <dui:Button Text="Tap me"
                         Clicked="TapMe" />
         </VerticalStackLayout>

--- a/src/app/Playground/MainPage.xaml.cs
+++ b/src/app/Playground/MainPage.xaml.cs
@@ -109,4 +109,11 @@ public partial class MainPage
         });
         Shell.Current.Navigation.PushModalAsync(navigationPage);
     }
+
+    private void GoToSamplingPatientScanRepro(object sender, EventArgs e)
+    {
+        var scannerPage = new SamplingPatientScanRepro();
+        var navigationPage = new NavigationPage(scannerPage);
+        Shell.Current.Navigation.PushModalAsync(navigationPage);
+    }
 }

--- a/src/app/Playground/VetleSamples/SamplingPatientScanRepro.xaml
+++ b/src/app/Playground/VetleSamples/SamplingPatientScanRepro.xaml
@@ -3,11 +3,10 @@
 <dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                  xmlns:dui="http://dips.com/mobile.ui"
-                 x:Class="Playground.EirikSamples.BarcodeScanResumeRepro"
+                 x:Class="Playground.VetleSamples.SamplingPatientScanRepro"
                  NavigationPage.BarBackgroundColor="Black"
                  NavigationPage.BarTextColor="White"
-                 Title="Barcode Resume Repro (#1415)"
+                 Title="Bekreft pasient-ID"
                  SafeAreaEdges="None">
-
-    <dui:CameraPreview x:Name="CameraPreview"/>
+    <dui:CameraPreview x:Name="CameraPreview" />
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/SamplingPatientScanRepro.xaml.cs
+++ b/src/app/Playground/VetleSamples/SamplingPatientScanRepro.xaml.cs
@@ -1,0 +1,141 @@
+using DIPS.Mobile.UI.API.Camera.BarcodeScanning;
+using DIPS.Mobile.UI.Components.BottomSheets;
+using DIPS.Mobile.UI.Resources.Colors;
+using DIPS.Mobile.UI.Resources.Sizes;
+using DIPS.Mobile.UI.Resources.Styles;
+using DIPS.Mobile.UI.Resources.Styles.Button;
+using DIPS.Mobile.UI.Resources.Styles.Label;
+
+namespace Playground.VetleSamples;
+
+/// <summary>
+/// Reproduces the Arena Mobile SamplingPatientBarcodeResultStrategy scanner layout.
+/// Opens as a modal NavigationPage with:
+///   - Top toolbar: patient banner placeholder
+///   - Tooltip: instruction label
+///   - Bottom toolbar: "or" label + button
+///   - ScanRectangleBarcodeScanStrategy
+///
+/// Use this to verify that top/bottom toolbar sizing works correctly.
+/// </summary>
+public partial class SamplingPatientScanRepro
+{
+    private readonly BarcodeScanner m_barcodeScanner;
+
+    public SamplingPatientScanRepro()
+    {
+        InitializeComponent();
+        m_barcodeScanner = new BarcodeScanner();
+
+        ToolbarItems.Add(new ToolbarItem
+        {
+            Text = "Avbryt",
+            Command = new Command(() => Shell.Current.Navigation.PopModalAsync())
+        });
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        _ = StartScanning();
+    }
+
+    protected override void OnDisappearing()
+    {
+        m_barcodeScanner.StopAndDispose();
+        base.OnDisappearing();
+    }
+
+    private async Task StartScanning()
+    {
+        try
+        {
+            await m_barcodeScanner.Start(new BarcodeScannerStartOptions
+            {
+                Preview = CameraPreview,
+                OnCameraFailed = e => DisplayAlert("Kamera feilet", e.Message, "OK"),
+                OnBarcodeAcceptedAsync = OnBarcodeAccepted,
+                Strategy = new ScanRectangleBarcodeScanStrategy(),
+            });
+
+            // Add top content — simulates the minimized patient banner
+            var patientBanner = new Frame
+            {
+                BackgroundColor = Color.FromArgb("#333333"),
+                CornerRadius = 8,
+                Padding = new Thickness(12, 8),
+                Margin = new Thickness(Sizes.GetSize(SizeName.size_3), 0),
+                VerticalOptions = LayoutOptions.Start,
+                Content = new Label
+                {
+                    Text = "Ola Nordmann — 01019012345",
+                    TextColor = Microsoft.Maui.Graphics.Colors.White,
+                    FontSize = 14,
+                }
+            };
+            CameraPreview.AddTopToolbarView(patientBanner);
+
+            // Add tooltip — simulates the scan instruction
+            m_barcodeScanner.SetTooltipView(new DIPS.Mobile.UI.Components.Labels.Label
+            {
+                Text = "Skann armbåndet til pasienten",
+                Style = Styles.GetLabelStyle(LabelStyle.Body300),
+                TextColor = Microsoft.Maui.Graphics.Colors.White,
+                HorizontalTextAlignment = TextAlignment.Center,
+            });
+
+            // Add bottom content — simulates the "or enter birth number" section
+            var bottomContent = new VerticalStackLayout
+            {
+                Children =
+                {
+                    new DIPS.Mobile.UI.Components.Labels.Label
+                    {
+                        Text = "eller",
+                        Style = Styles.GetLabelStyle(LabelStyle.Body300),
+                        TextColor = Microsoft.Maui.Graphics.Colors.White,
+                        HorizontalTextAlignment = TextAlignment.Center,
+                        Margin = new Thickness(0, Sizes.GetSize(SizeName.size_4)),
+                    },
+                    new DIPS.Mobile.UI.Components.Buttons.Button
+                    {
+                        Text = "Tast inn fødselsnummer",
+                        TextColor = Microsoft.Maui.Graphics.Colors.White,
+                        Style = Styles.GetButtonStyle(ButtonStyle.DefaultLarge),
+                        HorizontalOptions = LayoutOptions.Fill,
+                        Margin = new Thickness(Sizes.GetSize(SizeName.size_3), 0),
+                    }
+                }
+            };
+            CameraPreview.AddBottomToolbarView(bottomContent);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[SamplingPatientScanRepro] Start failed: {ex}");
+        }
+    }
+
+    private Task OnBarcodeAccepted(BarcodeScanResult result)
+    {
+        m_barcodeScanner.PauseScanning(resetOverlay: false);
+
+        var sheet = new BottomSheet { Title = "Skanneresultat" };
+        sheet.Content = new VerticalStackLayout
+        {
+            Padding = 16,
+            Children =
+            {
+                new Label { Text = $"Strekkode: {result.Barcode.RawValue}", Margin = new Thickness(0, 0, 0, 8) },
+                new Label { Text = $"Format: {result.Barcode.Format}" },
+            }
+        };
+
+        sheet.Closed += (_, _) =>
+        {
+            m_barcodeScanner.ResumeScanning();
+        };
+
+        sheet.Open();
+        return Task.CompletedTask;
+    }
+}

--- a/src/library/DIPS.Mobile.UI/API/Camera/Preview/CameraPreview.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Preview/CameraPreview.cs
@@ -17,7 +17,7 @@ public partial class CameraPreview : ContentView
 {
     private readonly TaskCompletionSource m_hasLoadedTcs = new();
     private WeakReference<ICameraUseCase?> m_cameraUseCase;
-    
+
     private Grid? m_grid;
     private Grid m_bottomToolbarContainer;
     private Grid m_topToolbarContainer;
@@ -29,41 +29,36 @@ public partial class CameraPreview : ContentView
     internal const float ThreeFourRatio = .75f;
     internal const float TopToolbarPercentHeightOfLetterBox = .25f;
     internal const float BottomToolbarPercentHeightOfLetterBox = .75f;
-    
+
     public CameraPreview()
     {
         BackgroundColor = Colors.Black;
         Loaded += OnLoaded;
-        
+
 #if __IOS__
         Content = ConstructView();
 #else
-        
+
 #endif
     }
 
     private void OnLoaded(object? sender, EventArgs e)
     {
-#if __IOS__
-        if (UIApplication.SharedApplication.KeyWindow != null)
-        {
-            Padding = new Thickness(0, UIApplication.SharedApplication.KeyWindow.SafeAreaInsets.Top, 0,
-                UIApplication.SharedApplication.KeyWindow.SafeAreaInsets.Bottom);
-        }
-#endif
         m_hasLoadedTcs.TrySetResult();
     }
-    
+
     public Grid ConstructView()
     {
         m_bottomToolbarContainer = new Grid
         {
-            VerticalOptions = LayoutOptions.End, 
+            SafeAreaEdges = SafeAreaEdges.None,
+            VerticalOptions = LayoutOptions.End,
             BackgroundColor = Colors.Transparent,
         };
-        
+
         m_topToolbarContainer = new Grid
         {
+            SafeAreaEdges = SafeAreaEdges.None,
             VerticalOptions = LayoutOptions.Start,
             BackgroundColor = Colors.Transparent,
         };
@@ -72,10 +67,11 @@ public partial class CameraPreview : ContentView
 
         m_grid = new Grid
         {
+            SafeAreaEdges = SafeAreaEdges.None,
             Children = { PreviewView, m_bottomToolbarContainer, m_topToolbarContainer },
             ColumnDefinitions = [new ColumnDefinition(GridLength.Star)]
         };
-        
+
         return m_grid;
     }
 
@@ -86,9 +82,9 @@ public partial class CameraPreview : ContentView
         get => m_cameraZoomView;
         set
         {
-            if(CameraZoomView is not null)
+            if (CameraZoomView is not null)
                 return;
-            
+
             m_cameraZoomView = value;
             m_grid?.Add(value);
         }
@@ -117,13 +113,15 @@ public partial class CameraPreview : ContentView
         {
             return;
         }
-        
+
         var actualPreviewHeight = (Width / ThreeFourRatio);
         var totalLetterBoxHeight = frameHeight - actualPreviewHeight;
 
         var topToolbarHeight = ComputeTopToolbarHeight((float)Width, frameHeight);
         m_topToolbarContainer.HeightRequest = topToolbarHeight;
         m_bottomToolbarContainer.HeightRequest = Math.Max(totalLetterBoxHeight - topToolbarHeight, 0);
+
+        System.Diagnostics.Debug.WriteLine($"[CameraPreview] frameHeight={frameHeight}, Width={Width}, actualPreviewHeight={actualPreviewHeight}, letterBox={totalLetterBoxHeight}, topToolbar={topToolbarHeight}, bottomToolbar={m_bottomToolbarContainer.HeightRequest}, Padding.Top={Padding.Top}, Padding.Bottom={Padding.Bottom}");
 
         if (CameraZoomView is not null)
         {
@@ -150,11 +148,11 @@ public partial class CameraPreview : ContentView
                    + Sizes.GetSize(SizeName.content_margin_small);
         }
     }
-    
+
     internal void AddFocusIndicator(float percentX, float percentY)
     {
         m_grid?.Remove(m_indicatorWrapper);
-        
+
         m_indicator = new Border
         {
             WidthRequest = Sizes.GetSize(SizeName.size_17),
@@ -177,7 +175,7 @@ public partial class CameraPreview : ContentView
             VerticalOptions = LayoutOptions.Start,
             HorizontalOptions = LayoutOptions.Start
         };
-        
+
         var viewToRemove = m_indicatorWrapper;
         var borderToRemoveAnimate = m_indicator;
 
@@ -185,10 +183,10 @@ public partial class CameraPreview : ContentView
         m_indicatorWrapper.TranslationY = percentY * PreviewView.Height;
 
         m_indicatorWrapper.TranslationY -= (m_indicator.HeightRequest / 2) - PreviewView.TranslationY;
-        
+
         m_indicator.ScaleTo(1, easing: Easing.SpringOut);
         m_indicator.FadeTo(1);
-        
+
         m_grid?.Add(m_indicatorWrapper);
 
         Task.Run(async () =>
@@ -209,45 +207,45 @@ public partial class CameraPreview : ContentView
 
     public void AddTopToolbarView(View? toolbarItems)
     {
-        if(m_topToolbarContainer.Contains(toolbarItems))
+        if (m_topToolbarContainer.Contains(toolbarItems))
             return;
-        
+
         m_topToolbarContainer.Add(toolbarItems);
     }
-    
+
     public void RemoveTopToolbarView(View? toolbarItems)
     {
-        if (toolbarItems is null) 
+        if (toolbarItems is null)
             return;
-        
+
         m_topToolbarContainer.Remove(toolbarItems);
         toolbarItems.DisconnectHandlers();
     }
 
     public void AddBottomToolbarView(View? toolbarItems)
     {
-        if(m_bottomToolbarContainer.Contains(toolbarItems))
+        if (m_bottomToolbarContainer.Contains(toolbarItems))
             return;
-        
+
         m_bottomToolbarContainer.Add(toolbarItems);
     }
-    
+
     public void RemoveBottomToolbarView(View? toolbarItems)
     {
-        if (toolbarItems is null) 
+        if (toolbarItems is null)
             return;
-        
+
         m_bottomToolbarContainer.Remove(toolbarItems);
         toolbarItems.DisconnectHandlers();
     }
-    
+
     internal void AddViewToRoot(View view, int index = -1, bool usePreviewViewTranslation = false)
     {
         if (usePreviewViewTranslation)
         {
             view.TranslationY = PreviewView.TranslationY;
         }
-        
+
         if (index == -1)
         {
             m_grid?.Add(view);
@@ -257,18 +255,18 @@ public partial class CameraPreview : ContentView
             m_grid?.Insert(index, view);
         }
     }
-    
+
     public void RemoveViewFromRoot(View? view)
     {
-        if(view is null)
+        if (view is null)
             return;
-        
+
         if (m_grid != null && m_grid.Remove(view))
         {
             view.DisconnectHandlers();
         }
     }
-    
+
     public Task HasLoaded()
     {
         return m_hasLoadedTcs.Task;
@@ -279,11 +277,11 @@ public partial class CameraPreview : ContentView
         m_cameraUseCase = new WeakReference<ICameraUseCase?>(cameraUseCase);
     }
 
-    protected override void OnHandlerChanging(HandlerChangingEventArgs args) 
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
         try
         {
-            if(args.NewHandler == null) // User has navigated from the page
+            if (args.NewHandler == null) // User has navigated from the page
             {
 #if __ANDROID__
             // On Android, the view is constructed in the handler, so the automatic leak resolver can not access the content of this view.

--- a/src/library/DIPS.Mobile.UI/API/Camera/Preview/CameraPreview.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Preview/CameraPreview.cs
@@ -121,8 +121,6 @@ public partial class CameraPreview : ContentView
         m_topToolbarContainer.HeightRequest = topToolbarHeight;
         m_bottomToolbarContainer.HeightRequest = Math.Max(totalLetterBoxHeight - topToolbarHeight, 0);
 
-        System.Diagnostics.Debug.WriteLine($"[CameraPreview] frameHeight={frameHeight}, Width={Width}, actualPreviewHeight={actualPreviewHeight}, letterBox={totalLetterBoxHeight}, topToolbar={topToolbarHeight}, bottomToolbar={m_bottomToolbarContainer.HeightRequest}, Padding.Top={Padding.Top}, Padding.Bottom={Padding.Bottom}");
-
         if (CameraZoomView is not null)
         {
             CameraZoomView.Margin = new Thickness(0, 0, 0, Sizes.GetSize(SizeName.content_margin_small) + m_bottomToolbarContainer.HeightRequest);


### PR DESCRIPTION
### Problem
On iOS, `CameraPreview` applied manual safe-area padding (`Padding = SafeAreaInsets`) to the entire view. This shrunk the frame height used for the letterbox/toolbar height calculation, making the top toolbar too small — especially on regular shell pages where the shell already handles safe area insets.

### Fix
- Removed the manual `Padding` assignment in `OnLoaded` on iOS
- Set `SafeAreaEdges.None` on the internal `m_grid`, `m_topToolbarContainer`, and `m_bottomToolbarContainer` so MAUI does not apply automatic safe-area insets to these containers