### PR TITLE
Fix barcode overlay z-order, support runtime navigation bar color changes, and remove SafeAreaEdges.None from CameraPreview containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [60.0.2]
+- [BarcodeScanner] Fixed barcode scan overlay rendering on top of toolbar containers by inserting the overlay at the correct z-order position.
+- [ContentPage] `NavigationPage.BarBackgroundColorProperty` and `NavigationPage.BarTextColorProperty` changes are now propagated at runtime, allowing dynamic navigation bar color updates without re-navigation.
+- [CameraPreview] Removed `SafeAreaEdges.None` from internal containers so maui handles insets.
+
 ## [60.0.1]
 - [CameraPreview] Removed manual safe-area padding on iOS and set `SafeAreaEdges.None` on internal containers so the top toolbar renders correctly on both modal and regular shell pages.
 

--- a/src/app/Playground/VetleSamples/BarcodeNoNavBarRepro.xaml
+++ b/src/app/Playground/VetleSamples/BarcodeNoNavBarRepro.xaml
@@ -1,0 +1,14 @@
+<?xml
+    version="1.0"
+    encoding="utf-8"?>
+
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:dui="http://dips.com/mobile.ui"
+                 x:Class="Playground.VetleSamples.BarcodeNoNavBarRepro"
+                 Title="No NavBar Repro"
+                 NavigationPage.HasNavigationBar="False"
+                 NavigationPage.BarBackgroundColor="Black"
+                 NavigationPage.BarTextColor="White">
+    <dui:CameraPreview x:Name="CameraPreview"/>
+</dui:ContentPage>

--- a/src/app/Playground/VetleSamples/BarcodeNoNavBarRepro.xaml.cs
+++ b/src/app/Playground/VetleSamples/BarcodeNoNavBarRepro.xaml.cs
@@ -1,0 +1,93 @@
+using DIPS.Mobile.UI.API.Camera;
+using DIPS.Mobile.UI.API.Camera.BarcodeScanning;
+using Colors = Microsoft.Maui.Graphics.Colors;
+
+namespace Playground.VetleSamples;
+
+/// <summary>
+/// Repro: When no navigation bar in a modal page, top toolbar is squished into the status bar.
+/// Open this page modally with a NavigationPage wrapper (nav bar hidden) and observe
+/// the top toolbar content overlapping with the status bar.
+/// </summary>
+public partial class BarcodeNoNavBarRepro
+{
+    private readonly BarcodeScanner m_barcodeScanner;
+
+    public BarcodeNoNavBarRepro()
+    {
+        InitializeComponent();
+        m_barcodeScanner = new BarcodeScanner();
+    }
+
+    private async Task Start()
+    {
+        try
+        {
+            await m_barcodeScanner.Start(new BarcodeScannerStartOptions
+            {
+                Preview = CameraPreview,
+                OnCameraFailed = CameraFailed,
+                OnBarcodeAcceptedAsync = HandleBarcodeAcceptedAsync,
+                Strategy = new ScanRectangleBarcodeScanStrategy
+                {
+                    WidthFraction = 0.8f,
+                    HeightFraction = 0.3f
+                }
+            });
+
+            CameraPreview.AddTopToolbarView(new BoxView
+            {
+                Color = Colors.White,
+                HeightRequest = 50,
+                WidthRequest = 200,
+                HorizontalOptions = LayoutOptions.Center
+            });
+            CameraPreview.AddBottomToolbarView(CreateCloseButton());
+        }
+        catch (Exception exception)
+        {
+            Console.WriteLine(exception);
+        }
+    }
+
+    private void CameraFailed(CameraException e)
+    {
+        Console.WriteLine($"Camera failed: {e.Message}");
+    }
+
+    private Task HandleBarcodeAcceptedAsync(BarcodeScanResult barcodeScanResult)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected override void OnAppearing()
+    {
+        _ = Start();
+        base.OnAppearing();
+    }
+
+    private void Close()
+    {
+        m_barcodeScanner.StopAndDispose();
+        Shell.Current.Navigation.PopModalAsync();
+    }
+
+    protected override bool OnBackButtonPressed()
+    {
+        Close();
+        return true;
+    }
+
+    private Button CreateCloseButton()
+    {
+        var button = new Button
+        {
+            Text = "Close",
+            TextColor = Colors.White,
+            BackgroundColor = Colors.Transparent,
+            HorizontalOptions = LayoutOptions.Center
+        };
+        button.Clicked += (_, _) => Close();
+        return button;
+    }
+}

--- a/src/app/Playground/VetleSamples/BarcodeNoNavBarStatusBarRepro.xaml
+++ b/src/app/Playground/VetleSamples/BarcodeNoNavBarStatusBarRepro.xaml
@@ -1,0 +1,14 @@
+<?xml
+    version="1.0"
+    encoding="utf-8"?>
+
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:dui="http://dips.com/mobile.ui"
+                 x:Class="Playground.VetleSamples.BarcodeNoNavBarStatusBarRepro"
+                 Title="StatusBar Color Repro"
+                 NavigationPage.HasNavigationBar="False"
+                 NavigationPage.BarBackgroundColor="Black"
+                 NavigationPage.BarTextColor="White">
+    <dui:CameraPreview x:Name="CameraPreview"/>
+</dui:ContentPage>

--- a/src/app/Playground/VetleSamples/BarcodeNoNavBarStatusBarRepro.xaml.cs
+++ b/src/app/Playground/VetleSamples/BarcodeNoNavBarStatusBarRepro.xaml.cs
@@ -1,0 +1,88 @@
+using DIPS.Mobile.UI.API.Camera;
+using DIPS.Mobile.UI.API.Camera.BarcodeScanning;
+using Colors = Microsoft.Maui.Graphics.Colors;
+
+namespace Playground.VetleSamples;
+
+/// <summary>
+/// Repro: When navigation bar is hidden in a modal, the status bar text color is not changed.
+/// Open this page modally with a NavigationPage wrapper (nav bar hidden) and observe
+/// the status bar text remains dark instead of switching to light for the camera background.
+/// </summary>
+public partial class BarcodeNoNavBarStatusBarRepro
+{
+    private readonly BarcodeScanner m_barcodeScanner;
+
+    public BarcodeNoNavBarStatusBarRepro()
+    {
+        InitializeComponent();
+        m_barcodeScanner = new BarcodeScanner();
+    }
+
+    private async Task Start()
+    {
+        try
+        {
+            await m_barcodeScanner.Start(new BarcodeScannerStartOptions
+            {
+                Preview = CameraPreview,
+                OnCameraFailed = CameraFailed,
+                OnBarcodeAcceptedAsync = HandleBarcodeAcceptedAsync
+            });
+
+            CameraPreview.AddTopToolbarView(new BoxView
+            {
+                Color = Colors.White,
+                HeightRequest = 50,
+                WidthRequest = 200,
+                HorizontalOptions = LayoutOptions.Center
+            });
+            CameraPreview.AddBottomToolbarView(CreateCloseButton());
+        }
+        catch (Exception exception)
+        {
+            Console.WriteLine(exception);
+        }
+    }
+
+    private void CameraFailed(CameraException e)
+    {
+        Console.WriteLine($"Camera failed: {e.Message}");
+    }
+
+    private Task HandleBarcodeAcceptedAsync(BarcodeScanResult barcodeScanResult)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected override void OnAppearing()
+    {
+        _ = Start();
+        base.OnAppearing();
+    }
+
+    private void Close()
+    {
+        m_barcodeScanner.StopAndDispose();
+        Shell.Current.Navigation.PopModalAsync();
+    }
+
+    protected override bool OnBackButtonPressed()
+    {
+        Close();
+        return true;
+    }
+
+    private Button CreateCloseButton()
+    {
+        var button = new Button
+        {
+            Text = "Close",
+            TextColor = Colors.White,
+            BackgroundColor = Colors.Transparent,
+            HorizontalOptions = LayoutOptions.Center
+        };
+        button.Clicked += (_, _) => Close();
+        return button;
+    }
+}

--- a/src/app/Playground/VetleSamples/BarcodeOverlayToolbarRepro.xaml
+++ b/src/app/Playground/VetleSamples/BarcodeOverlayToolbarRepro.xaml
@@ -1,0 +1,17 @@
+<?xml
+    version="1.0"
+    encoding="utf-8"?>
+
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:dui="http://dips.com/mobile.ui"
+                 x:Class="Playground.VetleSamples.BarcodeOverlayToolbarRepro"
+                 Title="Overlay Toolbar Repro"
+                 NavigationPage.BarBackgroundColor="Black"
+                 NavigationPage.BarTextColor="White">
+    <dui:ContentPage.ToolbarItems>
+        <ToolbarItem IconImageSource="{dui:Icons close_line}"
+                     Clicked="Close"/>
+    </dui:ContentPage.ToolbarItems>
+    <dui:CameraPreview x:Name="CameraPreview"/>
+</dui:ContentPage>

--- a/src/app/Playground/VetleSamples/BarcodeOverlayToolbarRepro.xaml.cs
+++ b/src/app/Playground/VetleSamples/BarcodeOverlayToolbarRepro.xaml.cs
@@ -1,0 +1,89 @@
+using DIPS.Mobile.UI.API.Camera;
+using DIPS.Mobile.UI.API.Camera.BarcodeScanning;
+using Colors = Microsoft.Maui.Graphics.Colors;
+
+namespace Playground.VetleSamples;
+
+/// <summary>
+/// Repro: Android's GraphicsView overlay spans the entire top and bottom toolbar.
+/// Open this page modally with a NavigationPage wrapper and observe the overlay
+/// extending behind the navigation bar and bottom safe area on Android.
+/// </summary>
+public partial class BarcodeOverlayToolbarRepro
+{
+    private readonly BarcodeScanner m_barcodeScanner;
+
+    public BarcodeOverlayToolbarRepro()
+    {
+        InitializeComponent();
+        m_barcodeScanner = new BarcodeScanner();
+    }
+
+    private async Task Start()
+    {
+        try
+        {
+            await m_barcodeScanner.Start(new BarcodeScannerStartOptions
+            {
+                Preview = CameraPreview,
+                OnCameraFailed = CameraFailed,
+                OnBarcodeAcceptedAsync = HandleBarcodeAcceptedAsync,
+                Strategy = new ScanRectangleBarcodeScanStrategy
+                {
+                    WidthFraction = 0.8f,
+                    HeightFraction = 0.3f
+                }
+            });
+
+            CameraPreview.AddTopToolbarView(new BoxView
+            {
+                Color = Colors.White,
+                HeightRequest = 50,
+                WidthRequest = 200,
+                HorizontalOptions = LayoutOptions.Center
+            });
+            CameraPreview.AddBottomToolbarView(CreateCloseButton());
+        }
+        catch (Exception exception)
+        {
+            Console.WriteLine(exception);
+        }
+    }
+
+    private void CameraFailed(CameraException e)
+    {
+        Console.WriteLine($"Camera failed: {e.Message}");
+    }
+
+    private Task HandleBarcodeAcceptedAsync(BarcodeScanResult barcodeScanResult)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected override void OnAppearing()
+    {
+        _ = Start();
+        base.OnAppearing();
+    }
+
+    private void Close()
+    {
+        m_barcodeScanner.StopAndDispose();
+        Shell.Current.Navigation.PopModalAsync();
+    }
+
+    private void Close(object? sender, EventArgs e) => Close();
+
+    private Button CreateCloseButton()
+    {
+        var button = new Button
+        {
+            Text = "Close",
+            TextColor = Colors.White,
+            BackgroundColor = Colors.Transparent,
+            HorizontalOptions = LayoutOptions.Center
+        };
+        button.Clicked += (_, _) => Close();
+        return button;
+    }
+}

--- a/src/app/Playground/VetleSamples/CameraNavBarColorNoNavBarRepro.xaml
+++ b/src/app/Playground/VetleSamples/CameraNavBarColorNoNavBarRepro.xaml
@@ -1,0 +1,19 @@
+<?xml
+    version="1.0"
+    encoding="utf-8"?>
+
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:dui="http://dips.com/mobile.ui"
+                 x:Class="Playground.VetleSamples.CameraNavBarColorNoNavBarRepro"
+                 Title="Camera NavBar Color (No NavBar)"
+                 NavigationPage.HasNavigationBar="False"
+                 NavigationPage.BarBackgroundColor="Black"
+                 NavigationPage.BarTextColor="White">
+    <Grid SafeAreaEdges="None">
+        <dui:CameraPreview x:Name="CameraPreview"/>
+        <Image x:Name="CapturedImageView"
+               IsVisible="False"
+               Aspect="AspectFit"/>
+    </Grid>
+</dui:ContentPage>

--- a/src/app/Playground/VetleSamples/CameraNavBarColorNoNavBarRepro.xaml.cs
+++ b/src/app/Playground/VetleSamples/CameraNavBarColorNoNavBarRepro.xaml.cs
@@ -1,0 +1,77 @@
+using DIPS.Mobile.UI.API.Camera;
+using DIPS.Mobile.UI.API.Camera.ImageCapturing;
+using DIPS.Mobile.UI.API.Camera.ImageCapturing.Settings;
+using DIPS.Mobile.UI.Resources.Colors;
+using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
+using NavigationPage = Microsoft.Maui.Controls.NavigationPage;
+
+namespace Playground.VetleSamples;
+
+/// <summary>
+/// Repro: Same as CameraNavBarColorRepro but with navigation bar hidden.
+/// </summary>
+public partial class CameraNavBarColorNoNavBarRepro
+{
+    private readonly ImageCapture m_imageCapture;
+
+    public CameraNavBarColorNoNavBarRepro()
+    {
+        InitializeComponent();
+        m_imageCapture = new ImageCapture();
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        _ = StartCamera();
+    }
+
+    private async Task StartCamera()
+    {
+        try
+        {
+            var cameraOptions = new CameraOptions
+            {
+                CancelButtonCommand = new Command(CloseModal)
+            };
+
+            await m_imageCapture.StartSingleImageCapture(
+                CameraPreview,
+                OnImageCaptured,
+                OnCameraFailed,
+                cameraOptions);
+        }
+        catch (Exception exception)
+        {
+            Console.WriteLine(exception);
+        }
+    }
+
+    private void OnImageCaptured(CapturedImage capturedImage)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            // Show captured image
+            CapturedImageView.Source = ImageSource.FromStream(() => new MemoryStream(capturedImage.AsByteArray));
+            CapturedImageView.IsVisible = true;
+            CameraPreview.IsVisible = false;
+
+            // Change navbar to default color
+            SetValue(NavigationPage.BarBackgroundColorProperty,
+                Colors.GetColor(ColorName.color_surface_default));
+
+            Title = "Check Image";
+        });
+    }
+
+    private void OnCameraFailed(CameraException e)
+    {
+        Console.WriteLine($"Camera failed: {e.Message}");
+    }
+
+    private void CloseModal()
+    {
+        m_imageCapture.StopAndDispose();
+        Shell.Current.Navigation.PopModalAsync();
+    }
+}

--- a/src/app/Playground/VetleSamples/CameraNavBarColorRepro.xaml
+++ b/src/app/Playground/VetleSamples/CameraNavBarColorRepro.xaml
@@ -1,0 +1,26 @@
+<?xml
+    version="1.0"
+    encoding="utf-8"?>
+
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:dui="http://dips.com/mobile.ui"
+                 x:Class="Playground.VetleSamples.CameraNavBarColorRepro"
+                 Title="Camera NavBar Color"
+                 NavigationPage.BarBackgroundColor="Black"
+                 NavigationPage.BarTextColor="White">
+    <dui:ContentPage.ToolbarItems>
+        <ToolbarItem Text="Close"
+                     Clicked="Close"/>
+        <ToolbarItem x:Name="RetakeToolbarItem"
+                     Text="Retake"
+                     Clicked="Retake"
+                     IsEnabled="False"/>
+    </dui:ContentPage.ToolbarItems>
+    <Grid SafeAreaEdges="None">
+        <dui:CameraPreview x:Name="CameraPreview"/>
+        <Image x:Name="CapturedImageView"
+               IsVisible="False"
+               Aspect="AspectFit"/>
+    </Grid>
+</dui:ContentPage>

--- a/src/app/Playground/VetleSamples/CameraNavBarColorRepro.xaml.cs
+++ b/src/app/Playground/VetleSamples/CameraNavBarColorRepro.xaml.cs
@@ -1,0 +1,98 @@
+using DIPS.Mobile.UI.API.Camera;
+using DIPS.Mobile.UI.API.Camera.ImageCapturing;
+using DIPS.Mobile.UI.API.Camera.ImageCapturing.Settings;
+using DIPS.Mobile.UI.Resources.Colors;
+using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
+using NavigationPage = Microsoft.Maui.Controls.NavigationPage;
+
+namespace Playground.VetleSamples;
+
+/// <summary>
+/// Repro: Open modal camera with black navbar, take photo, switch content
+/// to show captured image and change navbar color to default.
+/// </summary>
+public partial class CameraNavBarColorRepro
+{
+    private readonly ImageCapture m_imageCapture;
+
+    public CameraNavBarColorRepro()
+    {
+        InitializeComponent();
+        m_imageCapture = new ImageCapture();
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        _ = StartCamera();
+    }
+
+    private async Task StartCamera()
+    {
+        try
+        {
+            var cameraOptions = new CameraOptions
+            {
+                CancelButtonCommand = new Command(CloseModal)
+            };
+
+            await m_imageCapture.StartSingleImageCapture(
+                CameraPreview,
+                OnImageCaptured,
+                OnCameraFailed,
+                cameraOptions);
+        }
+        catch (Exception exception)
+        {
+            Console.WriteLine(exception);
+        }
+    }
+
+    private void OnImageCaptured(CapturedImage capturedImage)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            // Show captured image
+            CapturedImageView.Source = ImageSource.FromStream(() => new MemoryStream(capturedImage.AsByteArray));
+            CapturedImageView.IsVisible = true;
+            CameraPreview.IsVisible = false;
+
+            // Change navbar to default color
+            SetValue(NavigationPage.BarBackgroundColorProperty,
+                Colors.GetColor(ColorName.color_surface_default));
+            SetValue(NavigationPage.BarTextColorProperty,
+                Colors.GetColor(ColorName.color_text_default));
+
+            Title = "Check Image";
+            RetakeToolbarItem.IsEnabled = true;
+        });
+    }
+
+    private void Retake(object? sender, EventArgs e)
+    {
+        CapturedImageView.IsVisible = false;
+        CapturedImageView.Source = null;
+        CameraPreview.IsVisible = true;
+        RetakeToolbarItem.IsEnabled = false;
+
+        // Change navbar back to black
+        SetValue(NavigationPage.BarBackgroundColorProperty, Microsoft.Maui.Graphics.Colors.Black);
+        SetValue(NavigationPage.BarTextColorProperty, Microsoft.Maui.Graphics.Colors.White);
+        Title = "Camera NavBar Color";
+
+        _ = StartCamera();
+    }
+
+    private void OnCameraFailed(CameraException e)
+    {
+        Console.WriteLine($"Camera failed: {e.Message}");
+    }
+
+    private void CloseModal()
+    {
+        m_imageCapture.StopAndDispose();
+        Shell.Current.Navigation.PopModalAsync();
+    }
+
+    private void Close(object? sender, EventArgs e) => CloseModal();
+}

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -11,17 +11,51 @@
                  Shell.NavBarIsVisible="True">
 
     <dui:ContentPage.ToolbarItems>
-        <ToolbarItem Text="Close" />
+        <ToolbarItem Text="Close"/>
     </dui:ContentPage.ToolbarItems>
 
-    <!-- Reproducing ResistanceMatrixPage ShouldBounce issue -->
-    <Grid ColumnDefinitions="Auto, *"
-          RowDefinitions="Auto, *"
-          ColumnSpacing="0"
-          RowSpacing="0">
+    <ScrollView>
+        <dui:VerticalStackLayout Spacing="0"
+                                 Margin="{dui:Thickness Left=content_margin_medium, Right=content_margin_medium, Top=content_margin_large}">
 
-       <dui:Button Clicked="Button_OnClicked" />
+            <!-- BarcodeScanning repro samples -->
+            <Label Text="BarcodeScanning Issues"
+                   Style="{dui:Styles Label=SectionHeader}"/>
 
-    </Grid>
+            <dui:VerticalStackLayout Spacing="0"
+                                     dui:Layout.AutoCornerRadius="True"
+                                     Margin="{dui:Thickness Top=content_margin_small}">
+                <dui:NavigationListItem x:Name="OverlayToolbarItem"
+                                        Title="Overlay spans toolbar (Android)"
+                                        Subtitle="GraphicsView overlay extends behind nav bar and bottom area"
+                                        HasBottomDivider="True"/>
+                <dui:NavigationListItem x:Name="NoNavBarToolbarItem"
+                                        Title="No nav bar - toolbar squished"
+                                        Subtitle="Top toolbar overlaps status bar when nav bar hidden in modal"
+                                        HasBottomDivider="True"/>
+                <dui:NavigationListItem x:Name="NoNavBarStatusBarItem"
+                                        Title="No nav bar - status bar color"
+                                        Subtitle="Status bar text color not changed when nav bar hidden in modal"/>
+            </dui:VerticalStackLayout>
+
+            <!-- Camera navbar color repro -->
+            <Label Text="Camera Issues"
+                   Style="{dui:Styles Label=SectionHeader}"
+                   Margin="{dui:Thickness Top=content_margin_large}"/>
+
+            <dui:VerticalStackLayout Spacing="0"
+                                     dui:Layout.AutoCornerRadius="True"
+                                     Margin="{dui:Thickness Top=content_margin_small}">
+                <dui:NavigationListItem x:Name="CameraNavBarColorItem"
+                                        Title="NavBar color change after capture"
+                                        Subtitle="Black navbar during camera, switch to default after photo taken"
+                                        HasBottomDivider="True"/>
+                <dui:NavigationListItem x:Name="CameraNavBarColorNoNavBarItem"
+                                        Title="NavBar color change (no nav bar)"
+                                        Subtitle="Same as above but with navigation bar hidden"/>
+            </dui:VerticalStackLayout>
+
+        </dui:VerticalStackLayout>
+    </ScrollView>
 
 </dui:ContentPage>

--- a/src/app/Playground/VetleSamples/VetlePage.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml.cs
@@ -22,11 +22,16 @@ public partial class VetlePage
     public VetlePage()
     {
         InitializeComponent();
-        TestCommand = new Command(SwitchRoot); 
+        TestCommand = new Command(SwitchRoot);
 
         _ = FuckThisShitUp();
         /*Shell.OnTabTapped += ShellOnOnTabTapped;*/
 
+        OverlayToolbarItem.Command = new Command(() => OpenModal(new BarcodeOverlayToolbarRepro()));
+        NoNavBarToolbarItem.Command = new Command(() => OpenModal(new BarcodeNoNavBarRepro()));
+        NoNavBarStatusBarItem.Command = new Command(() => OpenModal(new BarcodeNoNavBarStatusBarRepro()));
+        CameraNavBarColorItem.Command = new Command(() => OpenModal(new CameraNavBarColorRepro()));
+        CameraNavBarColorNoNavBarItem.Command = new Command(() => OpenModal(new CameraNavBarColorNoNavBarRepro()));
     }
 
     private void ShellOnOnTabTapped(string obj)
@@ -39,12 +44,15 @@ public partial class VetlePage
 
     private async Task FuckThisShitUp()
     {
-        var thread = new Thread (() => {
-            while (true) {
-                Thread.Sleep (5000);
+        var thread = new Thread(() =>
+        {
+            while (true)
+            {
+                Thread.Sleep(5000);
                 GC.Collect();
             }
-        }) { IsBackground = true };
+        })
+        { IsBackground = true };
         thread.Start();
     }
 
@@ -52,13 +60,13 @@ public partial class VetlePage
     protected override void OnBindingContextChanged()
     {
         base.OnBindingContextChanged();
-        
+
         TestBool = BindingContext is VetlePageViewModel;
     }
 
     private void Test123()
     {
-        var tabBar = new TabBar {Route = "app"};
+        var tabBar = new TabBar { Route = "app" };
 
         tabBar.Items.Add(new Tab
         {
@@ -97,15 +105,15 @@ public partial class VetlePage
 
     private void SwitchRoot()
     {
-        
+
 
     }
 
     protected override void OnHandlerChanged()
     {
         base.OnHandlerChanged();
-        
-        
+
+
     }
 
     protected override async void OnAppearing()
@@ -145,8 +153,8 @@ public partial class VetlePage
     protected override void OnSizeAllocated(double width, double height)
     {
         base.OnSizeAllocated(width, height);
-        
-        
+
+
     }
 
 
@@ -154,25 +162,25 @@ public partial class VetlePage
 
     private void Switch_OnToggled(object sender, ToggledEventArgs e)
     {
-        
-        
+
+
         /*ContentControl.SelectorItem = e.Value;*/
-        
-        
+
+
     }
 
 
     private void Entry_OnCompleted(object sender, EventArgs e)
     {
-        
+
     }
-    
+
     private void VisualElement_OnLoaded(object? sender, EventArgs e)
     {
 #if __IOS__
 
         if (sender is not Grid grid) return;
-            
+
         var insets = UIKit.UIApplication.SharedApplication.KeyWindow!.SafeAreaInsets;
         grid.Padding = new Thickness(grid.Padding.Left, insets.Top, grid.Padding.Right, grid.Padding.Bottom + insets.Bottom);
 
@@ -184,13 +192,13 @@ public partial class VetlePage
         /*SignInButton.SetSemanticFocus();*/
     }
 
-    
+
 
     private void SwapRoot(object sender, EventArgs e)
     {
         SwapRoot(new DataTemplate(() => new MainPage()));
     }
-    
+
     public static void SwapRoot(DataTemplate dataTemplate)
     {
         var tabBar = new TabBar();
@@ -229,7 +237,7 @@ public partial class VetlePage
 
     private void SearchBar_OnUnfocused(object sender, EventArgs e)
     {
-        
+
     }
 
     private void ListItem_OnTapped(object sender, EventArgs e)
@@ -249,6 +257,11 @@ public partial class VetlePage
         Navigation.PushModalAsync(navigationPage);
     }
 
+    private static void OpenModal(Microsoft.Maui.Controls.Page page)
+    {
+        Shell.Current.Navigation.PushModalAsync(new NavigationPage(page));
+    }
+
     private void Button_OnClicked2(object sender, EventArgs e)
     {
         _ = Navigation.PushModalAsync(new VetleTestPage1());
@@ -258,5 +271,5 @@ public partial class VetlePage
     {
         _ = Navigation.PushAsync(new VetleTestPage1());
     }
-    
+
 }

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScanner.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScanner.cs
@@ -125,7 +125,9 @@ public partial class BarcodeScanner : ICameraUseCase
                 scanRectangleStrategy.BracketsTravelDuration,
                 scanRectangleStrategy.FormingDuration);
 
-            m_cameraPreview?.AddViewToRoot(m_scanRectangleOverlay);
+            // Insert after PreviewView (index 0) but before the toolbar containers
+            // so that toolbars render on top of the overlay dim layer.
+            m_cameraPreview?.AddViewToRoot(m_scanRectangleOverlay, index: 1);
         }
     }
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/Preview/CameraPreview.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Preview/CameraPreview.cs
@@ -51,14 +51,12 @@ public partial class CameraPreview : ContentView
     {
         m_bottomToolbarContainer = new Grid
         {
-            SafeAreaEdges = SafeAreaEdges.None,
             VerticalOptions = LayoutOptions.End,
             BackgroundColor = Colors.Transparent,
         };
 
         m_topToolbarContainer = new Grid
         {
-            SafeAreaEdges = SafeAreaEdges.None,
             VerticalOptions = LayoutOptions.Start,
             BackgroundColor = Colors.Transparent,
         };
@@ -67,7 +65,6 @@ public partial class CameraPreview : ContentView
 
         m_grid = new Grid
         {
-            SafeAreaEdges = SafeAreaEdges.None,
             Children = { PreviewView, m_bottomToolbarContainer, m_topToolbarContainer },
             ColumnDefinitions = [new ColumnDefinition(GridLength.Star)]
         };
@@ -114,7 +111,7 @@ public partial class CameraPreview : ContentView
             return;
         }
 
-        var actualPreviewHeight = (Width / ThreeFourRatio);
+        var actualPreviewHeight = Width / ThreeFourRatio;
         var totalLetterBoxHeight = frameHeight - actualPreviewHeight;
 
         var topToolbarHeight = ComputeTopToolbarHeight((float)Width, frameHeight);

--- a/src/library/DIPS.Mobile.UI/Components/Pages/ContentPage.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pages/ContentPage.cs
@@ -65,6 +65,17 @@ namespace DIPS.Mobile.UI.Components.Pages
             }
         }
 
+        protected override void OnPropertyChanged(string? propertyName = null)
+        {
+            base.OnPropertyChanged(propertyName);
+
+            if (propertyName == NavigationPage.BarBackgroundColorProperty.PropertyName ||
+                propertyName == NavigationPage.BarTextColorProperty.PropertyName)
+            {
+                OnNavigationBarColorPropertyChanged();
+            }
+        }
+
         protected override void OnAppearing()
         {
             base.OnAppearing();
@@ -83,7 +94,7 @@ namespace DIPS.Mobile.UI.Components.Pages
             StatusBarHandler.TrySetStatusBarColor(this, GetEffectiveStatusBarColor());
 #endif
         }
-        
+
         protected override void OnNavigatedTo(NavigatedToEventArgs args)
         {
             base.OnNavigatedTo(args);

--- a/src/library/DIPS.Mobile.UI/Components/Pages/ContentPage.navigationbar.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pages/ContentPage.navigationbar.cs
@@ -34,6 +34,16 @@ namespace DIPS.Mobile.UI.Components.Pages
             RefreshStatusBarTextOnPlatform(navigationPage);
         }
 
+        internal void OnNavigationBarColorPropertyChanged()
+        {
+            if (Parent is not NavigationPage navigationPage)
+                return;
+
+            navigationPage.BarBackgroundColor = GetNavigationBarPropertyColor(NavigationPage.BarBackgroundColorProperty);
+            navigationPage.BarTextColor = GetNavigationBarPropertyColor(NavigationPage.BarTextColorProperty);
+            RefreshStatusBarTextOnPlatform(navigationPage);
+        }
+
         private Color GetNavigationBarPropertyColor(BindableProperty navigationBarColorProperty)
         {
             return (Color)GetValue(navigationBarColorProperty);


### PR DESCRIPTION
### Description of Change

**Fix barcode scanner overlay z-order and add runtime navigation bar color updates**

This PR addresses multiple camera and navigation bar issues:

**1. Barcode scan overlay z-order**
The `BarcodeScanRectangleOverlay` was added to the CameraPreview grid after the toolbar containers, causing the dim overlay to render on top of the toolbars. Fixed by inserting the overlay at index 1 (between PreviewView and the toolbar containers).

**2. Runtime NavigationPage bar color propagation**
`NavigationPage.BarBackgroundColorProperty` and `BarTextColorProperty` changes at runtime (e.g., switching from a black camera navbar to a default color after capture) were not propagated to the NavigationPage. Added `OnPropertyChanged` override in `ContentPage` that detects these property changes and calls `OnNavigationBarColorPropertyChanged()` to update the NavigationPage and refresh the status bar.

**3. CameraPreview SafeAreaEdges cleanup**
Removed explicit `SafeAreaEdges.None` from internal CameraPreview containers (top/bottom toolbar, grid) so MAUI handles insets.

**Playground repro samples added:**
- `BarcodeOverlayToolbarRepro` — overlay spanning toolbar
- `BarcodeNoNavBarRepro` — toolbar squished into status bar when nav bar hidden
- `BarcodeNoNavBarStatusBarRepro` — status bar text color when nav bar hidden
- `CameraNavBarColorRepro` — navbar color change after photo capture with retake
- `CameraNavBarColorNoNavBarRepro` — same as above with hidden nav bar
