### PR TITLE
Fix Touch button trait for bound descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [60.2.7]
+- [Touch] Fixed missing button trait when a tappable view gets its accessibility description from a binding.
+
 ## [60.2.6]
 - [Label] `SectionHeader` labels are now exposed as level 2 semantic headings by default, improving VoiceOver and TalkBack navigation for section headers.
 

--- a/src/app/Components/AccessibilitySamples/VoiceOverSamples/TouchSamples/TouchSamples.xaml
+++ b/src/app/Components/AccessibilitySamples/VoiceOverSamples/TouchSamples/TouchSamples.xaml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:dui="http://dips.com/mobile.ui"
+                 xmlns:touchSamples="clr-namespace:Components.AccessibilitySamples.VoiceOverSamples.TouchSamples"
+                 x:Class="Components.AccessibilitySamples.VoiceOverSamples.TouchSamples.TouchSamples"
+                 x:DataType="touchSamples:TouchSamplesViewModel"
+                 Title="Touch Command">
+
+    <dui:ContentPage.BindingContext>
+        <touchSamples:TouchSamplesViewModel />
+    </dui:ContentPage.BindingContext>
+
+    <dui:ScrollView Padding="{dui:Sizes size_4}">
+        <dui:VerticalStackLayout Spacing="{dui:Sizes size_5}">
+
+            <dui:Label Text="Touch.Command with bound SemanticProperties.Description"
+                       Style="{dui:Styles Label=SectionHeader}" />
+
+            <dui:Label Text="The card below should be announced as a button when focused by VoiceOver or TalkBack. Its description comes from a MultiBinding."
+                       Style="{dui:Styles Label=UI200}"
+                       TextColor="{dui:Colors color_text_subtle}" />
+
+            <dui:VerticalStackLayout Spacing="{dui:Sizes size_2}">
+                <dui:VerticalStackLayout Padding="{dui:Sizes size_3}"
+                                         Spacing="{dui:Sizes size_1}"
+                                         BackgroundColor="{dui:Colors color_surface_default}"
+                                         dui:Layout.AutoCornerRadius="True"
+                                         dui:Touch.Command="{Binding OpenPatientCardCommand}">
+                    <SemanticProperties.Description>
+                        <MultiBinding StringFormat="{}{0}, {1}">
+                            <Binding Path="PatientName" />
+                            <Binding Path="PersonaliaText" />
+                        </MultiBinding>
+                    </SemanticProperties.Description>
+
+                    <dui:Label Text="{Binding PatientName}"
+                               Style="{dui:Styles Label=Body400}"
+                               AutomationProperties.IsInAccessibleTree="False" />
+
+                    <dui:Label Text="{Binding PersonaliaText}"
+                               Style="{dui:Styles Label=UI200}"
+                               TextColor="{dui:Colors color_text_subtle}"
+                               AutomationProperties.IsInAccessibleTree="False" />
+                </dui:VerticalStackLayout>
+
+                <dui:Label Text="{Binding TapStatusText}"
+                           Style="{dui:Styles Label=UI100}"
+                           TextColor="{dui:Colors color_text_subtle}" />
+            </dui:VerticalStackLayout>
+
+        </dui:VerticalStackLayout>
+    </dui:ScrollView>
+
+</dui:ContentPage>

--- a/src/app/Components/AccessibilitySamples/VoiceOverSamples/TouchSamples/TouchSamples.xaml.cs
+++ b/src/app/Components/AccessibilitySamples/VoiceOverSamples/TouchSamples/TouchSamples.xaml.cs
@@ -1,0 +1,9 @@
+namespace Components.AccessibilitySamples.VoiceOverSamples.TouchSamples;
+
+public partial class TouchSamples
+{
+    public TouchSamples()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/app/Components/AccessibilitySamples/VoiceOverSamples/TouchSamples/TouchSamplesViewModel.cs
+++ b/src/app/Components/AccessibilitySamples/VoiceOverSamples/TouchSamples/TouchSamplesViewModel.cs
@@ -1,0 +1,33 @@
+using DIPS.Mobile.UI.MVVM;
+using System.Windows.Input;
+
+namespace Components.AccessibilitySamples.VoiceOverSamples.TouchSamples;
+
+public class TouchSamplesViewModel : ViewModel
+{
+    private int m_tapCount;
+    private string m_tapStatusText = "Card has not been opened.";
+
+    public TouchSamplesViewModel()
+    {
+        OpenPatientCardCommand = new Command(OpenPatientCard);
+    }
+
+    public string PatientName => "Test Patient";
+
+    public string PersonaliaText => "Born 01.01.1970, female";
+
+    public string TapStatusText
+    {
+        get => m_tapStatusText;
+        set => RaiseWhenSet(ref m_tapStatusText, value);
+    }
+
+    public ICommand OpenPatientCardCommand { get; }
+
+    private void OpenPatientCard()
+    {
+        m_tapCount++;
+        TapStatusText = $"Card opened {m_tapCount} time(s).";
+    }
+}

--- a/src/app/Components/AccessibilitySamples/VoiceOverSamples/VoiceOverSamples.xaml
+++ b/src/app/Components/AccessibilitySamples/VoiceOverSamples/VoiceOverSamples.xaml
@@ -9,6 +9,7 @@
                  xmlns:listItemInteractiveContentSamples="clr-namespace:Components.AccessibilitySamples.VoiceOverSamples.ListItemInteractiveContentSamples"
                  xmlns:navigationListItemSamples="clr-namespace:Components.AccessibilitySamples.VoiceOverSamples.NavigationListItemSamples"
                  xmlns:traitSamples="clr-namespace:Components.AccessibilitySamples.VoiceOverSamples.TraitSamples"
+                 xmlns:touchSamples="clr-namespace:Components.AccessibilitySamples.VoiceOverSamples.TouchSamples"
                  x:Class="Components.AccessibilitySamples.VoiceOverSamples.VoiceOverSamples"
                  Title="{x:Static localizedStrings:LocalizedStrings.VoiceOver}">
 
@@ -28,6 +29,11 @@
                               Subtitle="{x:Static localizedStrings:LocalizedStrings.VoiceOver_ListItem_Interactive_Subtitle}"
                               HasBottomDivider="True"
                               Command="{helpers:NavigationCommand ContentPageType={x:Type listItemInteractiveContentSamples:ListItemInteractiveContentSamples}}" />
+
+                <dui:ListItem Title="Touch Command"
+                              Subtitle="Bound accessibility description"
+                              HasBottomDivider="True"
+                              Command="{helpers:NavigationCommand ContentPageType={x:Type touchSamples:TouchSamples}}" />
                 
                 <dui:ListItem Title="{x:Static localizedStrings:LocalizedStrings.VoiceOver_Trait_Title}"
                               Subtitle="{x:Static localizedStrings:LocalizedStrings.VoiceOver_Trait_Subtitle}"

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/Android/TouchPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/Android/TouchPlatformEffect.cs
@@ -82,11 +82,10 @@ public partial class TouchPlatformEffect
         if (Touch.GetIsButtonTraitEnabled(Element))
         {
             var existingDelegate = Control.GetAccessibilityDelegate();
-        
-            // We don't want TalkBack to only say "Button"
-            if(existingDelegate is null)
+
+            if (existingDelegate is TouchAccessibilityDelegate)
                 return;
-        
+
             Control.SetAccessibilityDelegate(new TouchAccessibilityDelegate(existingDelegate));   
         }
     }

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchPlatformEffect.cs
@@ -38,12 +38,21 @@ public partial class TouchPlatformEffect
 
     private partial void OnAccessibilityDescriptionSet()
     {
-        // Append the AccessibilityTraits to `Button` if there is an accessibility description set
-        if (!string.IsNullOrEmpty(Control.AccessibilityLabel) && Touch.GetIsButtonTraitEnabled(Element))
-        {
-            // Use | to append, to make sure we are not overwriting anything here
-            Control.AccessibilityTraits |= UIAccessibilityTrait.Button;
-        }
+        MainThread.BeginInvokeOnMainThread(AddButtonTraitWhenDescriptionIsSet);
+    }
+
+    private void AddButtonTraitWhenDescriptionIsSet()
+    {
+        if (Control is null or UIButton)
+            return;
+
+        if (!Touch.GetIsButtonTraitEnabled(Element))
+            return;
+
+        if (string.IsNullOrEmpty(SemanticProperties.GetDescription(Element)) && string.IsNullOrEmpty(Control.AccessibilityLabel))
+            return;
+
+        Control.AccessibilityTraits |= UIAccessibilityTrait.Button;
     }
 
     private void OnLongPress(UILongPressGestureRecognizer e)


### PR DESCRIPTION
## Oppsummering

Fikser at `dui:Touch.Command` kan mangle knapp-semantikk når `SemanticProperties.Description` kommer fra binding.

- iOS legger nå på button trait etter at description-bindingen har fått oppdatere native accessibility label.
- Android setter Touch accessibility delegate også når elementet ikke har en eksisterende delegate fra før, og unngår å pakke inn samme Touch-delegate flere ganger.
- Legger til en repro i Components-testappen under `VoiceOver/TalkBack` > `Touch Command` med `SemanticProperties.Description` fra `MultiBinding`.
- Oppdaterer `CHANGELOG.md` med versjon `60.2.6`.

## Verifisering

- `dotnet build src/library/DIPS.Mobile.UI/DIPS.Mobile.UI.csproj -f net10.0-ios -c Debug`
- `dotnet build src/library/DIPS.Mobile.UI/DIPS.Mobile.UI.csproj -f net10.0-android -c Debug`
- `dotnet test src/tests/unittests/DIPS.Mobile.UI.UnitTests.csproj -c Debug`
- `dotnet build src/app/Components/Components.csproj -f net10.0-ios -c Debug -v quiet -clp:ErrorsOnly`
- `dotnet build src/app/Components/Components.csproj -f net10.0-android -c Debug -v quiet -clp:ErrorsOnly`

Byggene går gjennom med eksisterende warnings.
