### PR TITLE
Added new multicapture camera UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [61.4.0]
+- [ImageCapture] When taking several photos in a row, the most recent photo now shows as a thumbnail in the bottom-left corner of the camera and updates with each capture. The thumbnail can be tapped to review and/or remove photos from the capture session.
+- [ImageCapture] Added MaxImageCount with a default of 15 when using MultiImageCapture to avoid crash as images are stored in-memory only.
+- [Gallery] Fixed issue where gallery always reset to the first image when the collection changed.
+
 ## [61.3.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/src/app/Components/ComponentsSamples/ImageCapturing/MultiImageCaptureModalPage.xaml.cs
+++ b/src/app/Components/ComponentsSamples/ImageCapturing/MultiImageCaptureModalPage.xaml.cs
@@ -9,6 +9,7 @@ public partial class MultiImageCaptureModalPage
     private readonly bool m_requiresConfirmation;
     private readonly List<CapturedImage> m_capturedImages = [];
     private readonly ImageCapture m_imageCapture = new();
+    private bool m_hasStartedCapture;
     private readonly TaskCompletionSource<List<CapturedImage>> m_completion =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -24,6 +25,10 @@ public partial class MultiImageCaptureModalPage
     {
         base.OnAppearing();
 
+        if (m_hasStartedCapture)
+            return;
+        m_hasStartedCapture = true;
+
         var cameraOptions = new CameraOptions
         {
             CancelButtonCommand = new Command(OnCancelled)
@@ -32,16 +37,21 @@ public partial class MultiImageCaptureModalPage
         var multiImageCaptureOptions = new MultiImageCaptureOptions
         {
             RequiresConfirmationOnEachImage = m_requiresConfirmation,
-            FinishedButtonCommand = new Command(OnFinished)
+            FinishedButtonCommand = new Command(OnFinished),
+            MaxImageCount = 10,
+            OnImageRemoved = OnImageRemoved
         };
         
         await m_imageCapture.StartMultiImageCapture(CameraPreview, OnImageCaptured, OnCameraFailed,
             cameraOptions, multiImageCaptureOptions);
     }
 
-    protected override void OnDisappearing()
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnDisappearing();
+        base.OnHandlerChanging(args);
+
+        if (args.NewHandler is not null)
+            return;
 
         m_imageCapture.Stop();
 
@@ -52,6 +62,11 @@ public partial class MultiImageCaptureModalPage
     private void OnImageCaptured(CapturedImage capturedImage)
     {
         m_capturedImages.Add(capturedImage);
+    }
+
+    private void OnImageRemoved(CapturedImage capturedImage)
+    {
+        m_capturedImages.Remove(capturedImage);
     }
 
     private async void OnFinished()

--- a/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/BottomToolbar/GalleryBottomSheetBottomToolbar.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/BottomToolbar/GalleryBottomSheetBottomToolbar.cs
@@ -39,6 +39,6 @@ internal class GalleryBottomSheetBottomToolbar : Grid
         };
         
         Add(removeButtonWithText);
-        Add(doneButtonWithText);   
+        Add(doneButtonWithText);
     }
 }

--- a/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/GalleryBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/GalleryBottomSheet.cs
@@ -212,7 +212,7 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
         if (args.NewHandler is not null)
         {
             OnImagesChanged();
-            _ = OnCarouselViewPositionChanged(m_carouselView!.Position);    
+            _ = OnCarouselViewPositionChanged(m_carouselView!.Position);
         }
     }
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCapture.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCapture.cs
@@ -62,7 +62,7 @@ public partial class ImageCapture : CameraFragment
             ? AndroidX.Camera.Core.ImageCapture.FlashModeOn
             : AndroidX.Camera.Core.ImageCapture.FlashModeOff;
         
-        m_imageCaptureCallback?.Dispose();
+        m_imageCaptureCallback?.IgnoreRemainingCallbacks();
         m_imageCaptureCallback = new ImageCaptureCallback(
             onCaptureStarted: () => SimulateCameraShutter(false),
             onImageCaptureFailed: InvokeOnImageCaptureFailed,
@@ -80,7 +80,7 @@ public partial class ImageCapture : CameraFragment
     {
         CancelAnyActiveImageProcessing();
 
-        m_imageCaptureCallback?.Dispose();
+        m_imageCaptureCallback?.IgnoreRemainingCallbacks();
         m_imageCaptureCallback = null;
 
         await base.TryStop();
@@ -96,7 +96,7 @@ public partial class ImageCapture : CameraFragment
     {
         if (imageCaptureException.Message != null)
         {
-            PlatformOnCameraFailed(new CameraException("DidTryCaptureImage", imageCaptureException));
+            OnImageCaptureFailed(new CameraException("DidTryCaptureImage", imageCaptureException));
         }
     }
 
@@ -135,7 +135,7 @@ public partial class ImageCapture : CameraFragment
         }
         catch (Exception e)
         {
-            PlatformOnCameraFailed(new CameraException("ProcessImageFailed", e));
+            OnImageCaptureFailed(new CameraException("ProcessImageFailed", e));
         }
     }
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCaptureCallback.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCaptureCallback.cs
@@ -20,9 +20,9 @@ internal class ImageCaptureCallback : AndroidX.Camera.Core.ImageCapture.OnImageC
     }
     
     /// <remarks>
-    /// If CameraX hands this Java callback to managed code after the C# instance has been disposed, Android will try to rebuild the 
+    /// If CameraX hands this Java callback to managed code after the C# instance has been disposed, Android will try to rebuild the
     /// managed object, and crash if this constructor doesn't exist.
-    
+    ///
     /// From the .NET for Android architecture docs, "Premature Dispose() Calls" section:
     /// https://learn.microsoft.com/en-us/previous-versions/xamarin/android/internals/architecture
     /// "If a JNI handle enters managed code after the mapping has been broken, it looks like Java Activation,

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCaptureCallback.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Android/ImageCaptureCallback.cs
@@ -1,3 +1,4 @@
+using Android.Runtime;
 using AndroidX.Camera.Core;
 
 namespace DIPS.Mobile.UI.API.Camera.ImageCapturing;
@@ -17,11 +18,25 @@ internal class ImageCaptureCallback : AndroidX.Camera.Core.ImageCapture.OnImageC
         m_onImageCaptured = onImageCaptured;
         m_onImageCaptureFailed = onImageCaptureFailed;
     }
+    
+    /// <remarks>
+    /// If CameraX hands this Java callback to managed code after the C# instance has been disposed, Android will try to rebuild the 
+    /// managed object, and crash if this constructor doesn't exist.
+    
+    /// From the .NET for Android architecture docs, "Premature Dispose() Calls" section:
+    /// https://learn.microsoft.com/en-us/previous-versions/xamarin/android/internals/architecture
+    /// "If a JNI handle enters managed code after the mapping has been broken, it looks like Java Activation,
+    /// and the (IntPtr, JniHandleOwnership) constructor will be checked for and invoked. If the constructor
+    /// doesn't exist, then an exception will be thrown."
+    /// </remarks>
+    protected ImageCaptureCallback(IntPtr javaReference, JniHandleOwnership transfer)
+        : base(javaReference, transfer)
+    {
+    }
 
     /// <summary>
     /// Called when the camera hardware has started exposing the sensor.
     /// Use this to display shutter animation or similar feedback.
-    ///
     /// </summary>
     /// <remarks>
     /// From docs:
@@ -41,7 +56,7 @@ internal class ImageCaptureCallback : AndroidX.Camera.Core.ImageCapture.OnImageC
     {
         m_onImageCaptureFailed?.Invoke(exception);
         base.OnError(exception);
-        ClearDelegates();
+        IgnoreRemainingCallbacks();
     }
 
     public override void OnCaptureSuccess(IImageProxy image)
@@ -49,10 +64,16 @@ internal class ImageCaptureCallback : AndroidX.Camera.Core.ImageCapture.OnImageC
         m_onImageCaptured?.Invoke(image);
         base.OnCaptureSuccess(image);
         image?.Close();
-        ClearDelegates();
+        IgnoreRemainingCallbacks();
     }
-
-    private void ClearDelegates()
+    
+    /// <remarks>
+    /// From the .NET for Android architecture docs, "Premature Dispose() Calls" section:
+    /// https://learn.microsoft.com/en-us/previous-versions/xamarin/android/internals/architecture
+    /// "Only Dispose() of managed callable wrapper subclasses when you know that the Java object will not be
+    /// used anymore..."
+    /// </remarks>
+    internal void IgnoreRemainingCallbacks()
     {
         m_onCaptureStarted = null;
         m_onImageCaptured = null;
@@ -61,7 +82,7 @@ internal class ImageCaptureCallback : AndroidX.Camera.Core.ImageCapture.OnImageC
 
     protected override void Dispose(bool disposing)
     {
-        ClearDelegates();
+        IgnoreRemainingCallbacks();
         base.Dispose(disposing);
     }
 }

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.CapturedImagesGallery.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.CapturedImagesGallery.cs
@@ -1,0 +1,148 @@
+using DIPS.Mobile.UI.API.Camera.ImageCapturing.Views;
+using DIPS.Mobile.UI.API.Camera.ImageCapturing.Views.BottomToolbar.StreamingState;
+using DIPS.Mobile.UI.Components.Alerting.Dialog;
+using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
+
+namespace DIPS.Mobile.UI.API.Camera.ImageCapturing;
+
+public partial class ImageCapture
+{
+    private readonly List<CapturedImage> m_capturedImages = [];
+    private CapturedImagesGalleryButton? m_capturedImagesGalleryButton;
+    private CapturedImagesGalleryOverlay? m_galleryOverlay;
+
+    private bool HasReachedImageLimit =>
+        m_cameraSession is MultiCaptureSession multiCaptureSession
+        && m_capturedImages.Count >= multiCaptureSession.MultiImageCaptureOptions.MaxImageCount;
+
+    /// <summary>
+    /// Only show optimistic UI when no per-image confirmation is needed. With per-image confirmation, the image is not
+    /// committed until the user accepts it, and should not update UI optimistically.
+    /// </summary>
+    private bool ShouldUpdateImagePreviewImmediately =>
+        m_cameraSession is MultiCaptureSession { MultiImageCaptureOptions.RequiresConfirmationOnEachImage: false };
+    
+    private void OptimisticallyUpdateGalleryButton()
+    {
+        if (!ShouldUpdateImagePreviewImmediately)
+            return;
+
+        var pendingImageCount = m_capturedImages.Count + 1;
+        m_capturedImagesGalleryButton?.ShowPendingCapture(pendingImageCount);
+    }
+
+    private CapturedImagesGalleryButton? CreateCapturedImagesGalleryButtonForMultiCapture()
+    {
+        if (m_cameraSession is not MultiCaptureSession)
+        {
+            m_capturedImagesGalleryButton = null;
+            return null;
+        }
+
+        m_capturedImagesGalleryButton = new CapturedImagesGalleryButton(OpenCapturedImagesGallery);
+        
+        m_capturedImagesGalleryButton.ShowMostRecentImageAndCount(m_capturedImages);
+        
+        return m_capturedImagesGalleryButton;
+    }
+
+    private void AddImageAndUpdateImagePreview(CapturedImage capturedImage)
+    {
+        m_capturedImages.Add(capturedImage);
+        
+        m_capturedImagesGalleryButton?.ShowMostRecentImageAndCount(m_capturedImages);
+
+        if (HasReachedImageLimit)
+        {
+            ShowMaxImagesReachedMessage();
+        }
+    }
+
+    private void ShowMaxImagesReachedMessage()
+    {
+        if (m_cameraSession is not MultiCaptureSession multiCaptureSession)
+            throw new InvalidOperationException($"{nameof(ShowMaxImagesReachedMessage)} is only valid during a multi capture session, but the session was {m_cameraSession?.GetType().Name ?? "null"}.");
+
+        var maxImageCount = multiCaptureSession.MultiImageCaptureOptions.MaxImageCount;
+        _ = DialogService.ShowMessage(configurator => configurator
+            .SetTitle(DUILocalizedStrings.MaxImagesReachedTitle)
+            .SetDescription(string.Format(DUILocalizedStrings.MaxImagesReachedMessage, maxImageCount))
+            .SetActionTitle(DUILocalizedStrings.Ok));
+    }
+
+    private void OpenCapturedImagesGallery()
+    {
+        if (m_capturedImages.Count == 0)
+            throw new InvalidOperationException("Captured-images gallery opened with no images. The preview is hidden when empty, so this should be unreachable.");
+
+        if (m_cameraPreview is null)
+            throw new InvalidOperationException("Captured-images gallery opened after the camera preview was torn down.");
+
+        // Guard against repeat taps
+        if (m_galleryOverlay is not null)
+            return;
+        
+        m_cameraPreview.HidePreview();
+
+        var startingIndex = m_capturedImages.Count - 1;
+        
+        m_galleryOverlay = new CapturedImagesGalleryOverlay(
+            m_capturedImages, 
+            startingIndex, 
+            onRemoveImageAtAction: RemoveImageAndUpdateGalleryButton, 
+            onCloseAction: CloseCapturedImagesGallery);
+        
+        m_cameraPreview.AddViewToRoot(m_galleryOverlay);
+    }
+
+    private async void CloseCapturedImagesGallery()
+    {
+        try
+        {
+            ArgumentNullException.ThrowIfNull(m_cameraPreview);
+            ArgumentNullException.ThrowIfNull(m_galleryOverlay);
+            
+            var overlay = m_galleryOverlay;
+            m_galleryOverlay = null;
+            
+            m_cameraPreview.ShowPreview();
+            
+            await overlay.FadeOutAsync();
+
+            // The user can navigate away from the page during the fade, which nulls the preview.
+            if (m_cameraPreview is null)
+                return;
+
+            m_cameraPreview.RemoveViewFromRoot(overlay);
+
+            m_capturedImagesGalleryButton?.ShowMostRecentImageAndCount(m_capturedImages);
+            m_bottomToolbarView?.SetShutterButtonEnabled(true);
+        }
+        catch (Exception e)
+        {
+            Log(e.Message);
+        }
+    }
+
+    private void TearDownGalleryOverlay()
+    {
+        m_cameraPreview?.RemoveViewFromRoot(m_galleryOverlay);
+        m_galleryOverlay = null;
+    }
+
+    private void RemoveImageAndUpdateGalleryButton(int index)
+    {
+        if (index < 0 || index >= m_capturedImages.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), index, $"The gallery asked to remove an image at an index outside the captured set (count {m_capturedImages.Count}).");
+
+        var removedImage = m_capturedImages[index];
+        m_capturedImages.RemoveAt(index);
+
+        if (m_cameraSession is MultiCaptureSession multiCaptureSession)
+        {
+            multiCaptureSession.MultiImageCaptureOptions.OnImageRemoved?.Invoke(removedImage);
+        }
+
+        m_capturedImagesGalleryButton?.ShowMostRecentImageAndCount(m_capturedImages);
+    }
+}

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.ConfirmState.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.ConfirmState.cs
@@ -72,16 +72,16 @@ public partial class ImageCapture : IConfirmStateObserver
     void IConfirmStateObserver.OnUsePhotoButtonTapped()
     {
         m_onImageCapturedDelegate?.Invoke(m_currentlyCapturedImage);
-        
+
         if (m_cameraSession is MultiCaptureSession)
         {
+            AddImageAndUpdateImagePreview(m_currentlyCapturedImage);
             GoToStreamingState();
             _ = PlatformStart(m_cameraSession.CameraOptions, m_cameraFailedDelegate);
             return;
         }
         
-        ResetAllVisuals();
-        PlatformStop();
+        Stop();
     }
 
     void IConfirmStateObserver.OnRetakePhotoButtonTapped()

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.StreamingState.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.StreamingState.cs
@@ -1,4 +1,5 @@
 using DIPS.Mobile.UI.API.Camera.ImageCapturing.Observers;
+using DIPS.Mobile.UI.API.Camera.ImageCapturing.Views.BottomToolbar.StreamingState;
 using DIPS.Mobile.UI.Components.Alerting.Dialog;
 using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
 
@@ -8,6 +9,12 @@ public partial class ImageCapture : IStreamingStateObserver
 {
     void IStreamingStateObserver.OnTappedShutterButton()
     {
+        if (HasReachedImageLimit)
+        {
+            ShowMaxImagesReachedMessage();
+            return;
+        }
+
         try
         {
             m_bottomToolbarView?.SetShutterButtonEnabled(false);
@@ -15,7 +22,7 @@ public partial class ImageCapture : IStreamingStateObserver
         }
         catch (Exception e)
         {
-            PlatformOnCameraFailed(new CameraException("DidTryCaptureImage", e));
+            OnImageCaptureFailed(new CameraException("DidTryCaptureImage", e));
         }
     }
 
@@ -28,7 +35,17 @@ public partial class ImageCapture : IStreamingStateObserver
     {
         m_cameraPreview.GoToStreamingState();
         m_topToolbarView.GoToStreamingState(this);
-        m_bottomToolbarView.GoToStreamingState(this);
+
+        StreamingTrailingControl trailingControl = m_cameraSession switch
+        {
+            MultiCaptureSession multiCaptureSession =>
+                new StreamingTrailingControl.FinishCapture(multiCaptureSession.MultiImageCaptureOptions.FinishedButtonText, OnFinishedImageCaptureButtonTapped),
+            _ => new StreamingTrailingControl.Flash()
+        };
+
+        var leadingControl = CreateCapturedImagesGalleryButtonForMultiCapture();
+
+        m_bottomToolbarView.GoToStreamingState(this, trailingControl, leadingControl);
 
         m_bottomToolbarView.SetShutterButtonEnabled(true);
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/ImageCapture.cs
@@ -43,7 +43,8 @@ public partial class ImageCapture : ICameraUseCase
 #nullable enable
 
     private CancellationTokenSource? m_captureProcessingCts;
-    
+    private bool m_isCapturing;
+
     public async Task StartSingleImageCapture(CameraPreview cameraPreview, DidCaptureImage onImageCapturedDelegate, 
         CameraFailed cameraFailedDelegate, CameraOptions cameraOptions)
     {
@@ -52,9 +53,17 @@ public partial class ImageCapture : ICameraUseCase
         await StartImageCapture(cameraPreview, onImageCapturedDelegate, cameraFailedDelegate);
     }
     
-    public async Task StartMultiImageCapture(CameraPreview cameraPreview, DidCaptureImage onImageCapturedDelegate, 
+    public async Task StartMultiImageCapture(CameraPreview cameraPreview, DidCaptureImage onImageCapturedDelegate,
         CameraFailed cameraFailedDelegate, CameraOptions cameraOptions, MultiImageCaptureOptions multiImageCaptureOptions)
     {
+        ArgumentNullException.ThrowIfNull(cameraPreview);
+        ArgumentNullException.ThrowIfNull(onImageCapturedDelegate);
+        ArgumentNullException.ThrowIfNull(cameraFailedDelegate);
+        ArgumentNullException.ThrowIfNull(cameraOptions);
+        ArgumentNullException.ThrowIfNull(multiImageCaptureOptions);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(multiImageCaptureOptions.MaxImageCount);
+
+        m_capturedImages.Clear();
         m_cameraSession = new MultiCaptureSession(cameraOptions, multiImageCaptureOptions);
 
         await StartImageCapture(cameraPreview, onImageCapturedDelegate, cameraFailedDelegate);
@@ -63,12 +72,16 @@ public partial class ImageCapture : ICameraUseCase
     private async Task StartImageCapture(CameraPreview cameraPreview, DidCaptureImage onImageCapturedDelegate,
         CameraFailed cameraFailedDelegate)
     {
+        if (m_isCapturing)
+            throw new InvalidOperationException("A capture session is already running. Stop the current session before starting another.");
+
         m_cameraPreview = cameraPreview;
         m_cameraPreview.AddUseCase(this);
         m_onImageCapturedDelegate = onImageCapturedDelegate;
         m_cameraFailedDelegate = cameraFailedDelegate;
         if (await CameraPermissions.CanUseCamera())
         {
+            m_isCapturing = true;
             Log("Permitted to use camera");
             await m_cameraPreview.HasLoaded();
             ConstructCrossPlatformViews();
@@ -84,7 +97,7 @@ public partial class ImageCapture : ICameraUseCase
     private void ConstructCrossPlatformViews()
     {
         m_bottomToolbarView = [];
-        m_topToolbarView = new ImageCaptureTopToolbarView(m_cameraSession, OnCancelImageCaptureButtonTapped, OnFinishedImageCaptureButtonTapped);
+        m_topToolbarView = new ImageCaptureTopToolbarView(m_cameraSession, OnCancelImageCaptureButtonTapped);
         
         m_cameraPreview?.AddTopToolbarView(m_topToolbarView);
         m_cameraPreview?.AddBottomToolbarView(m_bottomToolbarView);
@@ -101,6 +114,8 @@ public partial class ImageCapture : ICameraUseCase
     /// </summary>
     private async Task SimulateCameraShutter(bool addActivityIndicator = true)
     {
+        OptimisticallyUpdateGalleryButton();
+
         var blackBox = new BoxView { BackgroundColor = Microsoft.Maui.Graphics.Colors.Black, Opacity = 0 };
 
         VibrationService.SelectionChanged();
@@ -121,8 +136,7 @@ public partial class ImageCapture : ICameraUseCase
     private void OnCancelImageCaptureButtonTapped()
     {
         m_cameraSession.CameraOptions.CancelButtonCommand?.Execute(null);
-        ResetAllVisuals();
-        PlatformStop();
+        Stop();
     }
     
     private void Log(string message)
@@ -137,7 +151,8 @@ public partial class ImageCapture : ICameraUseCase
         m_cameraPreview.RemoveViewFromRoot(m_activityIndicator);
         m_cameraPreview.RemoveViewFromRoot(m_keepCameraStillHint);
         m_cameraPreview.RemoveViewFromRoot(m_confirmImage);
-        
+        TearDownGalleryOverlay();
+
         if (m_cameraPreview.CameraZoomView != null)
         {
             m_cameraPreview.CameraZoomView.Opacity = 0;
@@ -153,8 +168,12 @@ public partial class ImageCapture : ICameraUseCase
         {
             CancelAnyActiveImageProcessing();
             PlatformStop();
+            TearDownGalleryOverlay();
             m_cameraPreview = null;
             m_onImageCapturedDelegate = null;
+            m_capturedImages.Clear();
+            m_capturedImagesGalleryButton = null;
+            m_isCapturing = false;
         }
         catch (Exception e)
         {
@@ -166,6 +185,7 @@ public partial class ImageCapture : ICameraUseCase
     {
         ResetAllVisuals();
         PlatformStop();
+        m_isCapturing = false;
     }
 
     private void OnPhotoCaptured(CapturedImage capturedImage)
@@ -173,11 +193,18 @@ public partial class ImageCapture : ICameraUseCase
         if (m_cameraSession is MultiCaptureSession { MultiImageCaptureOptions.RequiresConfirmationOnEachImage: false })
         {
             m_onImageCapturedDelegate?.Invoke(capturedImage);
+            AddImageAndUpdateImagePreview(capturedImage);
             ContinueInPreviewState();
             return;
         }
-            
+
         GoToConfirmState(capturedImage);
+    }
+
+    private void OnImageCaptureFailed(CameraException cameraException)
+    {
+        m_capturedImagesGalleryButton?.CancelPendingCapture(m_capturedImages);
+        PlatformOnCameraFailed(cameraException);
     }
 
     private void ContinueInPreviewState()
@@ -193,9 +220,8 @@ public partial class ImageCapture : ICameraUseCase
         {
             multiCaptureSession.MultiImageCaptureOptions.FinishedButtonCommand?.Execute(null);
         }
-        
-        ResetAllVisuals();
-        PlatformStop();
+
+        Stop();
     }
 
     private void CancelAnyActiveImageProcessing()

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/OnCapturedImageRemoved.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/OnCapturedImageRemoved.cs
@@ -1,0 +1,6 @@
+namespace DIPS.Mobile.UI.API.Camera.ImageCapturing;
+
+/// <summary>
+/// Invoked when the user removes an image from the in-camera gallery during a multi capture session.
+/// </summary>
+public delegate void OnCapturedImageRemoved(CapturedImage capturedImage);

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Settings/CameraOptions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Settings/CameraOptions.cs
@@ -47,8 +47,8 @@ public record MultiImageCaptureOptions
     /// <summary>
     /// Maximum amount of images the user is allowed to capture in one session. Captured images
     /// are held in-memory during a camera session, so this is also the safeguard that keeps memory bounded.
-    /// <remarks>Defaults to 15.</remarks>
     /// </summary>
+    /// <remarks>Defaults to 15.</remarks>
     public int MaxImageCount { get; init; } = 15;
 
     /// <summary>

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Settings/CameraOptions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Settings/CameraOptions.cs
@@ -43,6 +43,18 @@ public record MultiImageCaptureOptions
 
     /// <summary>Invoked when the user taps the finished button to confirm the captured images.</summary>
     public ICommand? FinishedButtonCommand { get; init; }
+
+    /// <summary>
+    /// Maximum amount of images the user is allowed to capture in one session. Captured images
+    /// are held in-memory during a camera session, so this is also the safeguard that keeps memory bounded.
+    /// <remarks>Defaults to 15.</remarks>
+    /// </summary>
+    public int MaxImageCount { get; init; } = 15;
+
+    /// <summary>
+    /// Invoked when the user removes an image from the in-camera gallery.
+    /// </summary>
+    public OnCapturedImageRemoved? OnImageRemoved { get; init; }
 }
 
 internal class CameraInfo

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/ButtonWithText.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/ButtonWithText.cs
@@ -10,6 +10,9 @@ public class ButtonWithText : VerticalStackLayout
 {
     public ButtonWithText(string text, ImageSource imageSource, Action? onTapped)
     {
+        ArgumentException.ThrowIfNullOrEmpty(text);
+        ArgumentNullException.ThrowIfNull(imageSource);
+
         var button = new Button
         {
             ImageSource = imageSource,
@@ -18,7 +21,7 @@ public class ButtonWithText : VerticalStackLayout
             Style = Styles.GetButtonStyle(ButtonStyle.GhostIconLarge),
             Command = new Command(onTapped)
         };
-        
+
         var label = new Label
         {
             Text = text,
@@ -27,7 +30,12 @@ public class ButtonWithText : VerticalStackLayout
             HorizontalOptions = LayoutOptions.Center,
             Margin = new Thickness(0, Sizes.GetSize(SizeName.content_margin_medium), 0, 0)
         };
-        
+
+        // The button shows only an icon, so screen readers have no name to read.
+        // Name the button with the caption, and stop the caption from being read again on its own.
+        SemanticProperties.SetDescription(button, text);
+        AutomationProperties.SetExcludedWithChildren(label, true);
+
         Add(button);
         Add(label);
     }

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/ImageCaptureBottomToolbarView.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/ImageCaptureBottomToolbarView.cs
@@ -21,11 +21,11 @@ internal class ImageCaptureBottomToolbarView : Grid
         });
     }
 
-    public void GoToStreamingState(IStreamingStateObserver streamingStateObserver)
+    public void GoToStreamingState(IStreamingStateObserver streamingStateObserver, StreamingTrailingControl trailingControl, View? leadingControl = null)
     {
         DisconnectHandlers(() =>
         {
-            Add(new StreamingStateView(streamingStateObserver));
+            Add(new StreamingStateView(streamingStateObserver, trailingControl, leadingControl));
         });
     }
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/Android/CapturedImagesGalleryButton.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/Android/CapturedImagesGalleryButton.cs
@@ -1,0 +1,72 @@
+using Android.Animation;
+using Android.Graphics;
+using View = Android.Views.View;
+
+namespace DIPS.Mobile.UI.API.Camera.ImageCapturing.Views.BottomToolbar.StreamingState;
+
+internal sealed partial class CapturedImagesGalleryButton
+{
+    private const float BlurRadius = 12f;
+    private const long BlurFadeDurationInMilliseconds = 200;
+
+    private ValueAnimator? m_blurAnimator;
+    private float m_currentBlurRadius;
+
+    private partial void SetThumbnailBlurred(bool shouldBlurThumbnail)
+    {
+        if (m_thumbnail.Handler?.PlatformView is not View nativeThumbnail)
+            return;
+        
+        var targetBlurRadius = shouldBlurThumbnail ? BlurRadius : 0f;
+        
+        AnimateBlurRadius(nativeThumbnail, targetBlurRadius);
+    }
+
+    private void AnimateBlurRadius(View nativeThumbnail, float targetRadius)
+    {
+        m_blurAnimator?.Cancel();
+
+        var startBlurRadius = m_currentBlurRadius;
+        
+        var animator = ValueAnimator.OfFloat(0f, 1f);
+
+        if (animator is null) return;
+        
+        animator.SetDuration(BlurFadeDurationInMilliseconds);
+        
+        animator.Update += (_, e) =>
+        {
+            var animatedFraction = e.Animation?.AnimatedFraction ?? 1f;
+
+            var fractionalBlurIncreaseOrDecrease = ((targetRadius - startBlurRadius) * animatedFraction);
+            
+            var blurRadius = startBlurRadius + fractionalBlurIncreaseOrDecrease;
+            
+            m_currentBlurRadius = blurRadius;
+            
+            nativeThumbnail.ApplyBlurRadius(blurRadius);
+        };
+        
+        animator.Start();
+
+        m_blurAnimator = animator;
+    }
+}
+
+internal static class AndroidImageFilterExtensions
+{
+    public static void ApplyBlurRadius(this View nativeThumbnail, float radius)
+    {
+        if (nativeThumbnail.Handle == IntPtr.Zero)
+            return;
+        
+        // Disable blur if radius is non-positive.
+        var blurEffect = radius <= 0f
+            ? null
+            : RenderEffect.CreateBlurEffect(radius, radius, Shader.TileMode.Clamp!);
+
+        nativeThumbnail.SetRenderEffect(blurEffect);
+    }
+}
+
+

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/CapturedImagesGalleryButton.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/CapturedImagesGalleryButton.cs
@@ -14,7 +14,7 @@ namespace DIPS.Mobile.UI.API.Camera.ImageCapturing.Views.BottomToolbar.Streaming
 /// </summary>
 internal sealed partial class CapturedImagesGalleryButton : Grid
 {
-    private const float ThumbnailSize = 48;
+    private static readonly double ThumbnailSize = Sizes.GetSize(SizeName.size_12);
 
     private readonly BoxView m_placeholder;
     private readonly Image m_thumbnail;
@@ -83,6 +83,11 @@ internal sealed partial class CapturedImagesGalleryButton : Grid
         Add(m_placeholder);
         Add(m_thumbnail);
         Add(m_countBadge);
+
+        // The children are decorative; keep focus on the container only.
+        AutomationProperties.SetExcludedWithChildren(m_placeholder, true);
+        AutomationProperties.SetExcludedWithChildren(m_thumbnail, true);
+        AutomationProperties.SetExcludedWithChildren(m_countBadge, true);
 
         this.RotateWithDeviceOrientation();
     }

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/CapturedImagesGalleryButton.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/CapturedImagesGalleryButton.cs
@@ -1,0 +1,169 @@
+using System.ComponentModel;
+using DIPS.Mobile.UI.Effects.Touch;
+using DIPS.Mobile.UI.Resources.Colors;
+using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
+using DIPS.Mobile.UI.Resources.Styles;
+using DIPS.Mobile.UI.Resources.Styles.Label;
+using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
+using Image = DIPS.Mobile.UI.Components.Images.Image.Image;
+
+namespace DIPS.Mobile.UI.API.Camera.ImageCapturing.Views.BottomToolbar.StreamingState;
+
+/// <summary>
+/// The most recently captured image, shown in the camera's bottom-left during multi capture. Tapping it opens the captured-images gallery.
+/// </summary>
+internal sealed partial class CapturedImagesGalleryButton : Grid
+{
+    private const float ThumbnailSize = 48;
+
+    private readonly BoxView m_placeholder;
+    private readonly Image m_thumbnail;
+    private readonly Label m_countLabel;
+    private readonly ContentView m_countBadge;
+    private readonly Action m_onTapped;
+
+    private bool m_isAwaitingCapturedImage;
+
+    public CapturedImagesGalleryButton(Action onTapped)
+    {
+        ArgumentNullException.ThrowIfNull(onTapped);
+
+        m_onTapped = onTapped;
+
+        IsVisible = false;
+        VerticalOptions = LayoutOptions.Center;
+        HorizontalOptions = LayoutOptions.Start;
+        WidthRequest = ThumbnailSize;
+        HeightRequest = ThumbnailSize;
+
+        m_placeholder = new BoxView
+        {
+            Color = Colors.GetColor(ColorName.color_palette_base_white, 0.2f),
+            CornerRadius = Sizes.GetSize(SizeName.radius_small),
+            WidthRequest = ThumbnailSize,
+            HeightRequest = ThumbnailSize
+        };
+
+        m_thumbnail = new Image
+        {
+            Aspect = Aspect.AspectFill,
+            Opacity = 0,
+            WidthRequest = ThumbnailSize,
+            HeightRequest = ThumbnailSize
+        };
+        UI.Effects.Layout.Layout.SetCornerRadius(m_thumbnail, Sizes.GetSize(SizeName.radius_small));
+        UI.Effects.Layout.Layout.SetStroke(m_thumbnail, Colors.GetColor(ColorName.color_palette_base_white, 0.15f));
+        UI.Effects.Layout.Layout.SetStrokeThickness(m_thumbnail, 1);
+        m_thumbnail.PropertyChanged += OnThumbnailPropertyChanged;
+
+        m_countLabel = new Label
+        {
+            TextColor = Colors.GetColor(ColorName.color_palette_base_white),
+            Style = Styles.GetLabelStyle(LabelStyle.UI100),
+            HorizontalOptions = LayoutOptions.Center,
+            VerticalOptions = LayoutOptions.Center
+        };
+
+        m_countBadge = new ContentView
+        {
+            Content = m_countLabel,
+            BackgroundColor = Colors.GetColor(ColorName.color_palette_base_black, 0.6f),
+            Padding = new Thickness(Sizes.GetSize(SizeName.content_margin_xsmall), 0),
+            MinimumWidthRequest = Sizes.GetSize(SizeName.size_5),
+            HeightRequest = Sizes.GetSize(SizeName.size_5),
+            HorizontalOptions = LayoutOptions.End,
+            VerticalOptions = LayoutOptions.Start,
+            Margin = new Thickness(0, -Sizes.GetSize(SizeName.content_margin_xsmall), -Sizes.GetSize(SizeName.content_margin_xsmall), 0)
+        };
+        UI.Effects.Layout.Layout.SetCornerRadius(m_countBadge, Sizes.GetSize(SizeName.size_5) / 2);
+
+        Touch.SetCommand(this, new Command(OnTapped));
+        SemanticProperties.SetDescription(this, DUILocalizedStrings.Accessibility_OpenCapturedImages);
+
+        Add(m_placeholder);
+        Add(m_thumbnail);
+        Add(m_countBadge);
+
+        this.RotateWithDeviceOrientation();
+    }
+
+    /// <summary>
+    /// Shows the button the moment the shutter fires, before the captured image is processed.
+    /// Bumps the count and blurs the previous thumbnail until the new one has decoded.
+    /// </summary>
+    public void ShowPendingCapture(int pendingImageCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pendingImageCount);
+
+        IsVisible = true;
+        m_countLabel.Text = pendingImageCount.ToString();
+        m_isAwaitingCapturedImage = true;
+
+        SetThumbnailBlurred(true);
+    }
+
+    /// <summary>
+    /// Rolls back the optimistic count and placeholder from <see cref="ShowPendingCapture" />.
+    /// </summary>
+    public void CancelPendingCapture(IReadOnlyList<CapturedImage> images)
+    {
+        ArgumentNullException.ThrowIfNull(images);
+
+        if (!m_isAwaitingCapturedImage)
+            return;
+
+        ShowMostRecentImageAndCount(images);
+    }
+
+    public void ShowMostRecentImageAndCount(IReadOnlyList<CapturedImage> images)
+    {
+        ArgumentNullException.ThrowIfNull(images);
+
+        var wasAwaitingCapturedImage = m_isAwaitingCapturedImage;
+        m_isAwaitingCapturedImage = false;
+
+        if (images.Count == 0)
+        {
+            SetThumbnailBlurred(false);
+            IsVisible = false;
+            return;
+        }
+
+        IsVisible = true;
+        
+        if (!wasAwaitingCapturedImage)
+            m_thumbnail.Opacity = 0;
+
+        var mostRecentImage = images[^1];
+        var thumbnailBytes = mostRecentImage.ThumbnailAsByteArray ?? mostRecentImage.AsByteArray;
+        m_thumbnail.Source = ImageSource.FromStream(() => new MemoryStream(thumbnailBytes));
+
+        m_countLabel.Text = images.Count.ToString();
+    }
+
+    private void OnTapped()
+    {
+        if (m_isAwaitingCapturedImage)
+            return;
+
+        m_onTapped();
+    }
+
+    private void OnThumbnailPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        var hasFinishedLoading =
+            e.PropertyName == Microsoft.Maui.Controls.Image.IsLoadingProperty.PropertyName && !m_thumbnail.IsLoading;
+        if (!hasFinishedLoading)
+            return;
+        
+        SetThumbnailBlurred(false);
+
+        if (m_thumbnail.Opacity < 1)
+            _ = m_thumbnail.FadeToAsync(1, 150);
+    }
+    
+    /// <summary>
+    /// Blurs the previous thumbnail natively while a new capture is in flight.
+    /// </summary>
+    private partial void SetThumbnailBlurred(bool isBlurred);
+}

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/FlashButton.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/FlashButton.cs
@@ -1,0 +1,40 @@
+using DIPS.Mobile.UI.API.Camera.ImageCapturing.Observers;
+using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
+using DIPS.Mobile.UI.Resources.Styles;
+using DIPS.Mobile.UI.Resources.Styles.Button;
+using Button = DIPS.Mobile.UI.Components.Buttons.Button;
+
+namespace DIPS.Mobile.UI.API.Camera.ImageCapturing.Views.BottomToolbar.StreamingState;
+
+internal sealed class FlashButton : Button
+{
+    private readonly IStreamingStateObserver m_streamingStateObserver;
+
+    public FlashButton(IStreamingStateObserver streamingStateObserver)
+    {
+        m_streamingStateObserver = streamingStateObserver;
+
+        Style = Styles.GetButtonStyle(ButtonStyle.GhostIconLarge);
+        ImageTintColor = Microsoft.Maui.Graphics.Colors.White;
+        VerticalOptions = LayoutOptions.Center;
+        Command = new Command(OnTapped);
+
+        UpdateFlashIcon();
+        SemanticProperties.SetDescription(this, DUILocalizedStrings.Accessability_TapToActivateFlash);
+
+        this.RotateWithDeviceOrientation();
+    }
+
+    private void OnTapped()
+    {
+        m_streamingStateObserver.OnTappedFlashButton();
+        UpdateFlashIcon();
+    }
+
+    private void UpdateFlashIcon()
+    {
+        ImageSource = m_streamingStateObserver.FlashActive
+            ? Icons.GetIcon(IconName.flash_line)
+            : Icons.GetIcon(IconName.flash_off_fill);
+    }
+}

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/StreamingStateView.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/StreamingStateView.cs
@@ -1,50 +1,42 @@
 using DIPS.Mobile.UI.API.Camera.ImageCapturing.Observers;
-using DIPS.Mobile.UI.API.Library;
-using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
-using DIPS.Mobile.UI.Resources.Styles;
-using DIPS.Mobile.UI.Resources.Styles.Button;
-using Button = DIPS.Mobile.UI.Components.Buttons.Button;
-using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
 
 namespace DIPS.Mobile.UI.API.Camera.ImageCapturing.Views.BottomToolbar.StreamingState;
 
 internal class StreamingStateView : Grid
 {
     private readonly ShutterButton m_shutterButton;
-    private readonly Button m_blitzButton;
 
-    public StreamingStateView(IStreamingStateObserver streamingStateObserver)
+    public StreamingStateView(IStreamingStateObserver streamingStateObserver, StreamingTrailingControl trailingControl, View? leadingControl = null)
     {
-        var isBlitzOn = streamingStateObserver.FlashActive;
-        
-        
         m_shutterButton = new ShutterButton(streamingStateObserver.OnTappedShutterButton);
-        m_blitzButton = new Button
+        Add(m_shutterButton);
+        
+        if (leadingControl is not null)
         {
-            Style = Styles.GetButtonStyle(ButtonStyle.GhostIconLarge),
-            ImageSource = isBlitzOn ? Icons.GetIcon(IconName.flash_line) : Icons.GetIcon(IconName.flash_off_fill),
-            ImageTintColor = Microsoft.Maui.Graphics.Colors.White,
+            Add(leadingControl);
+        }
+
+        View trailingView = trailingControl switch
+        {
+            StreamingTrailingControl.FinishCapture finishCapture => CreateFinishCaptureButton(finishCapture),
+            StreamingTrailingControl.Flash => new FlashButton(streamingStateObserver) { HorizontalOptions = LayoutOptions.End },
+            _ => throw new ArgumentOutOfRangeException(nameof(trailingControl), trailingControl, "Unknown streaming trailing control.")
+        };
+
+        Add(trailingView);
+    }
+
+    private static ButtonWithText CreateFinishCaptureButton(StreamingTrailingControl.FinishCapture finishCapture)
+    {
+        var finishButton = new ButtonWithText(finishCapture.Text, Icons.GetIcon(IconName.check_line), finishCapture.OnTapped)
+        {
             HorizontalOptions = LayoutOptions.End,
             VerticalOptions = LayoutOptions.Center
         };
-        SemanticProperties.SetDescription(m_blitzButton, DUILocalizedStrings.Accessability_TapToActivateFlash);
 
-        m_blitzButton.Command = new Command(() =>
-        {
-            isBlitzOn = !isBlitzOn;
-            streamingStateObserver.OnTappedFlashButton();
-            m_blitzButton.ImageSource = isBlitzOn ? Icons.GetIcon(IconName.flash_line) : Icons.GetIcon(IconName.flash_off_fill);
-        });
-        
-        Add(m_shutterButton);
-        Add(m_blitzButton);
-        
-        DUI.OrientationChanged += DUIOnOrientationChanged;
-    }
+        finishButton.RotateWithDeviceOrientation();
 
-    private void DUIOnOrientationChanged(OrientationDegree orientationDegree)
-    {
-        m_blitzButton.RotateTo(orientationDegree.OrientationDegreeToMauiRotation());
+        return finishButton;
     }
 
     public void SetShutterButtonEnabled(bool isEnabled)
@@ -57,16 +49,6 @@ internal class StreamingStateView : Grid
         else
         {
             m_shutterButton.Disable();
-        }
-    }
-
-    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
-    {
-        base.OnHandlerChanging(args);
-
-        if (args.NewHandler is null)
-        {
-            DUI.OrientationChanged -= DUIOnOrientationChanged;
         }
     }
 }

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/StreamingTrailingControl.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/StreamingTrailingControl.cs
@@ -1,0 +1,15 @@
+namespace DIPS.Mobile.UI.API.Camera.ImageCapturing.Views.BottomToolbar.StreamingState;
+
+/// <summary>
+/// The control shown next to the shutter in the streaming bottom bar.
+/// </summary>
+internal abstract record StreamingTrailingControl
+{
+    /// <summary>Flash on/off toggle. Used by single capture and multi capture with per-image confirmation.</summary>
+    internal sealed record Flash : StreamingTrailingControl;
+
+    /// <summary>
+    /// Finish button that ends the capture session.
+    /// </summary>
+    internal sealed record FinishCapture(string Text, Action OnTapped) : StreamingTrailingControl;
+}

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/dotnet/CapturedImagesGalleryButton.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/dotnet/CapturedImagesGalleryButton.cs
@@ -1,0 +1,8 @@
+namespace DIPS.Mobile.UI.API.Camera.ImageCapturing.Views.BottomToolbar.StreamingState;
+
+internal sealed partial class CapturedImagesGalleryButton
+{
+    private partial void SetThumbnailBlurred(bool shouldBlurThumbnail)
+    {
+    }
+}

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/iOS/CapturedImagesGalleryButton.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/iOS/CapturedImagesGalleryButton.cs
@@ -1,0 +1,102 @@
+using System.Runtime.InteropServices;
+using CoreImage;
+using DIPS.Mobile.UI.Internal.Logging;
+using UIKit;
+
+namespace DIPS.Mobile.UI.API.Camera.ImageCapturing.Views.BottomToolbar.StreamingState;
+
+internal sealed partial class CapturedImagesGalleryButton
+{
+    private const float BlurRadius = 220f;
+    private const double BlurFadeDurationInSeconds = 0.2;
+
+    private UIImageView? m_blurOverlay;
+
+    private partial void SetThumbnailBlurred(bool shouldBlurThumbnail)
+    {
+        try
+        {
+            if (shouldBlurThumbnail)
+            {
+                FadeBlurredThumbnailIn();
+            }
+            else
+            {
+                FadeBlurredThumbnailOut();
+            }
+        }
+        catch (Exception e)
+        {
+            DUILogService.LogError<CapturedImagesGalleryButton>(e.Message);
+        }
+    }
+
+    private void FadeBlurredThumbnailIn()
+    {
+        // The thumbnail's native view is not realized yet, so there is nothing to blur.
+        if (m_thumbnail.Handler?.PlatformView is not UIImageView nativeThumbnail)
+            return;
+        
+        // No previous image to blur, for example on the very first capture.
+        if (nativeThumbnail.Image?.CGImage is null)
+            return;
+
+        using var sourceImage = ConvertToCiImage(nativeThumbnail.Image);
+        
+        var blurredImage = sourceImage
+            .RegisterEdgeClampFilter()
+            .RegisterGaussianBlurFilter(BlurRadius)
+            .ApplyFilters(sourceImage.Extent);
+        
+        if (blurredImage is null)
+            return;
+
+        var blurredImageView = CreateBlurredOverlay(nativeThumbnail);
+
+        blurredImageView.Image = blurredImage;
+        blurredImageView.Frame = nativeThumbnail.Bounds;
+
+        UIView.Animate(BlurFadeDurationInSeconds, () => blurredImageView.Alpha = 1);
+    }
+
+    private void FadeBlurredThumbnailOut()
+    {
+        if (m_blurOverlay is null)
+            return;
+        
+        var blurOverlay = m_blurOverlay;
+        
+        UIView.Animate(BlurFadeDurationInSeconds, () => blurOverlay.Alpha = 0);
+    }
+
+    private UIImageView CreateBlurredOverlay(UIView nativeThumbnail)
+    {
+        if (m_blurOverlay is not null)
+            return m_blurOverlay;
+
+        var blurOverlay = new UIImageView
+        {
+            ContentMode = UIViewContentMode.ScaleAspectFill,
+            ClipsToBounds = true,
+            Alpha = 0,
+            AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight
+        };
+        
+        blurOverlay.Layer.CornerRadius = (NFloat)Sizes.GetSize(SizeName.radius_small);
+
+        nativeThumbnail.AddSubview(blurOverlay);
+        
+        m_blurOverlay = blurOverlay;
+        
+        return blurOverlay;
+    }
+
+    private static CIImage ConvertToCiImage(UIImage source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(source.CGImage);
+
+        var coreImageInput = new CIImage(source.CGImage);
+        return coreImageInput;
+    }
+}

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/iOS/CoreImageFilterExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/iOS/CoreImageFilterExtensions.cs
@@ -1,0 +1,70 @@
+using CoreGraphics;
+using CoreImage;
+using UIKit;
+
+namespace DIPS.Mobile.UI.API.Camera.ImageCapturing.Views.BottomToolbar.StreamingState;
+
+internal static class CoreImageFilterExtensions
+{
+    /// <summary>
+    /// Gaussian blur mixes each pixel with surrounding ones. At a photo's edge there is nothing outside to
+    /// mix with, so the edges will fade out. EdgeClamp repeats edge pixels outwards to fix this.
+    /// </summary>
+    /// <param name="image"></param>
+    /// <returns></returns>
+    public static CIImage RegisterEdgeClampFilter(this CIImage image)
+    {
+        ArgumentNullException.ThrowIfNull(image);
+        
+        using var edgeClampFilter = new CIAffineClamp();
+        
+        edgeClampFilter.InputImage = image;
+
+        var clampedImage = GetOutputImageFromFilter(edgeClampFilter);
+
+        return clampedImage;
+    }
+
+    public static CIImage RegisterGaussianBlurFilter(this CIImage image, float radius)
+    {
+        ArgumentNullException.ThrowIfNull(image);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(radius);
+
+        using var gaussianBlurFilter = new CIGaussianBlur();
+        
+        gaussianBlurFilter.InputImage = image;
+        gaussianBlurFilter.Radius = radius;
+
+        var blurredImage = GetOutputImageFromFilter(gaussianBlurFilter);
+
+        return blurredImage;
+    }
+
+    public static UIImage? ApplyFilters(this CIImage filteredImage, CGRect originalBounds)
+    {
+        ArgumentNullException.ThrowIfNull(filteredImage);
+
+        using var renderContext = CIContext.FromOptions(null);
+
+        // Crop back to original size to counteract any edge clamp filter.
+        using var renderedBitmap = renderContext.CreateCGImage(filteredImage, originalBounds);
+
+        if (renderedBitmap is null)
+            return null;
+
+        var imageWithFiltersApplied = UIImage.FromImage(renderedBitmap);
+        
+        return imageWithFiltersApplied;
+    }
+
+    private static CIImage GetOutputImageFromFilter(CIFilter filter)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        var outputImage = filter.OutputImage;
+        if (outputImage is null)
+            throw new InvalidOperationException($"{filter.GetType().Name} produced no output image.");
+
+        return outputImage;
+    }
+}

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/iOS/CoreImageFilterExtensions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/BottomToolbar/StreamingState/iOS/CoreImageFilterExtensions.cs
@@ -10,8 +10,8 @@ internal static class CoreImageFilterExtensions
     /// Gaussian blur mixes each pixel with surrounding ones. At a photo's edge there is nothing outside to
     /// mix with, so the edges will fade out. EdgeClamp repeats edge pixels outwards to fix this.
     /// </summary>
-    /// <param name="image"></param>
-    /// <returns></returns>
+    /// <param name="image">The input image.</param>
+    /// <returns>A clamped image suitable for subsequent blur filtering.</returns>
     public static CIImage RegisterEdgeClampFilter(this CIImage image)
     {
         ArgumentNullException.ThrowIfNull(image);

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/CameraZoom/ZoomButtons.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/CameraZoom/ZoomButtons.cs
@@ -1,4 +1,3 @@
-using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.Resources.Styles;
 using DIPS.Mobile.UI.Resources.Styles.Label;
 using Microsoft.Maui.Controls.Shapes;
@@ -44,9 +43,9 @@ internal class ZoomButtons : HorizontalStackLayout
         
         this.SizeChanged += OnSizeChanged;
         
-        DUI.OrientationChanged += OrientationChanged;
+        ApplyRotationBehaviorOnZoomButtons();
     }
-
+    
     private static List<float> CreateDefaultZoomRatios(float minRatio, float maxRatio)
     {
         var zoomRatios = new List<float>();
@@ -75,14 +74,11 @@ internal class ZoomButtons : HorizontalStackLayout
         }
     }
 
-    private void OrientationChanged(OrientationDegree orientationDegree)
+    private void ApplyRotationBehaviorOnZoomButtons()
     {
-        foreach (var child in Children)
+        foreach (var zoomButton in m_zoomButtons)
         {
-            if (child is View view)
-            {
-                view.RotateTo(orientationDegree.OrientationDegreeToMauiRotation());
-            }
+            zoomButton.RotateWithDeviceOrientation();
         }
     }
 
@@ -142,7 +138,6 @@ internal class ZoomButtons : HorizontalStackLayout
         if (args.NewHandler is not null)
             return;
         
-        DUI.OrientationChanged -= OrientationChanged;
         this.SizeChanged -= OnSizeChanged;
         
     }

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/CameraZoom/ZoomSlider.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/CameraZoom/ZoomSlider.cs
@@ -1,4 +1,3 @@
-using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.API.Vibration;
 using DIPS.Mobile.UI.Components.Slidable;
 using DIPS.Mobile.UI.Resources.Styles;
@@ -84,12 +83,7 @@ internal class ZoomSlider : Grid
         CreateZoomDisplayButton();
         
         m_zoomRatiosLayout.SizeChanged += ZoomRatiosLayoutOnSizeChanged;
-        DUI.OrientationChanged += OnOrientationChanged;
-    }
-
-    private void OnOrientationChanged(OrientationDegree orientationDegree)
-    {
-        m_zoomRatioLevelLabel.RotateTo(orientationDegree.OrientationDegreeToMauiRotation());
+        m_zoomRatioLevelLabel.RotateWithDeviceOrientation();
     }
 
     public void FadeTo(float opacity)
@@ -327,7 +321,6 @@ internal class ZoomSlider : Grid
             return;
 
         m_zoomRatiosLayout.SizeChanged -= ZoomRatiosLayoutOnSizeChanged;
-        DUI.OrientationChanged -= OnOrientationChanged;
         m_cancellationTokenSource.Cancel();
     }
 }

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/CapturedImagesGalleryOverlay.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/CapturedImagesGalleryOverlay.cs
@@ -1,0 +1,141 @@
+using System.Collections.ObjectModel;
+using DIPS.Mobile.UI.API.Camera.ImageCapturing.Views.BottomToolbar;
+using DIPS.Mobile.UI.Components.Alerting.Dialog;
+using DIPS.Mobile.UI.Internal.Logging;
+using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
+using DIPS.Mobile.UI.Resources.Styles;
+using DIPS.Mobile.UI.Resources.Styles.Label;
+using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
+
+namespace DIPS.Mobile.UI.API.Camera.ImageCapturing.Views;
+
+/// <summary>
+/// The in-camera gallery for multi capture.
+/// </summary>
+internal sealed class CapturedImagesGalleryOverlay : Grid
+{
+    private readonly ObservableCollection<ImageSource> m_imageSources;
+    private readonly Action<int> m_onRemoveImageAtAction;
+    private readonly Components.Gallery.Gallery m_gallery;
+    private readonly Label m_emptyStateLabel;
+    private readonly ButtonWithText m_removeButton;
+
+    private bool m_hasAnimatedIn;
+
+    public CapturedImagesGalleryOverlay(IReadOnlyList<CapturedImage> images, int startingIndex, Action<int> onRemoveImageAtAction, Action onCloseAction)
+    {
+        ArgumentNullException.ThrowIfNull(images);
+        ArgumentNullException.ThrowIfNull(onRemoveImageAtAction);
+        ArgumentNullException.ThrowIfNull(onCloseAction);
+        if (images.Count == 0)
+            throw new ArgumentException("The captured-images gallery needs at least one image to open.", nameof(images));
+
+        m_onRemoveImageAtAction = onRemoveImageAtAction;
+
+        BackgroundColor = Colors.GetColor(ColorName.color_palette_base_black);
+        
+        Opacity = 0;
+
+        m_imageSources = new ObservableCollection<ImageSource>(images.Select(ToImageSource));
+
+        m_gallery = new Components.Gallery.Gallery
+        {
+            CurrentImageIndex = startingIndex,
+            Images = m_imageSources,
+            FadeOutOnZoom = true
+        };
+
+        m_emptyStateLabel = new Label
+        {
+            Text = DUILocalizedStrings.NoCapturedImages,
+            TextColor = Colors.GetColor(ColorName.color_palette_base_white),
+            Style = Styles.GetLabelStyle(LabelStyle.Body300),
+            HorizontalOptions = LayoutOptions.Center,
+            VerticalOptions = LayoutOptions.Center,
+            IsVisible = false
+        };
+
+        m_removeButton = new ButtonWithText(DUILocalizedStrings.Delete, Icons.GetIcon(IconName.delete_line), OnRemoveImageTapped)
+        {
+            VerticalOptions = LayoutOptions.End,
+            HorizontalOptions = LayoutOptions.Start
+        };
+
+        var doneButton = new ButtonWithText(DUILocalizedStrings.Done, Icons.GetIcon(IconName.check_line), onCloseAction)
+        {
+            VerticalOptions = LayoutOptions.End,
+            HorizontalOptions = LayoutOptions.End
+        };
+
+        var bottomToolbar = new Grid
+        {
+            VerticalOptions = LayoutOptions.End,
+            Margin = new Thickness(Sizes.GetSize(SizeName.size_5), 0, Sizes.GetSize(SizeName.size_5), Sizes.GetSize(SizeName.size_5)),
+            Children = { m_removeButton, doneButton }
+        };
+
+        Add(m_gallery);
+        Add(m_emptyStateLabel);
+        Add(bottomToolbar);
+    }
+
+    protected override void OnHandlerChanged()
+    {
+        base.OnHandlerChanged();
+
+        if (Handler is null || m_hasAnimatedIn)
+            return;
+        
+        m_hasAnimatedIn = true;
+        
+        _ = this.FadeToAsync(1, 150);
+    }
+
+    public async Task FadeOutAsync()
+    {
+        await this.FadeToAsync(0, 150);
+    }
+
+    private async void OnRemoveImageTapped()
+    {
+        var index = m_gallery.CurrentImageIndex;
+        if (index < 0 || index >= m_imageSources.Count)
+            return;
+
+        try
+        {
+            var dialogResult = await DialogService.ShowMessage(configurator => configurator
+                .SetTitle(DUILocalizedStrings.RemoveImageTitle)
+                .SetDescription(DUILocalizedStrings.RemoveImageDescription)
+                .SetActionTitle(DUILocalizedStrings.Remove)
+                .SetCancelTitle(DUILocalizedStrings.Cancel)
+                .SetDestructive());
+
+            if (dialogResult == DialogAction.Closed)
+                return;
+
+            m_imageSources.RemoveAt(index);
+            m_onRemoveImageAtAction(index);
+
+            if (m_imageSources.Count == 0)
+                ShowEmptyState();
+        }
+        catch (Exception e)
+        {
+            DUILogService.LogError<CapturedImagesGalleryOverlay>(e.Message);
+        }
+    }
+
+    private void ShowEmptyState()
+    {
+        m_gallery.IsVisible = false;
+        m_removeButton.IsVisible = false;
+        m_emptyStateLabel.IsVisible = true;
+    }
+
+    private static ImageSource ToImageSource(CapturedImage capturedImage)
+    {
+        var imageBytes = capturedImage.AsByteArray;
+        return ImageSource.FromStream(() => new MemoryStream(imageBytes));
+    }
+}

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/RotateWithDeviceOrientation.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/RotateWithDeviceOrientation.cs
@@ -1,0 +1,32 @@
+using DIPS.Mobile.UI.API.Library;
+
+namespace DIPS.Mobile.UI.API.Camera.ImageCapturing.Views;
+
+internal static class RotateWithDeviceOrientationExtension
+{
+    /// <summary>
+    /// Keeps a control upright when the device turns.
+    /// Stops and unsubscribes once the control leaves the screen.
+    /// </summary>
+    public static void RotateWithDeviceOrientation(this VisualElement view)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+
+        void RotateToOrientation(OrientationDegree orientationDegree)
+        {
+            _ = view.RotateTo(orientationDegree.OrientationDegreeToMauiRotation());
+        }
+
+        void StopRotatingWhenRemovedFromScreen(object? sender, HandlerChangingEventArgs args)
+        {
+            if (args.NewHandler is not null)
+                return;
+
+            DUI.OrientationChanged -= RotateToOrientation;
+            view.HandlerChanging -= StopRotatingWhenRemovedFromScreen;
+        }
+
+        DUI.OrientationChanged += RotateToOrientation;
+        view.HandlerChanging += StopRotatingWhenRemovedFromScreen;
+    }
+}

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/TopToolbar/ImageCaptureTopToolbarView.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/TopToolbar/ImageCaptureTopToolbarView.cs
@@ -1,6 +1,7 @@
 using DIPS.Mobile.UI.API.Camera.ImageCapturing.BottomSheets;
 using DIPS.Mobile.UI.API.Camera.ImageCapturing.Observers;
 using DIPS.Mobile.UI.API.Camera.ImageCapturing.Settings;
+using DIPS.Mobile.UI.API.Camera.ImageCapturing.Views.BottomToolbar.StreamingState;
 using DIPS.Mobile.UI.API.Camera.Shared;
 using DIPS.Mobile.UI.API.Library;
 using DIPS.Mobile.UI.MemoryManagement;
@@ -21,26 +22,22 @@ internal class ImageCaptureTopToolbarView : Grid
     private Button? m_settingsButton;
     private Button? m_infoButton;
     private Button? m_editButton;
-    private Button? m_finishedButton;
 
     private OrientationDegree m_currentOrientationDegree;
 
     private bool m_isConfirmState;
 
-    public ImageCaptureTopToolbarView(CaptureSession captureSession, Action onCancelButtonTapped, Action onFinishedButtonTapped)
+    public ImageCaptureTopToolbarView(CaptureSession captureSession, Action onCancelButtonTapped)
     {
         m_captureSession = captureSession;
-
-        var multiCaptureSession = captureSession as MultiCaptureSession;
-        var isMultiMode = multiCaptureSession is not null;
-
+        
         m_doneButton = new Button
         {
             Style = Styles.GetButtonStyle(ButtonStyle.GhostLarge),
             Text = captureSession.CameraOptions.CancelButtonText,
             TextColor = Colors.White,
             VerticalOptions = LayoutOptions.Center,
-            HorizontalOptions = isMultiMode ? LayoutOptions.Start : LayoutOptions.End,
+            HorizontalOptions = LayoutOptions.End,
             Command = new Command(onCancelButtonTapped)
         };
 
@@ -54,22 +51,6 @@ internal class ImageCaptureTopToolbarView : Grid
         Add(m_doneButton);
         Add(m_upperLeftColumn);
 
-        if (multiCaptureSession is not null)
-        {
-            var finishedButtonText = multiCaptureSession.MultiImageCaptureOptions.FinishedButtonText;
-            m_finishedButton = new Button
-            {
-                Style = Styles.GetButtonStyle(ButtonStyle.GhostLarge),
-                Text = !string.IsNullOrEmpty(finishedButtonText) ? finishedButtonText : DUILocalizedStrings.Done,
-                TextColor = Colors.White,
-                VerticalOptions = LayoutOptions.Center,
-                HorizontalOptions = LayoutOptions.End,
-                Command = new Command(onFinishedButtonTapped)
-            };
-
-            Add(m_finishedButton);
-        }
-
         DUI.OrientationChanged += OnOrientationChanged;
     }
 
@@ -78,7 +59,6 @@ internal class ImageCaptureTopToolbarView : Grid
         if (!m_isConfirmState)
         {
             m_doneButton.RotateTo(orientationDegree.OrientationDegreeToMauiRotation());
-            m_finishedButton?.RotateTo(orientationDegree.OrientationDegreeToMauiRotation());
             m_settingsButton?.RotateTo(orientationDegree.OrientationDegreeToMauiRotation());
         }
 
@@ -161,6 +141,10 @@ internal class ImageCaptureTopToolbarView : Grid
             {
                 new ImageCaptureSettingsBottomSheet(m_captureSession.CameraOptions, streamingStateObserver.OnSettingsChanged).Open();
             });
+        }
+        else if (m_captureSession is MultiCaptureSession)
+        {
+            m_upperLeftColumn.Add(new FlashButton(streamingStateObserver));
         }
     }
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/iOS/ImageCapture.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/iOS/ImageCapture.cs
@@ -28,9 +28,9 @@ public partial class ImageCapture : CameraSession
     private partial Task PlatformStop()
     {
         m_capturePhotoOutput = null;
-        m_photoCaptureDelegate?.Dispose();
+        m_photoCaptureDelegate?.IgnoreRemainingCallbacks();
         m_photoCaptureDelegate = null;
-        
+
         return base.StopCameraSession();
     }
 
@@ -58,8 +58,8 @@ public partial class ImageCapture : CameraSession
     private void PhotoCaptured(AVCapturePhoto photo)
     {
         m_isProcessingPhoto = false;
-        
-        m_photoCaptureDelegate?.Dispose();
+
+        m_photoCaptureDelegate?.IgnoreRemainingCallbacks();
         m_photoCaptureDelegate = null;
 
         try
@@ -83,7 +83,7 @@ public partial class ImageCapture : CameraSession
         }
         catch (Exception e)
         {
-            PlatformOnCameraFailed(new CameraException("PhotoCaptured", e));
+            OnImageCaptureFailed(new CameraException("PhotoCaptured", e));
         }
     }
 
@@ -111,7 +111,7 @@ public partial class ImageCapture : CameraSession
             return;
         }
         
-        m_photoCaptureDelegate = new PhotoCaptureDelegate(PhotoCaptured, PlatformOnCameraFailed, () =>
+        m_photoCaptureDelegate = new PhotoCaptureDelegate(PhotoCaptured, OnImageCaptureFailed, () =>
         {
             m_isProcessingPhoto = true;
             _ = SimulateCameraShutter();
@@ -149,6 +149,11 @@ public partial class ImageCapture : CameraSession
 #pragma warning disable CA1422
     private AVCapturePhotoSettings? CreateSettings()
     {
+        // The camera can be stopped while a capture is being set up, for example when the user leaves
+        // the page.
+        if (m_capturePhotoOutput is null)
+            return null;
+
         var formatKey = AVVideo.CodecKey;
         NSObject? formatValue = null;
         if (m_capturePhotoOutput.AvailablePhotoCodecTypes.Contains(AVVideo.CodecJPEG))
@@ -179,15 +184,15 @@ public partial class ImageCapture : CameraSession
 
 internal class PhotoCaptureDelegate(Action<AVCapturePhoto> onPhotoCaptured, Action<CameraException> onPhotoCaptureFailed, Action onBeforeCapture) : AVCapturePhotoCaptureDelegate
 {
-    private Action<CameraException> m_onPhotoCaptureFailed = onPhotoCaptureFailed;
-    private Action<AVCapturePhoto> m_onPhotoCaptured = onPhotoCaptured;
-    private Action m_onBeforeCapture = onBeforeCapture;
+    private Action<CameraException>? m_onPhotoCaptureFailed = onPhotoCaptureFailed;
+    private Action<AVCapturePhoto>? m_onPhotoCaptured = onPhotoCaptured;
+    private Action? m_onBeforeCapture = onBeforeCapture;
 
     public override void WillBeginCapture(AVCapturePhotoOutput captureOutput, AVCaptureResolvedPhotoSettings resolvedSettings)
     {
         Console.WriteLine("--- WillBeginCapture --- | " + captureOutput + "|" + resolvedSettings);
-        
-        m_onBeforeCapture.Invoke();
+
+        m_onBeforeCapture?.Invoke();
     }
 
     public override void DidFinishCapture(AVCapturePhotoOutput captureOutput,
@@ -208,17 +213,21 @@ internal class PhotoCaptureDelegate(Action<AVCapturePhoto> onPhotoCaptured, Acti
         
         if (error != null)
         {
-            m_onPhotoCaptureFailed.Invoke(new CameraException("iOS: DidFinishProcessingPhoto", new Exception(error.ToExceptionMessage()), error.LocalizedDescription, error.LocalizedRecoverySuggestion));
+            m_onPhotoCaptureFailed?.Invoke(new CameraException("iOS: DidFinishProcessingPhoto", new Exception(error.ToExceptionMessage()), error.LocalizedDescription, error.LocalizedRecoverySuggestion));
         }
-        m_onPhotoCaptured.Invoke(photo);
+        m_onPhotoCaptured?.Invoke(photo);
+    }
+    
+    internal void IgnoreRemainingCallbacks()
+    {
+        m_onPhotoCaptureFailed = null;
+        m_onPhotoCaptured = null;
+        m_onBeforeCapture = null;
     }
 
     protected override void Dispose(bool disposing)
     {
+        IgnoreRemainingCallbacks();
         base.Dispose(disposing);
-
-        m_onPhotoCaptureFailed = null!;
-        m_onPhotoCaptured = null!;
-        m_onBeforeCapture = null!;
     }
 }

--- a/src/library/DIPS.Mobile.UI/API/Camera/Preview/CameraPreview.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Preview/CameraPreview.cs
@@ -319,6 +319,14 @@ public partial class CameraPreview : ContentView
         PreviewView.IsVisible = false;
     }
 
+    /// <summary>
+    /// Shows the camera preview again after <see cref="HidePreview"/>.
+    /// </summary>
+    internal void ShowPreview()
+    {
+        PreviewView.IsVisible = true;
+    }
+
     public void GoToStreamingState()
     {
         PreviewView.IsVisible = true;

--- a/src/library/DIPS.Mobile.UI/Components/Gallery/Gallery.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Gallery/Gallery.cs
@@ -18,18 +18,27 @@ public partial class Gallery : Grid
     private readonly ContentView m_borderAroundNumberOfImages;
     private readonly Button? m_navigateNextImageButton;
     private readonly Button? m_navigatePreviousImageButton;
-    
+
     private bool m_isAnyImageZoomed;
-    
+    private int m_indexToRevealOnSettle = -1;
+
     private INotifyCollectionChanged? m_previousCollection;
 
     public Gallery()
     {
         BackgroundColor = Colors.Black;
 
-        var carouselView = new CarouselView.CarouselView { HorizontalScrollBarVisibility = ScrollBarVisibility.Never };
-        carouselView.SetBinding(ItemsView.ItemsSourceProperty, static (Gallery gallery) => gallery.Images, source: this);
+        var carouselView = new CarouselView.CarouselView
+        {
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Never,
+            // CarouselView's default behavior scrolls back to the first image whenever the image
+            // collection changes, so removing any image but the first would jump the view to the
+            // start. KeepScrollOffset avoids this by staying at the same position.
+            ItemsUpdatingScrollMode = ItemsUpdatingScrollMode.KeepScrollOffset
+        };
         
+        carouselView.SetBinding(ItemsView.ItemsSourceProperty, static (Gallery gallery) => gallery.Images, source: this);
+
         carouselView.ItemTemplate = new DataTemplate(() =>
         {
             var zoomContainer = new PanZoomContainer.PanZoomContainer();
@@ -37,9 +46,10 @@ public partial class Gallery : Grid
             zoomContainer.PropertyChanged += OnZoomContainerPropertyChanged;
             return zoomContainer;
         });
-        
+
         carouselView.Loop = false;
         carouselView.PeekAreaInsets = new Thickness(0);
+        carouselView.PositionChanged += OnCarouselViewPositionChanged;
         AutomationProperties.SetExcludedWithChildren(carouselView, true);
         this.SetBinding(CurrentImageIndexProperty, static (CarouselView.CarouselView carouselView) => carouselView.Position, source: carouselView, mode: BindingMode.TwoWay);
         
@@ -114,8 +124,48 @@ public partial class Gallery : Grid
     {
         base.OnHandlerChanged();
 
+        HideUntilCarouselSettlesOnInitialImage();
         UpdateNavigationButtonsVisibility();
         AnnounceCurrentImage();
+    }
+
+    private void HideUntilCarouselSettlesOnInitialImage()
+    {
+        // On initial load, CarouselView renders the image on index 0 before changing to an image on a non-zero index,
+        // leading to a short flash of the first image.
+        // To fix this, we hide the whole gallery until the carousel reports it has reached the target, then fade it in.
+        if (Handler is null || CurrentImageIndex <= 0)
+            return;
+
+        m_indexToRevealOnSettle = CurrentImageIndex;
+        
+        Opacity = 0;
+        
+        _ = RevealAfterSettleTimeout();
+    }
+
+    private void OnCarouselViewPositionChanged(object? sender, PositionChangedEventArgs e)
+    {
+        if (m_indexToRevealOnSettle < 0 || e.CurrentPosition != m_indexToRevealOnSettle)
+            return;
+
+        FadeGalleryIn();
+    }
+
+    private async Task RevealAfterSettleTimeout()
+    {
+        await Task.Delay(250);
+        
+        FadeGalleryIn();
+    }
+
+    private void FadeGalleryIn()
+    {
+        if (m_indexToRevealOnSettle < 0)
+            return;
+
+        m_indexToRevealOnSettle = -1;
+        _ = this.FadeToAsync(1, 150);
     }
 
     private void AnnounceCurrentImage()

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.Designer.cs
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.Designer.cs
@@ -303,6 +303,36 @@ namespace DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings {
             }
         }
         
+        internal static string Ok {
+            get {
+                return ResourceManager.GetString("Ok", resourceCulture);
+            }
+        }
+        
+        internal static string MaxImagesReachedTitle {
+            get {
+                return ResourceManager.GetString("MaxImagesReachedTitle", resourceCulture);
+            }
+        }
+        
+        internal static string MaxImagesReachedMessage {
+            get {
+                return ResourceManager.GetString("MaxImagesReachedMessage", resourceCulture);
+            }
+        }
+        
+        internal static string NoCapturedImages {
+            get {
+                return ResourceManager.GetString("NoCapturedImages", resourceCulture);
+            }
+        }
+        
+        internal static string Accessibility_OpenCapturedImages {
+            get {
+                return ResourceManager.GetString("Accessibility_OpenCapturedImages", resourceCulture);
+            }
+        }
+        
         internal static string RemoveImageDescription {
             get {
                 return ResourceManager.GetString("RemoveImageDescription", resourceCulture);
@@ -584,7 +614,7 @@ namespace DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings {
                 return ResourceManager.GetString("Of", resourceCulture);
             }
         }
-
+        
         internal static string BarcodeScanProgress {
             get {
                 return ResourceManager.GetString("BarcodeScanProgress", resourceCulture);

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.en.resx
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.en.resx
@@ -143,6 +143,21 @@
     <data name="RemoveImageTitle" xml:space="preserve">
         <value>Remove image</value>
     </data>
+    <data name="Ok" xml:space="preserve">
+        <value>OK</value>
+    </data>
+    <data name="MaxImagesReachedTitle" xml:space="preserve">
+        <value>Maximum number of images reached</value>
+    </data>
+    <data name="MaxImagesReachedMessage" xml:space="preserve">
+        <value>You can add a maximum of {0} images.</value>
+    </data>
+    <data name="NoCapturedImages" xml:space="preserve">
+        <value>No images</value>
+    </data>
+    <data name="Accessibility_OpenCapturedImages" xml:space="preserve">
+        <value>Open the image gallery</value>
+    </data>
     <data name="RemoveImageDescription" xml:space="preserve">
         <value>Do you want to remove the image?</value>
     </data>

--- a/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.resx
+++ b/src/library/DIPS.Mobile.UI/Resources/LocalizedStrings/LocalizedStrings/DUILocalizedStrings.resx
@@ -147,6 +147,21 @@
     <data name="RemoveImageTitle" xml:space="preserve">
         <value>Fjern bilde</value>
     </data>
+    <data name="Ok" xml:space="preserve">
+        <value>OK</value>
+    </data>
+    <data name="MaxImagesReachedTitle" xml:space="preserve">
+        <value>Maks antall bilder nådd</value>
+    </data>
+    <data name="MaxImagesReachedMessage" xml:space="preserve">
+        <value>Du kan legge til maksimalt {0} bilder.</value>
+    </data>
+    <data name="NoCapturedImages" xml:space="preserve">
+        <value>Ingen bilder</value>
+    </data>
+    <data name="Accessibility_OpenCapturedImages" xml:space="preserve">
+        <value>Åpne bildegalleriet</value>
+    </data>
     <data name="RemoveImageDescription" xml:space="preserve">
         <value>Vil du fjerne bildet?</value>
     </data>

--- a/wiki/Media/ImageCapture.md
+++ b/wiki/Media/ImageCapture.md
@@ -3,7 +3,7 @@
 The `ImageCapture` component lets you capture images using the device's camera. It supports two modes:
 
 - **Single image:** the user takes one photo, confirms it, and the camera closes.
-- **Multiple images:** the user takes several photos in one session, and the session ends when they tap the finish button.
+- **Multiple images:** the user takes several photos in one session and ends the session with the finish button. Per-image confirmation is optional. The user can also optionally review and/or delete the photos in a gallery view before ending the session.
 
 ## Setup
 
@@ -20,7 +20,7 @@ private readonly List<CapturedImage> m_images = [];
 private readonly ImageCapture m_imageCapture = new();
 ```
 
-> We recommend starting the camera in `OnAppearing`.
+> We recommend starting the camera in `OnHandlerChanged`.
 
 > **NOTE:** On iOS, devices with ultra-wide cameras can use the ultra-wide lens through the shared zoom controls while starting the preview in normal wide framing. On those devices, the zoom controls can show `0.5x` for the ultra-wide lens.
 
@@ -60,7 +60,9 @@ private async Task StartMultiImageCapture()
     var multiOptions = new MultiImageCaptureOptions
     {
         RequiresConfirmationOnEachImage = false,
+        MaxImageCount = 10,
         FinishedButtonCommand = new Command(OnFinished),
+        OnImageRemoved = OnImageRemoved,
     };
 
     await m_imageCapture.StartMultiImageCapture(
@@ -74,7 +76,24 @@ private async Task StartMultiImageCapture()
 - **`false`** (default): each image is delivered to your delegate as soon as it is captured, and the camera stays ready for the next shot. Faster for batch capture.
 - **`true`**: each image first goes through the confirm screen. The delegate fires only after the user accepts it.
 
-`FinishedButtonCommand` is invoked when the user taps the finish button in the top toolbar. Use it to close the page or commit the captured list.
+`MaxImageCount` caps how many photos one session can hold. It defaults to 15 and must be greater than zero. Captured photos stay in memory for the whole session, so this cap is what keeps memory bounded. When the user reaches the cap, the camera shows a message and ignores the shutter until they remove a photo.
+
+`FinishedButtonCommand` runs when the user taps the finish button. The finish button sits next to the shutter at the bottom of the screen, and its label defaults to "Done". Use this command to close the page or commit the captured list.
+
+## Reviewing and removing photos
+
+During multi-capture, a thumbnail of the most recent photo appears in the bottom-left corner of the camera, with a badge showing how many photos the session holds. The thumbnail updates after every shot.
+
+Tapping the thumbnail opens a full-screen gallery. The user can swipe through every photo taken so far. The Delete button removes the photo on screen after a confirmation prompt. The Done button closes the gallery and returns to the camera.
+
+When the user deletes a photo in the gallery, `OnImageRemoved` fires with that `CapturedImage`. Handle it to keep your own list matched to what the user kept:
+
+```csharp
+private void OnImageRemoved(CapturedImage capturedImage)
+{
+    m_images.Remove(capturedImage);
+}
+```
 
 ## Handling captured images
 
@@ -85,7 +104,7 @@ private void OnImageCaptured(CapturedImage capturedImage)
 }
 ```
 
-In multi-capture this method is called once per image, in capture order.
+In multi-capture this method is called once per image, in capture order. Pair it with `OnImageRemoved` so your list reflects every add and every removal the user makes.
 
 ## Handling camera failures
 
@@ -98,12 +117,20 @@ private void OnCameraFailed(CameraException e)
 
 ## Closing the camera
 
-Tapping the cancel button closes the camera and invokes `CancelButtonCommand` if you set one. Capturing an image in single mode also closes the camera. If you are not using our automatic memory leak tooling, stop the camera explicitly when the user navigates away:
+Tapping the cancel button closes the camera and invokes `CancelButtonCommand` if you set one. Capturing an image in single mode also closes the camera. If you are not using our automatic memory leak tooling, stop the camera explicitly when the user leaves the page:
 
 ```csharp
-protected override void OnDisappearing()
+protected override void OnHandlerChanging(HandlerChangingEventArgs args)
 {
-    base.OnDisappearing();
+    base.OnHandlerChanging(args);
+
+    if (args.NewHandler is not null)
+        return;
+
     m_imageCapture.Stop();
 }
 ```
+
+Use `OnHandlerChanging` rather than `OnDisappearing`. A null new handler means the page itself is being removed, so the camera stops only then. `OnDisappearing` also fires when a sheet or dialog covers the page, which would stop the camera while the user is still capturing.
+</content>
+</invoke>


### PR DESCRIPTION
### Description of Change

- [ImageCapture] When taking several photos in a row, the most recent photo now shows as a thumbnail in the bottom-left corner of the camera and updates with each capture. The thumbnail can be tapped to review and/or remove photos from the capture session.
- [ImageCapture] Added MaxImageCount with a default of 15 when using MultiImageCapture to avoid crash as images are stored in-memory only.
- [Gallery] Fixed issue where gallery always reset to the first image when the collection changed.

### Todos
- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->