### PR TITLE
Fix Android CollectionView crash during list reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+## [60.2.11]
+- [CollectionView][Android] Fixed crash when deferred item decoration updates ran after the RecyclerView was detached during list reloads.
+
 ## [60.2.10]
 - [ScrollView][Android] Rolled back Microsoft.Maui.Controls from 10.0.60 to 10.0.51 due to an Android scroll regression.
+
 
 ## [60.2.9]
 - Fixed issue where CallerMemberName was not passed on OnPropertyChanged override. Affects ContentPage, Button, Chip, ContextMenuItem, ContextMenuSeparatorItem, ImageButton, ActivityIndicator and SingleLineInputField.

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/Android/CollectionViewHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/Android/CollectionViewHandler.cs
@@ -428,13 +428,20 @@ public class ReorderableItemsViewAdapter : ReorderableItemsViewAdapter<Reorderab
 
         private void ScheduleUpdate()
         {
-            adapter.m_recyclerView?.Post(() =>
+            var recyclerView = adapter.m_recyclerView;
+            recyclerView?.Post(() =>
             {
-                adapter.m_recyclerView.InvalidateItemDecorations();
+                if (!ReferenceEquals(adapter.m_recyclerView, recyclerView))
+                    return;
+
+                recyclerView.InvalidateItemDecorations();
                 adapter.UpdateAllVisibleCells();
-                adapter.m_recyclerView?.Post(() =>
+                recyclerView.Post(() =>
                 {
-                    adapter.m_recyclerView.InvalidateItemDecorations();
+                    if (!ReferenceEquals(adapter.m_recyclerView, recyclerView))
+                        return;
+
+                    recyclerView.InvalidateItemDecorations();
                     adapter.UpdateAllVisibleCells();
                 });
             });


### PR DESCRIPTION
### Description of Change

Fixes an Android `CollectionView` crash where deferred item decoration updates could run after the adapter had been detached from its `RecyclerView` during list reloads.

The adapter now captures the `RecyclerView` instance that scheduled the deferred update and verifies that the adapter is still attached to that same instance before invalidating item decorations or updating visible cells.

### Todos
- [x] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->