### PR TITLE
Fix ScrollView HasAdditionalSpaceAtTheEnd on Android when Padding is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [60.0.5]
+- [ScrollView][Android] Fixed `HasAdditionalSpaceAtTheEnd` not applying bottom spacing when consumer sets `Padding` on the ScrollView.
+
 ## [60.0.4]
 - [ContextMenu] Added `ContextMenuItem.IsEnabled` bindable property to disable individual context menu items. Disabled items appear grayed out and cannot be tapped.
 - [ContextMenu] Added `ContextMenuEffect.IsEnabled` attached property to enable/disable an entire context menu on an element. When disabled, the context menu will not open at all.

--- a/src/app/Playground/VetleSamples/ScrollViewSpacingRepro.xaml
+++ b/src/app/Playground/VetleSamples/ScrollViewSpacingRepro.xaml
@@ -1,0 +1,73 @@
+<?xml
+    version="1.0"
+    encoding="utf-8"?>
+
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:dui="http://dips.com/mobile.ui"
+                 x:Class="Playground.VetleSamples.ScrollViewSpacingRepro"
+                 Title="ScrollView Spacing Repro">
+
+    <dui:ScrollView Padding="{dui:Thickness Left=size_2, Right=size_2}">
+        <dui:VerticalStackLayout Spacing="0"
+                                 Margin="{dui:Thickness Left=content_margin_medium, Right=content_margin_medium, Top=content_margin_large}">
+
+            <Label Text="ScrollView HasAdditionalSpaceAtTheEnd"
+                   Style="{dui:Styles Label=SectionHeader}"/>
+
+            <Label Text="Scroll to the bottom — there should be additional space after the last item so it's easy to interact with."
+                   Style="{dui:Styles Label=UI200}"
+                   Margin="{dui:Thickness Top=content_margin_small, Bottom=content_margin_medium}"/>
+
+            <dui:VerticalStackLayout Spacing="0"
+                                     dui:Layout.AutoCornerRadius="True">
+                <dui:ListItem Title="Item 1"
+                        Subtitle="First item in the list"
+                        HasBottomDivider="True"/>
+                <dui:ListItem Title="Item 2"
+                        Subtitle="Second item"
+                        HasBottomDivider="True"/>
+                <dui:ListItem Title="Item 3"
+                        Subtitle="Third item"
+                        HasBottomDivider="True"/>
+                <dui:ListItem Title="Item 4"
+                        Subtitle="Fourth item"
+                        HasBottomDivider="True"/>
+                <dui:ListItem Title="Item 5"
+                        Subtitle="Fifth item"
+                        HasBottomDivider="True"/>
+                <dui:ListItem Title="Item 6"
+                        Subtitle="Sixth item"
+                        HasBottomDivider="True"/>
+                <dui:ListItem Title="Item 7"
+                        Subtitle="Seventh item"
+                        HasBottomDivider="True"/>
+                <dui:ListItem Title="Item 8"
+                        Subtitle="Eighth item"
+                        HasBottomDivider="True"/>
+                <dui:ListItem Title="Item 9"
+                        Subtitle="Ninth item"
+                        HasBottomDivider="True"/>
+                <dui:ListItem Title="Item 10"
+                        Subtitle="Tenth item"
+                        HasBottomDivider="True"/>
+                <dui:ListItem Title="Item 11"
+                        Subtitle="Eleventh item"
+                        HasBottomDivider="True"/>
+                <dui:ListItem Title="Item 12"
+                        Subtitle="Twelfth item"
+                        HasBottomDivider="True"/>
+                <dui:ListItem Title="Item 13"
+                        Subtitle="Thirteenth item"
+                        HasBottomDivider="True"/>
+                <dui:ListItem Title="Item 14"
+                        Subtitle="Fourteenth item"
+                        HasBottomDivider="True"/>
+                <dui:ListItem Title="Item 15"
+                        Subtitle="This is the last item — should have space below"/>
+            </dui:VerticalStackLayout>
+
+        </dui:VerticalStackLayout>
+    </dui:ScrollView>
+
+</dui:ContentPage>

--- a/src/app/Playground/VetleSamples/ScrollViewSpacingRepro.xaml.cs
+++ b/src/app/Playground/VetleSamples/ScrollViewSpacingRepro.xaml.cs
@@ -1,0 +1,9 @@
+namespace Playground.VetleSamples;
+
+public partial class ScrollViewSpacingRepro
+{
+    public ScrollViewSpacingRepro()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/app/Playground/VetleSamples/VetlePage.xaml
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml
@@ -38,6 +38,19 @@
                                         Subtitle="Status bar text color not changed when nav bar hidden in modal"/>
             </dui:VerticalStackLayout>
 
+            <!-- ScrollView spacing repro -->
+            <Label Text="ScrollView Issues"
+                   Style="{dui:Styles Label=SectionHeader}"
+                   Margin="{dui:Thickness Top=content_margin_large}"/>
+
+            <dui:VerticalStackLayout Spacing="0"
+                                     dui:Layout.AutoCornerRadius="True"
+                                     Margin="{dui:Thickness Top=content_margin_small}">
+                <dui:NavigationListItem x:Name="ScrollViewSpacingItem"
+                                        Title="HasAdditionalSpaceAtTheEnd"
+                                        Subtitle="Bottom spacing not applied on Android (Arena.Mobile#1475)"/>
+            </dui:VerticalStackLayout>
+
             <!-- Camera navbar color repro -->
             <Label Text="Camera Issues"
                    Style="{dui:Styles Label=SectionHeader}"

--- a/src/app/Playground/VetleSamples/VetlePage.xaml.cs
+++ b/src/app/Playground/VetleSamples/VetlePage.xaml.cs
@@ -30,6 +30,7 @@ public partial class VetlePage
         OverlayToolbarItem.Command = new Command(() => OpenModal(new BarcodeOverlayToolbarRepro()));
         NoNavBarToolbarItem.Command = new Command(() => OpenModal(new BarcodeNoNavBarRepro()));
         NoNavBarStatusBarItem.Command = new Command(() => OpenModal(new BarcodeNoNavBarStatusBarRepro()));
+        ScrollViewSpacingItem.Command = new Command(() => Navigation.PushAsync(new ScrollViewSpacingRepro()));
         CameraNavBarColorItem.Command = new Command(() => OpenModal(new CameraNavBarColorRepro()));
         CameraNavBarColorNoNavBarItem.Command = new Command(() => OpenModal(new CameraNavBarColorNoNavBarRepro()));
     }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.cs
@@ -34,7 +34,7 @@ public partial class ScrollView : Microsoft.Maui.Controls.ScrollView
         {
             m_hasAddedSpaceToBottom = true;
             var newPadding = new Thickness(oldPadding.Left, oldPadding.Top, oldPadding.Right,
-                (int)(oldPadding.Bottom + (height / 2)));
+                oldPadding.Bottom + (height / 2));
             Padding = newPadding;
         }
     }

--- a/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/ScrollView/ScrollView.cs
@@ -4,18 +4,21 @@ public partial class ScrollView : Microsoft.Maui.Controls.ScrollView
 {
     private bool m_hasAddedSpaceToBottom;
 
-    public ScrollView()
-    {
-#if __ANDROID__ //Not possible to set padding on scroll view after its rendered
-        AdjustPadding(AndroidAdditionalSpaceAtEnd);
-#endif
-    }
-
 #if __IOS__
     protected override void OnSizeAllocated(double width, double height)
     {
         base.OnSizeAllocated(width, height);
         AdjustPadding(height);
+    }
+#endif
+
+#if __ANDROID__
+    protected override void OnHandlerChanged()
+    {
+        base.OnHandlerChanged();
+
+        if (Handler is not null)
+            AdjustPadding(AndroidAdditionalSpaceAtEnd);
     }
 #endif
 
@@ -33,6 +36,6 @@ public partial class ScrollView : Microsoft.Maui.Controls.ScrollView
             var newPadding = new Thickness(oldPadding.Left, oldPadding.Top, oldPadding.Right,
                 (int)(oldPadding.Bottom + (height / 2)));
             Padding = newPadding;
-        } 
+        }
     }
 }


### PR DESCRIPTION
### Description of Change

On Android, `dui:ScrollView` with `HasAdditionalSpaceAtTheEnd="True"` (the default) did not add bottom spacing when the consumer also set `Padding` on the ScrollView.

**Root cause**: `AdjustPadding` was called in the constructor — before XAML properties were applied. The consumer's `Padding` value would overwrite the adjusted padding, and since `m_hasAddedSpaceToBottom` was already `true`, the adjustment never re-ran.

**Fix**: Moved the Android `AdjustPadding` call from the constructor to `OnHandlerChanged`, where all XAML-set properties (including consumer `Padding`) are already applied. The extra bottom space is now correctly added on top of the consumer's padding.

Ref: dips/Arena.Mobile#1475

### Todos
- [x] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility