### PR TITLE
Fix button visibility in AlertView and CornerRadius on Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [60.2.2]
+- [AlertView] Fixed button not visible on iOS by replacing Remove/Add pattern with Grid.SetColumn/Grid.SetRow repositioning. Added reentrancy guard and width tracking to prevent infinite layout loops.
+- [Button] Fixed CornerRadius not updating when button size changes. Auto-calculated radius now recalculates on every size allocation instead of locking after first calculation.
+
 ## [60.2.1]
 - [BarcodeScanner] Fixed crash on Android when backgrounding the app while the barcode scanner is active. The crash was caused by ML Kit task callbacks being dispatched to an already-terminated executor.
 

--- a/src/app/Playground/HåvardSamples/AlertViewReproPage.xaml
+++ b/src/app/Playground/HåvardSamples/AlertViewReproPage.xaml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Repro for Arena.Mobile #1455: AlertView save button not visible with large text on iOS 26 -->
+<!-- Steps: 1) Increase text size on device to >100%, 2) Tap "Toggle AlertView" to show the blue bar -->
+<!-- Expected: Button "Lagre" should be visible. Observe if it only appears on 2nd toggle. -->
+
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:dui="http://dips.com/mobile.ui"
+                 x:Class="Playground.HåvardSamples.AlertViewReproPage"
+                 x:Name="This"
+                 Title="AlertView Repro #1455">
+
+    <dui:ScrollView Padding="{dui:Padding page_margin_small}">
+        <VerticalStackLayout Spacing="{dui:Sizes size_2}">
+
+            <dui:Label Text="Repro: Lagre-knapp i AlertView med stor tekststørrelse (iOS 26)"
+                       Style="{dui:Styles Label=UI300}" />
+
+            <dui:Label Text="Skru opp tekststørrelsen på enheten, og trykk på knappene under for å vise/skjule AlertView."
+                       Style="{dui:Styles Label=Body200}" />
+
+            <!-- Test 1: Toggle IsVisible on Information AlertView with LeftButton -->
+            <dui:Label Text="Test 1: Toggle IsVisible (som i behandlingsplan)"
+                       Style="{dui:Styles Label=UI200}"
+                       Margin="{dui:Thickness Top=size_4}" />
+
+            <dui:AlertView x:Name="AlertWithButton"
+                           Style="{dui:Styles Alert=Information}"
+                           Title="Du har ulagrede endringer"
+                           TitleTruncationMode="Moderate"
+                           LeftButtonText="Lagre"
+                           LeftButtonCommand="{Binding SaveCommand, Source={x:Reference This}}"
+                           IsVisible="False" />
+
+            <HorizontalStackLayout Spacing="{dui:Sizes size_2}">
+                <dui:Button Text="Toggle AlertView"
+                            Clicked="ToggleAlertView" />
+                <dui:Button Text="Show"
+                            Clicked="ShowAlertView" />
+                <dui:Button Text="Hide"
+                            Clicked="HideAlertView" />
+            </HorizontalStackLayout>
+
+            <!-- Test 2: AlertView that starts visible (reference/control) -->
+            <dui:Label Text="Test 2: Alltid synlig (kontrolltest)"
+                       Style="{dui:Styles Label=UI200}"
+                       Margin="{dui:Thickness Top=size_4}" />
+
+            <dui:AlertView Style="{dui:Styles Alert=Information}"
+                           Title="Du har ulagrede endringer"
+                           TitleTruncationMode="Moderate"
+                           LeftButtonText="Lagre"
+                           LeftButtonCommand="{Binding SaveCommand, Source={x:Reference This}}" />
+
+            <!-- Test 3: Aggressive truncation mode with button -->
+            <dui:Label Text="Test 3: Aggressive truncation + knapp"
+                       Style="{dui:Styles Label=UI200}"
+                       Margin="{dui:Thickness Top=size_4}" />
+
+            <dui:AlertView x:Name="AlertAggressive"
+                           Style="{dui:Styles Alert=Information}"
+                           Title="Du har ulagrede endringer i spesifikasjon og situasjon"
+                           TitleTruncationMode="Aggressive"
+                           LeftButtonText="Lagre"
+                           LeftButtonCommand="{Binding SaveCommand, Source={x:Reference This}}"
+                           IsVisible="False" />
+
+            <dui:Button Text="Toggle Aggressive"
+                        Clicked="ToggleAggressiveAlertView" />
+
+            <!-- Test 4: Long title that forces buttons below -->
+            <dui:Label Text="Test 4: Lang tittel som tvinger knapp under teksten"
+                       Style="{dui:Styles Label=UI200}"
+                       Margin="{dui:Thickness Top=size_4}" />
+
+            <dui:AlertView x:Name="AlertLongTitle"
+                           Style="{dui:Styles Alert=Information}"
+                           Title="Du har ulagrede endringer i dette planelementet som ikke er lagret ennå"
+                           TitleTruncationMode="Moderate"
+                           LeftButtonText="Lagre"
+                           LeftButtonCommand="{Binding SaveCommand, Source={x:Reference This}}"
+                           IsVisible="False" />
+
+            <dui:Button Text="Toggle lang tittel"
+                        Clicked="ToggleLongTitleAlertView" />
+
+            <!-- Test 5: Success alert (no button, just visibility toggle) -->
+            <dui:Label Text="Test 5: Success alert (uten knapp)"
+                       Style="{dui:Styles Label=UI200}"
+                       Margin="{dui:Thickness Top=size_4}" />
+
+            <dui:AlertView x:Name="AlertSuccess"
+                           Style="{dui:Styles Alert=Success}"
+                           Title="Endringene er lagret"
+                           TitleTruncationMode="Moderate"
+                           IsVisible="False" />
+
+            <dui:Button Text="Toggle Success"
+                        Clicked="ToggleSuccessAlertView" />
+
+            <dui:Label x:Name="StatusLabel"
+                       Text="Status: Venter..."
+                       Style="{dui:Styles Label=Body100}"
+                       Margin="{dui:Thickness Top=size_4}" />
+
+        </VerticalStackLayout>
+    </dui:ScrollView>
+</dui:ContentPage>

--- a/src/app/Playground/HåvardSamples/AlertViewReproPage.xaml.cs
+++ b/src/app/Playground/HåvardSamples/AlertViewReproPage.xaml.cs
@@ -1,0 +1,62 @@
+using System.Windows.Input;
+
+namespace Playground.HåvardSamples;
+
+/// <summary>
+/// Repro page for Arena.Mobile #1455:
+/// AlertView save button not visible with large text size on iOS 26.
+/// Also tests that AlertView layout is correct when toggling IsVisible.
+/// </summary>
+public partial class AlertViewReproPage
+{
+    private int m_toggleCount;
+    
+    public ICommand SaveCommand { get; }
+
+    public AlertViewReproPage()
+    {
+        SaveCommand = new Command(OnSave);
+        InitializeComponent();
+    }
+
+    private void OnSave()
+    {
+        StatusLabel.Text = "Status: Lagre-knapp trykket!";
+        AlertWithButton.IsVisible = false;
+        AlertSuccess.IsVisible = true;
+    }
+
+    private void ToggleAlertView(object sender, EventArgs e)
+    {
+        m_toggleCount++;
+        AlertWithButton.IsVisible = !AlertWithButton.IsVisible;
+        StatusLabel.Text = $"Status: Toggle #{m_toggleCount}, IsVisible={AlertWithButton.IsVisible}";
+    }
+
+    private void ShowAlertView(object sender, EventArgs e)
+    {
+        AlertWithButton.IsVisible = true;
+        StatusLabel.Text = "Status: Show (IsVisible=True)";
+    }
+
+    private void HideAlertView(object sender, EventArgs e)
+    {
+        AlertWithButton.IsVisible = false;
+        StatusLabel.Text = "Status: Hide (IsVisible=False)";
+    }
+
+    private void ToggleAggressiveAlertView(object sender, EventArgs e)
+    {
+        AlertAggressive.IsVisible = !AlertAggressive.IsVisible;
+    }
+
+    private void ToggleLongTitleAlertView(object sender, EventArgs e)
+    {
+        AlertLongTitle.IsVisible = !AlertLongTitle.IsVisible;
+    }
+
+    private void ToggleSuccessAlertView(object sender, EventArgs e)
+    {
+        AlertSuccess.IsVisible = !AlertSuccess.IsVisible;
+    }
+}

--- a/src/app/Playground/MainPage.xaml
+++ b/src/app/Playground/MainPage.xaml
@@ -17,6 +17,8 @@
                                     Tapped="GoToVetle" />
             <dui:NavigationListItem Title="Håvard"
                                     Tapped="GoToHåvard" />
+            <dui:NavigationListItem Title="AlertView Repro #1455"
+                                    Tapped="GoToAlertViewRepro" />
             <dui:NavigationListItem Title="Sander"
                                     Tapped="GoToSander" />
             <dui:NavigationListItem Title="Eirik"

--- a/src/app/Playground/MainPage.xaml.cs
+++ b/src/app/Playground/MainPage.xaml.cs
@@ -41,6 +41,11 @@ public partial class MainPage
         Shell.Current.Navigation.PushAsync(new HåvardPage());
     }
 
+    private void GoToAlertViewRepro(object sender, EventArgs e)
+    {
+        Shell.Current.Navigation.PushAsync(new HåvardSamples.AlertViewReproPage());
+    }
+
     private void GoToSander(object sender, EventArgs e)
     {
         Shell.Current.Navigation.PushAsync(new SanderPage());

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/Alert/AlertView.cs
@@ -27,6 +27,9 @@ namespace DIPS.Mobile.UI.Components.Alerting.Alert;
 public partial class AlertView : Grid
 {
     private readonly HorizontalStackLayout m_buttonsContainer;
+    private bool m_buttonsContainerAdded;
+    private bool m_isUpdatingButtonAlignment;
+    private double m_lastAllocatedWidth;
     private Image? m_icon;
     private ImageButton? m_closeIcon;
     private CustomTruncationTextView? m_titleAndDescriptionLabel;
@@ -70,47 +73,78 @@ public partial class AlertView : Grid
     protected override void OnSizeAllocated(double width, double height)
     {
         base.OnSizeAllocated(width, height);
+
+        // Skip if width hasn't changed — avoids infinite layout loops
+        // ReSharper disable once CompareOfFloatsByEqualityOperator
+        if (width == m_lastAllocatedWidth && m_buttonsContainerAdded)
+            return;
+        m_lastAllocatedWidth = width;
         
         UpdateButtonAlignment();
     }
 
     private void UpdateButtonAlignment()
     {
+        if (m_isUpdatingButtonAlignment) return;
         if (LeftButtonCommand is null && RightButtonCommand is null) 
             return;
         
-        Remove(m_buttonsContainer);
-        
-        if (IsLargeAlert)
+        m_isUpdatingButtonAlignment = true;
+        try
         {
-            m_buttonsContainer.Margin = new Thickness(0, Sizes.GetSize(SizeName.content_margin_small), 0, 0);
-            this.Add(m_buttonsContainer, 1, 1);
-            return;
+            if (IsLargeAlert)
+            {
+                m_buttonsContainer.Margin = new Thickness(0, Sizes.GetSize(SizeName.content_margin_small), 0, 0);
+                m_buttonsContainer.HorizontalOptions = LayoutOptions.Start;
+                SetButtonsPosition(1, 1);
+                return;
+            }
+        
+            if (Width <= 0)
+            {
+                m_buttonsContainer.Margin = new Thickness(0, Sizes.GetSize(SizeName.content_margin_small), 0, 0);
+                m_buttonsContainer.HorizontalOptions = LayoutOptions.Start;
+                SetButtonsPosition(1, 1);
+                return;
+            }
+        
+            var maxWidth = Measure(int.MaxValue, int.MaxValue).Width;
+            var buttonsWidth = m_buttonsContainer.Measure(int.MaxValue, int.MaxValue).Width;
+            var remainingWidth = Width - maxWidth - buttonsWidth;
+        
+            var buttonsWillFit = remainingWidth >= (Sizes.GetSize(SizeName.content_margin_small));
+        
+            if (buttonsWillFit)
+            {
+                m_buttonsContainer.Margin = new Thickness(0, 0, 0, 0);
+                m_buttonsContainer.HorizontalOptions = LayoutOptions.End;
+                SetButtonsPosition(2, 0);
+            }
+            else
+            {
+                m_buttonsContainer.Margin = new Thickness(0, Sizes.GetSize(SizeName.content_margin_small), 0, 0);
+                m_buttonsContainer.HorizontalOptions = LayoutOptions.Start;
+                SetButtonsPosition(1, 1);
+            }
         }
-        
-        var maxWidth = Measure(int.MaxValue, int.MaxValue).Width;
-        var buttonsWidth = m_buttonsContainer.Measure(int.MaxValue, int.MaxValue).Width;
-        var remainingWidth = Width - maxWidth - buttonsWidth;
-        
-        var buttonsWillFit = remainingWidth >= (Sizes.GetSize(SizeName.content_margin_small));
-        
-        if (buttonsWillFit)
+        finally
         {
-            m_buttonsContainer.Margin = new Thickness(0, 0, 0, 0);
-            m_buttonsContainer.HorizontalOptions = LayoutOptions.End;
-            this.Add(m_buttonsContainer, 2);
+            m_isUpdatingButtonAlignment = false;
+        }
+    }
+
+    private void SetButtonsPosition(int column, int row)
+    {
+        if (!m_buttonsContainerAdded)
+        {
+            this.Add(m_buttonsContainer, column, row);
+            m_buttonsContainerAdded = true;
         }
         else
         {
-            m_buttonsContainer.Margin = new Thickness(0, Sizes.GetSize(SizeName.content_margin_small), 0, 0);
-            m_buttonsContainer.HorizontalOptions = LayoutOptions.Start;
-            this.Add(m_buttonsContainer, 1, 1);
+            Grid.SetColumn(m_buttonsContainer, column);
+            Grid.SetRow(m_buttonsContainer, row);
         }
-
-#if __ANDROID__
-        // Workaround for Android layout issue where buttons is not visible in some cases
-        InvalidateMeasure();
-#endif
     }
 
     private void OnButtonChanged()

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
@@ -5,6 +5,7 @@ namespace DIPS.Mobile.UI.Components.Buttons
     public partial class Button : Microsoft.Maui.Controls.Button
     {
         private Style? m_buttonStyleBasedOn;
+        private int m_autoCornerRadius = -1;
 
         public Button()
         {
@@ -23,12 +24,17 @@ namespace DIPS.Mobile.UI.Components.Buttons
         {
             base.OnSizeAllocated(width, height);
 
-            if (CornerRadius != -1)
+            if (Height <= 0 || Width <= 0)
                 return;
 
-            if (!(Height == 0 || Width == 0))
+            var calculatedRadius = (int)(Math.Min(Width, Height) / 2);
+
+            // Recalculate if CornerRadius was never set or was auto-calculated.
+            // Skip if explicitly set (e.g. by style for icon buttons).
+            if (CornerRadius == -1 || CornerRadius == m_autoCornerRadius)
             {
-                CornerRadius = (int)(Math.Min(Width, Height) / 2);
+                CornerRadius = calculatedRadius;
+                m_autoCornerRadius = calculatedRadius;
             }
         }
 


### PR DESCRIPTION
## Fix button visibility in AlertView and CornerRadius on Button

### Description

Fixes two related button issues in AlertView:

**AlertView: Button not visible **
`UpdateButtonAlignment()` used `Remove()` + `Add()` to reposition the button container on every `OnSizeAllocated`. On iOS this caused buttons to never render. Additionally, `InvalidateMeasure()` was only called on Android.

Solution:
- The button container is added to the Grid only once (`m_buttonsContainerAdded`). Subsequent repositioning uses `Grid.SetColumn()`/`Grid.SetRow()`.
- A reentrancy guard (`m_isUpdatingButtonAlignment`) and width tracking (`m_lastAllocatedWidth`) prevent infinite layout loops.
- Removed the `#if __ANDROID__` guard around `InvalidateMeasure()` — it is no longer needed.

**Button: Incorrect CornerRadius on resize**
`Button.OnSizeAllocated` calculated `CornerRadius` only on first allocation (`if (CornerRadius != -1) return`). When the button was resized (e.g. during repositioning in AlertView), the original radius was kept — resulting in incorrect rounding.

Solution:
- New field `m_autoCornerRadius` tracks whether CornerRadius was auto-calculated.
- `OnSizeAllocated` recalculates CornerRadius on every size change as long as the value was auto-calculated. Explicitly set values (e.g. from a style) are not overwritten.

### Test instructions

> **Important:** Buttons in general should be tested on both platforms (iOS and Android) after these changes, as we have modified layout logic in AlertView and CornerRadius calculation in Button.

#### AlertView buttons
1. Open Playground → "AlertView Repro #1455"
2. **Test 1 (Toggle):** Tap "Toggle AlertView" — the "Lagre" button should appear immediately on the first toggle
3. **Test 2 (Always visible):** Verify the "Lagre" button is visible without interaction
4. **Test 3 (Aggressive truncation):** Toggle — button should appear with truncated title
5. **Test 4 (Long title):** Toggle — the button should move below the text when the title is too long
6. **Test 5 (Success without button):** Toggle — alert without button should display correctly

#### Large text size
7. Increase the device text size to >100%
8. Repeat tests 1–4 — buttons should still display correctly

#### CornerRadius
9. Observe that buttons in AlertView have correct pill shape (rounded corners) in all tests
10. Verify that other buttons in the app (e.g. on the Playground main page) still have correct CornerRadius

#### Rotation
11. With an AlertView visible, rotate the device between portrait and landscape
12. Buttons should reposition correctly (inline if there is room, below the text if not)

#### Regression testing
13. Verify that AlertView in Arena Mobil (treatment plan, save bar) works as expected on both platforms