### PR TITLE
rolled back maui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [60.0.3]
+- Rolled back Microsoft.Maui.Controls from 10.0.70 to 10.0.60 due to crash caused by known regression in MAUI (dotnet/maui#35584).
+
 ## [60.0.2]
 - [BarcodeScanner] Fixed barcode scan overlay rendering on top of toolbar containers by inserting the overlay at the correct z-order position.
 - [ContentPage] `NavigationPage.BarBackgroundColorProperty` and `NavigationPage.BarTextColorProperty` changes are now propagated at runtime, allowing dynamic navigation bar color updates without re-navigation.

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
     <PackageVersion Include="DotNetMeteor.HotReload.Plugin" Version="3.3.0" />
     <PackageVersion Include="LightInject" Version="6.6.4" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.70" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.60" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
     <PackageVersion Include="SkiaSharp" Version="3.119.1" />


### PR DESCRIPTION
### Description of Change

Rolled back Microsoft.Maui.Controls from 10.0.70 to 10.0.60 due to crash caused by known regression in MAUI (dotnet/maui#35584).

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->