### PR TITLE
Fixed OnPropertyChanged overrides not passing in CallerMemberName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [60.2.9]
-- [ContentPage] Fixed issue where CallerMemberName was not passed on OnPropertyChanged override.
+- Fixed issue where CallerMemberName was not passed on OnPropertyChanged override. Affects ContentPage, Button, Chip, ContextMenuItem, ContextMenuSeparatorItem, ImageButton, ActivityIndicator and SingleLineInputField
 
 ## [60.2.8]
 - [SystemMessage][iOS] Fixed system messages not being removed when displayed inside a modal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [60.2.9]
-- Fixed issue where CallerMemberName was not passed on OnPropertyChanged override. Affects ContentPage, Button, Chip, ContextMenuItem, ContextMenuSeparatorItem, ImageButton, ActivityIndicator and SingleLineInputField
+- Fixed issue where CallerMemberName was not passed on OnPropertyChanged override. Affects ContentPage, Button, Chip, ContextMenuItem, ContextMenuSeparatorItem, ImageButton, ActivityIndicator and SingleLineInputField.
 
 ## [60.2.8]
 - [SystemMessage][iOS] Fixed system messages not being removed when displayed inside a modal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [60.2.9]
+- [ContentPage] Fixed issue where CallerName was not passed on OnPropertyChanged override.
+
 ## [60.2.8]
 - [SystemMessage][iOS] Fixed system messages not being removed when displayed inside a modal.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [60.2.9]
-- [ContentPage] Fixed issue where CallerName was not passed on OnPropertyChanged override.
+- [ContentPage] Fixed issue where CallerMemberName was not passed on OnPropertyChanged override.
 
 ## [60.2.8]
 - [SystemMessage][iOS] Fixed system messages not being removed when displayed inside a modal.

--- a/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Buttons/Button.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using DIPS.Mobile.UI.Resources.Styles.Button;
 
 namespace DIPS.Mobile.UI.Components.Buttons
@@ -38,7 +39,7 @@ namespace DIPS.Mobile.UI.Components.Buttons
             }
         }
 
-        protected override void OnPropertyChanged(string propertyName = null)
+        protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {
             base.OnPropertyChanged(propertyName);
             

--- a/src/library/DIPS.Mobile.UI/Components/Chips/iOS/Chip.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Chips/iOS/Chip.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using DIPS.Mobile.UI.API.Accessibility;
 using DIPS.Mobile.UI.Effects.Touch;
 using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
@@ -193,7 +194,7 @@ public partial class Chip
         }
     }
 
-    protected override void OnPropertyChanged(string propertyName = null)
+    protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
     {
         base.OnPropertyChanged(propertyName);
 

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuItem.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace DIPS.Mobile.UI.Components.ContextMenus;
 
 /// <summary>
@@ -27,7 +29,7 @@ public partial class ContextMenuItem : Element, IContextMenuItem
     }
 
 #if __IOS__
-    protected override void OnPropertyChanged(string propertyName = null)
+    protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
     {
         base.OnPropertyChanged(propertyName);
         

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuSeparatorItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/ContextMenuSeparatorItem.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace DIPS.Mobile.UI.Components.ContextMenus;
 
 public class ContextMenuSeparatorItem : Element, IContextMenuItem
@@ -20,7 +22,7 @@ public class ContextMenuSeparatorItem : Element, IContextMenuItem
     public ContextMenu? ContextMenu { get; set; }
 
 #if __IOS__
-    protected override void OnPropertyChanged(string propertyName = null)
+    protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
     {
         base.OnPropertyChanged(propertyName);
         

--- a/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/ImageButton.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Images/ImageButton/ImageButton.cs
@@ -1,4 +1,5 @@
 
+using System.Runtime.CompilerServices;
 using Microsoft.Maui.Platform;
 namespace DIPS.Mobile.UI.Components.Images.ImageButton;
 
@@ -6,7 +7,7 @@ public partial class ImageButton : Microsoft.Maui.Controls.ImageButton
 {
     //TODO: Fix when MAUI fixes: https://github.com/dotnet/maui/issues/18001
 #if __ANDROID__
-    protected override void OnPropertyChanged(string propertyName = null)
+    protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
     {
         base.OnPropertyChanged(propertyName);
         if (propertyName.Equals(IsVisibleProperty.PropertyName))

--- a/src/library/DIPS.Mobile.UI/Components/Loading/Android/ActivityIndicator.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Loading/Android/ActivityIndicator.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using DIPS.Mobile.UI.Components.Loading.Android;
 using DIPS.Mobile.UI.Extensions.Android;
 using Google.Android.Material.ProgressIndicator;
@@ -6,7 +7,7 @@ namespace DIPS.Mobile.UI.Components.Loading;
 
 public partial class ActivityIndicator
 {
-    protected override void OnPropertyChanged(string? propertyName = null)
+    protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
         base.OnPropertyChanged(propertyName);
 

--- a/src/library/DIPS.Mobile.UI/Components/Pages/ContentPage.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pages/ContentPage.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using DIPS.Mobile.UI.API.Diagnostics;
 using DIPS.Mobile.UI.API.Library;
 
@@ -65,7 +66,7 @@ namespace DIPS.Mobile.UI.Components.Pages
             }
         }
 
-        protected override void OnPropertyChanged(string? propertyName = null)
+        protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)
         {
             base.OnPropertyChanged(propertyName);
 

--- a/src/library/DIPS.Mobile.UI/Components/TextFields/InputFields/SingleLineInputField.cs
+++ b/src/library/DIPS.Mobile.UI/Components/TextFields/InputFields/SingleLineInputField.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using DIPS.Mobile.UI.API.Accessibility;
 using DIPS.Mobile.UI.Effects.Touch;
 using DIPS.Mobile.UI.Formatters;
@@ -136,7 +137,7 @@ public partial class SingleLineInputField : Grid
         InnerGrid.Add(InputView, 0, 1);
     }
 
-    protected override void OnPropertyChanged(string? propertyName = null)
+    protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
         base.OnPropertyChanged(propertyName);
 


### PR DESCRIPTION
### Description of Change

Without CallerMemberName, calling PropertyChanged() without a nameof(property) would cause the MemberName to be null, leading to an error.