### PR TITLE
Fix iOS system message removal in modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [60.2.7]
+- [SystemMessage][iOS] Fixed system messages not being removed when displayed inside a modal.
+
 ## [60.2.6]
 - [Label] `SectionHeader` labels are now exposed as level 2 semantic headings by default, improving VoiceOver and TalkBack navigation for section headers.
 

--- a/src/library/DIPS.Mobile.UI/Components/Alerting/SystemMessage/iOS/SystemMessageService.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Alerting/SystemMessage/iOS/SystemMessageService.cs
@@ -13,7 +13,12 @@ public static partial class SystemMessageService
         {
             MainThread.BeginInvokeOnMainThread(delegate
             {
-                var rootView = Platform.GetCurrentUIViewController()?.View; 
+                var rootView = Platform.GetCurrentUIViewController()?.View;
+                if (rootView is null)
+                {
+                    return;
+                }
+
                 systemMessage.HeightRequest = rootView.Frame.Height;
                 systemMessage.WidthRequest = rootView.Frame.Width;
                 var systemMessageUIView = systemMessage.ToPlatform(DUI.GetCurrentMauiContext!);
@@ -25,7 +30,13 @@ public static partial class SystemMessageService
 
     private static partial void PlatformRemove()
     {
-        DUI.RootController!.RemoveUIViewChildWithTag(SystemMessageTagId);
+        var currentView = Platform.GetCurrentUIViewController()?.View;
+        currentView?.RemoveUIViewChildWithTag(SystemMessageTagId);
+
+        if (currentView != DUI.RootController)
+        {
+            DUI.RootController?.RemoveUIViewChildWithTag(SystemMessageTagId);
+        }
     }
   
 }


### PR DESCRIPTION
## Summary
- Remove iOS system messages from the currently presented UIViewController when dismissing them.
- Keep the root controller removal as a fallback for non-modal presentation.
- Add a changelog entry for 60.2.7.

## Testing
- `dotnet build src/library/DIPS.Mobile.UI/DIPS.Mobile.UI.csproj -f net10.0-ios`
  - Succeeded with existing warnings.