### PR TITLE
Improve iOS barcode close focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [60.2.12]
-- [BarcodeScanner][iOS] Improved close-range barcode scanning on devices with ultra-wide cameras and updated zoom controls to show `0.5x` when available.
+- [Camera][iOS] Added ultra-wide capable back camera selection and zoom mapping for barcode scanning and image capture on supported devices.
 
 ## [60.2.11]
 - [CollectionView][Android] Fixed crash when deferred item decoration updates ran after the RecyclerView was detached during list reloads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [60.2.12]
+- [BarcodeScanner][iOS] Improved close-range barcode scanning on devices with ultra-wide cameras and updated zoom controls to show `0.5x` when available.
+
 ## [60.2.11]
 - [CollectionView][Android] Fixed crash when deferred item decoration updates ran after the RecyclerView was detached during list reloads.
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/iOS/BarcodeScanner.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/iOS/BarcodeScanner.cs
@@ -9,7 +9,6 @@ public partial class BarcodeScanner : CameraSession
     //The rectangle that people see in the preview which we will focus on scanning bar codes in
     private AVCaptureMetadataOutput? m_captureMetadataOutput;
     private double m_rectOfInterestWidth;
-    private bool m_shouldStartAtWideConstituent;
 
     private readonly DispatchQueue m_metadataObjectsQueue = new(label: "metadata objects queue", attributes: new(), target: null);
     
@@ -81,88 +80,11 @@ public partial class BarcodeScanner : CameraSession
         {
             PreviewView.TryAddOrUpdateRectOfInterest();
         }
-        SetInitialWideConstituentZoomFactor();
         SetRecommendedZoomFactor();
     }
 
     // Prefer virtual back cameras so iOS starts at normal 1x wide framing but can switch to macro-capable lenses when close.
-    public override AVCaptureDevice? SelectCaptureDevice()
-    {
-        m_shouldStartAtWideConstituent = false;
-
-        return TryGetCaptureDevice(AVCaptureDeviceType.BuiltInTripleCamera, shouldStartAtWideConstituent: true) ??
-               TryGetCaptureDevice(AVCaptureDeviceType.BuiltInDualWideCamera, shouldStartAtWideConstituent: true) ??
-               TryGetCaptureDevice(AVCaptureDeviceType.BuiltInDualCamera, shouldStartAtWideConstituent: false) ??
-               TryGetCaptureDevice(AVCaptureDeviceType.BuiltInWideAngleCamera, shouldStartAtWideConstituent: false);
-    }
-
-    private AVCaptureDevice? TryGetCaptureDevice(AVCaptureDeviceType deviceType, bool shouldStartAtWideConstituent)
-    {
-        var captureDevice = AVCaptureDevice.GetDefaultDevice(deviceType, AVMediaTypes.Video, AVCaptureDevicePosition.Back);
-        if (captureDevice is null)
-        {
-            return null;
-        }
-
-        m_shouldStartAtWideConstituent = shouldStartAtWideConstituent;
-        return captureDevice;
-    }
-
-    private void SetInitialWideConstituentZoomFactor()
-    {
-        if (!m_shouldStartAtWideConstituent || CaptureDevice is null)
-        {
-            return;
-        }
-
-        var wideConstituentZoomFactor = GetWideConstituentZoomFactor();
-        if (wideConstituentZoomFactor is null)
-        {
-            return;
-        }
-
-        if (!CaptureDevice.LockForConfiguration(out var error))
-        {
-            if (error != null)
-            {
-                throw new Exception(error.ToString());
-            }
-
-            return;
-        }
-
-        try
-        {
-            CaptureDevice.VideoZoomFactor = wideConstituentZoomFactor.Value;
-        }
-        finally
-        {
-            CaptureDevice.UnlockForConfiguration();
-        }
-    }
-
-    protected override float ToDisplayZoomRatio(float captureDeviceZoomRatio)
-    {
-        var wideConstituentZoomFactor = GetWideConstituentZoomFactor();
-        return wideConstituentZoomFactor is null ? captureDeviceZoomRatio : captureDeviceZoomRatio / (float)wideConstituentZoomFactor.Value;
-    }
-
-    protected override float ToCaptureDeviceZoomRatio(float displayZoomRatio)
-    {
-        var wideConstituentZoomFactor = GetWideConstituentZoomFactor();
-        return wideConstituentZoomFactor is null ? displayZoomRatio : displayZoomRatio * (float)wideConstituentZoomFactor.Value;
-    }
-
-    private nfloat? GetWideConstituentZoomFactor()
-    {
-        if (!m_shouldStartAtWideConstituent || CaptureDevice is null)
-        {
-            return null;
-        }
-
-        var switchOverZoomFactors = CaptureDevice.VirtualDeviceSwitchOverVideoZoomFactors;
-        return switchOverZoomFactors.Length == 0 ? null : (nfloat)switchOverZoomFactors[0].DoubleValue;
-    }
+    public override AVCaptureDevice? SelectCaptureDevice() => SelectPreferredBackCaptureDevice();
 
     //Taken from: https://developer.apple.com/wwdc21/10047?time=117
     //and sample code from Apple: https://developer.apple.com/documentation/avfoundation/capture_setup/avcambarcode_detecting_barcodes_and_faces

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/iOS/BarcodeScanner.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/iOS/BarcodeScanner.cs
@@ -9,6 +9,7 @@ public partial class BarcodeScanner : CameraSession
     //The rectangle that people see in the preview which we will focus on scanning bar codes in
     private AVCaptureMetadataOutput? m_captureMetadataOutput;
     private double m_rectOfInterestWidth;
+    private bool m_shouldStartAtWideConstituent;
 
     private readonly DispatchQueue m_metadataObjectsQueue = new(label: "metadata objects queue", attributes: new(), target: null);
     
@@ -80,13 +81,88 @@ public partial class BarcodeScanner : CameraSession
         {
             PreviewView.TryAddOrUpdateRectOfInterest();
         }
+        SetInitialWideConstituentZoomFactor();
         SetRecommendedZoomFactor();
     }
 
-    //Choosing build in wide angle camera, same as the sample app from Apple: AVCamBarCode: https://developer.apple.com/documentation/avfoundation/capture_setup/avcambarcode_detecting_barcodes_and_faces
-    public override AVCaptureDevice? SelectCaptureDevice() =>
-        AVCaptureDevice.GetDefaultDevice(AVCaptureDeviceType.BuiltInWideAngleCamera,
-            AVMediaTypes.Video, AVCaptureDevicePosition.Back);
+    // Prefer virtual back cameras so iOS starts at normal 1x wide framing but can switch to macro-capable lenses when close.
+    public override AVCaptureDevice? SelectCaptureDevice()
+    {
+        m_shouldStartAtWideConstituent = false;
+
+        return TryGetCaptureDevice(AVCaptureDeviceType.BuiltInTripleCamera, shouldStartAtWideConstituent: true) ??
+               TryGetCaptureDevice(AVCaptureDeviceType.BuiltInDualWideCamera, shouldStartAtWideConstituent: true) ??
+               TryGetCaptureDevice(AVCaptureDeviceType.BuiltInDualCamera, shouldStartAtWideConstituent: false) ??
+               TryGetCaptureDevice(AVCaptureDeviceType.BuiltInWideAngleCamera, shouldStartAtWideConstituent: false);
+    }
+
+    private AVCaptureDevice? TryGetCaptureDevice(AVCaptureDeviceType deviceType, bool shouldStartAtWideConstituent)
+    {
+        var captureDevice = AVCaptureDevice.GetDefaultDevice(deviceType, AVMediaTypes.Video, AVCaptureDevicePosition.Back);
+        if (captureDevice is null)
+        {
+            return null;
+        }
+
+        m_shouldStartAtWideConstituent = shouldStartAtWideConstituent;
+        return captureDevice;
+    }
+
+    private void SetInitialWideConstituentZoomFactor()
+    {
+        if (!m_shouldStartAtWideConstituent || CaptureDevice is null)
+        {
+            return;
+        }
+
+        var wideConstituentZoomFactor = GetWideConstituentZoomFactor();
+        if (wideConstituentZoomFactor is null)
+        {
+            return;
+        }
+
+        if (!CaptureDevice.LockForConfiguration(out var error))
+        {
+            if (error != null)
+            {
+                throw new Exception(error.ToString());
+            }
+
+            return;
+        }
+
+        try
+        {
+            CaptureDevice.VideoZoomFactor = wideConstituentZoomFactor.Value;
+        }
+        finally
+        {
+            CaptureDevice.UnlockForConfiguration();
+        }
+    }
+
+    protected override float ToDisplayZoomRatio(float captureDeviceZoomRatio)
+    {
+        var wideConstituentZoomFactor = GetWideConstituentZoomFactor();
+        return wideConstituentZoomFactor is null ? captureDeviceZoomRatio : captureDeviceZoomRatio / (float)wideConstituentZoomFactor.Value;
+    }
+
+    protected override float ToCaptureDeviceZoomRatio(float displayZoomRatio)
+    {
+        var wideConstituentZoomFactor = GetWideConstituentZoomFactor();
+        return wideConstituentZoomFactor is null ? displayZoomRatio : displayZoomRatio * (float)wideConstituentZoomFactor.Value;
+    }
+
+    private nfloat? GetWideConstituentZoomFactor()
+    {
+        if (!m_shouldStartAtWideConstituent || CaptureDevice is null)
+        {
+            return null;
+        }
+
+        var switchOverZoomFactors = CaptureDevice.VirtualDeviceSwitchOverVideoZoomFactors;
+        return switchOverZoomFactors.Length == 0 ? null : (nfloat)switchOverZoomFactors[0].DoubleValue;
+    }
 
     //Taken from: https://developer.apple.com/wwdc21/10047?time=117
     //and sample code from Apple: https://developer.apple.com/documentation/avfoundation/capture_setup/avcambarcode_detecting_barcodes_and_faces
@@ -125,7 +201,7 @@ public partial class BarcodeScanner : CameraSession
         
         if (m_cameraPreview is { CameraZoomView: not null })
         {
-            m_cameraPreview.CameraZoomView.SetZoomRatio((float)captureDevice.VideoZoomFactor);
+            m_cameraPreview.CameraZoomView.SetZoomRatio(ToDisplayZoomRatio((float)captureDevice.VideoZoomFactor));
         }
     }
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/CameraZoom/CameraZoomView.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/CameraZoom/CameraZoomView.cs
@@ -20,9 +20,6 @@ internal class CameraZoomView : Grid
         InputTransparent = true;
         CascadeInputTransparent = false;
         
-        // We do not support ultra-wide cameras yet, so we can safely assume that the minimum ratio is 1
-        minRatio = 1;
-        
         VerticalOptions = LayoutOptions.End;
 
         Margin = new Thickness(0, 0, 0, Sizes.GetSize(SizeName.content_margin_large));

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/CameraZoom/ZoomButtons.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/CameraZoom/ZoomButtons.cs
@@ -18,9 +18,6 @@ internal class ZoomButtons : HorizontalStackLayout
     {
         m_onChangedZoomRatio = onChangedZoomRatio;
         m_onPanned = onPanned;
-
-        // We do not support ultra-wide cameras yet, so we can safely assume that the minimum ratio is 1
-        minRatio = 1;
         
         var panGestureRecognizer = new PanGestureRecognizer();
         panGestureRecognizer.PanUpdated += OnPanned;
@@ -33,35 +30,49 @@ internal class ZoomButtons : HorizontalStackLayout
         Padding = 2;
         
         UI.Effects.Layout.Layout.SetCornerRadius(this, Sizes.GetSize(SizeName.size_5));
-        
-        var firstButton = CreateCameraZoomButton(minRatio, true);
-        var secondButton = CreateCameraZoomButton(minRatio + 1);
-        var thirdButton = CreateCameraZoomButton(MathF.Min(secondButton.DefaultZoomRatio + 1, maxRatio));
 
-        // If we have not yet hit the max ratio, lets add another button
-        ZoomButton? fourthButton = null;
-        if (Math.Abs(thirdButton.DefaultZoomRatio - maxRatio) > 0.01f)
+        m_zoomButtons = CreateDefaultZoomRatios(minRatio, maxRatio)
+            .Select((zoomRatio, index) => CreateCameraZoomButton(zoomRatio, index == 0))
+            .ToList();
+
+        m_currentlyActiveButton = m_zoomButtons.First();
+
+        foreach (var zoomButton in m_zoomButtons)
         {
-            fourthButton = CreateCameraZoomButton(MathF.Min(secondButton.DefaultZoomRatio + 2, maxRatio));
+            Add(zoomButton);
         }
-
-        m_currentlyActiveButton = firstButton.IsDefaultActive ? firstButton : secondButton;
-        
-        Add(firstButton);
-        Add(secondButton);
-        Add(thirdButton);
-        
-        if(fourthButton is not null)
-            Add(fourthButton);
         
         this.SizeChanged += OnSizeChanged;
         
-        m_zoomButtons = [firstButton, secondButton, thirdButton];
-        
-        if(fourthButton is not null)
-            m_zoomButtons.Add(fourthButton);
-        
         DUI.OrientationChanged += OrientationChanged;
+    }
+
+    private static List<float> CreateDefaultZoomRatios(float minRatio, float maxRatio)
+    {
+        var zoomRatios = new List<float>();
+
+        AddZoomRatio(minRatio);
+        AddZoomRatio(minRatio < 1 ? 1 : minRatio + 1);
+        AddZoomRatio(MathF.Min(zoomRatios.Last() + 1, maxRatio));
+
+        var fourthZoomRatio = maxRatio;
+        if (Math.Abs(zoomRatios.Last() - fourthZoomRatio) > 0.01f)
+        {
+            AddZoomRatio(fourthZoomRatio);
+        }
+
+        return zoomRatios;
+
+        void AddZoomRatio(float zoomRatio)
+        {
+            zoomRatio = Math.Clamp(zoomRatio, minRatio, maxRatio);
+            if (zoomRatios.Any(existingZoomRatio => Math.Abs(existingZoomRatio - zoomRatio) <= 0.01f))
+            {
+                return;
+            }
+
+            zoomRatios.Add(zoomRatio);
+        }
     }
 
     private void OrientationChanged(OrientationDegree orientationDegree)
@@ -170,7 +181,7 @@ internal class ZoomButton : ContentView
         
         m_label = new Label
         {
-            Text = IsDefaultActive ? $"{defaultZoomRatio} ×" : $"{defaultZoomRatio}",
+            Text = IsDefaultActive ? $"{FormatZoomRatio(defaultZoomRatio)} ×" : FormatZoomRatio(defaultZoomRatio),
             TextColor = IsDefaultActive ? Colors.Gold : Colors.White,
             VerticalTextAlignment = TextAlignment.Center,
             HorizontalTextAlignment = TextAlignment.Center,
@@ -227,9 +238,11 @@ internal class ZoomButton : ContentView
 
     public void ResetToDefault()
     {
-        m_label.Text = $"{DefaultZoomRatio}";
+        m_label.Text = FormatZoomRatio(DefaultZoomRatio);
         m_label.TextColor = Colors.White;
     }
+
+    private static string FormatZoomRatio(float zoomRatio) => zoomRatio.ToString("0.#");
     
     public float DefaultZoomRatio { get; }
     public bool IsDefaultActive { get; }

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/CameraZoom/ZoomSlider.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/Views/CameraZoom/ZoomSlider.cs
@@ -16,15 +16,19 @@ internal class ZoomSlider : Grid
     private Border m_zoomRatioLevelBorder;
     private Label m_zoomRatioLevelLabel;
     
+    private readonly float m_minRatio;
     private readonly float m_maxRatio;
     
     private readonly Action<float> m_onChangedZoomRatio;
     private readonly Action<PanUpdatedEventArgs> m_onPanned;
     
     private double m_startingX;
+    private float m_startingZoomRatio;
     private double m_minimumZoomRatiosLayoutTranslationX;
     private double m_maxZoomRatiosLayoutTranslationX;
     private double m_zoomRatioLevel;
+    private float? m_pendingZoomRatio;
+    private bool m_hasMeasuredZoomRatiosLayout;
     
     private int m_currentSnappedZoomRatio;
 
@@ -34,6 +38,7 @@ internal class ZoomSlider : Grid
     {
         InputTransparent = true;
         CascadeInputTransparent = false;
+        m_minRatio = minRatio;
         m_maxRatio = maxRatio;
         m_onChangedZoomRatio = onChangedZoomRatio;
         m_onPanned = onPanned;
@@ -159,12 +164,23 @@ internal class ZoomSlider : Grid
     
     private void ZoomRatiosLayoutOnSizeChanged(object? sender, EventArgs e)
     {
-        if(m_zoomRatiosLayout.TranslationX != 0)
+        if (m_zoomRatiosLayout.Width <= 0)
             return;
-        
-        m_zoomRatiosLayout.TranslationX += m_zoomRatiosLayout.Width / 2;
-        m_maxZoomRatiosLayoutTranslationX = m_zoomRatiosLayout.TranslationX;
+
+        if (m_hasMeasuredZoomRatiosLayout && m_pendingZoomRatio is null)
+            return;
+
+        m_maxZoomRatiosLayoutTranslationX = m_zoomRatiosLayout.Width / 2;
         m_minimumZoomRatiosLayoutTranslationX = m_maxZoomRatiosLayoutTranslationX - m_zoomRatiosLayout.Width;
+        m_hasMeasuredZoomRatiosLayout = true;
+
+        if (m_pendingZoomRatio is { } pendingZoomRatio)
+        {
+            SetZoomRatio(pendingZoomRatio);
+            return;
+        }
+
+        m_zoomRatiosLayout.TranslationX = m_maxZoomRatiosLayoutTranslationX;
     }
 
     private double CalculateZoomRatio(double desiredTranslationX)
@@ -173,20 +189,27 @@ internal class ZoomSlider : Grid
         currentTranslation = m_zoomRatiosLayout.Width - currentTranslation;
         var translationPercentage = (currentTranslation / m_zoomRatiosLayout.Width);
 
-        var zoomRatioIndex = ((m_maxRatio - 1) * 10) * translationPercentage;
+        var zoomRatioIndex = ((m_maxRatio - m_minRatio) * 10) * translationPercentage;
         
-        return zoomRatioIndex / 10 + 1;
+        return zoomRatioIndex / 10 + m_minRatio;
     }
 
     private double CalculateTranslationXFromZoomRatio(float zoomRatio)
     {
-        return m_maxZoomRatiosLayoutTranslationX - (m_zoomRatiosLayout.Width * ((zoomRatio - 1) / (m_maxRatio - 1)));
+        if (Math.Abs(m_maxRatio - m_minRatio) < 0.01f)
+        {
+            return m_maxZoomRatiosLayoutTranslationX;
+        }
+
+        return m_maxZoomRatiosLayoutTranslationX - (m_zoomRatiosLayout.Width * ((zoomRatio - m_minRatio) / (m_maxRatio - m_minRatio)));
     }
 
     private void PanGestureRecognizerOnPanUpdated(PanUpdatedEventArgs e)
     {
         m_onPanned.Invoke(e);
     }
+
+    private float ClampZoomRatio(float zoomRatio) => Math.Clamp(zoomRatio, m_minRatio, m_maxRatio);
     
     public void TranslateZoomSlider(PanUpdatedEventArgs e)
     {
@@ -194,27 +217,24 @@ internal class ZoomSlider : Grid
         {
             case GestureStatus.Started:
                 m_startingX = e.TotalX;
+                m_startingZoomRatio = ClampZoomRatio((float)m_zoomRatioLevel);
                 
                 m_cancellationTokenSource.Cancel();
                 m_cancellationTokenSource = new CancellationTokenSource();
                 break;
             case GestureStatus.Running:
                 {
-                    var desiredTranslationX = m_zoomRatiosLayout.TranslationX + e.TotalX - m_startingX;
-            
-                    var actualZoomRatio = CalculateZoomRatio(m_zoomRatiosLayout.TranslationX);
-                    
-                    // Vibrate when near integers
-                    var roundedZoomRatio = (int)MathF.Round((float)actualZoomRatio);
-                    if (Math.Abs(roundedZoomRatio - actualZoomRatio) < 0.025f)
+                    if (m_minRatio < 1)
                     {
-                        if (roundedZoomRatio != m_currentSnappedZoomRatio)
-                        {
-                            VibrationService.SelectionChanged();
-                        }
-                        m_currentSnappedZoomRatio = roundedZoomRatio;
+                        var dragRange = Math.Max(Width, 1);
+                        var zoomRatioDelta = (float)((m_startingX - e.TotalX) / dragRange * (m_maxRatio - m_minRatio));
+                        var desiredZoomRatio = ClampZoomRatio(m_startingZoomRatio + zoomRatioDelta);
+                        m_zoomRatiosLayout.TranslationX = CalculateTranslationXFromZoomRatio(desiredZoomRatio);
+                        UpdateZoomRatio(desiredZoomRatio);
+                        break;
                     }
-                    else m_currentSnappedZoomRatio = -1;
+
+                    var desiredTranslationX = m_zoomRatiosLayout.TranslationX + e.TotalX - m_startingX;
                     
                     // Stop the user from panning too far or too little
                     if(desiredTranslationX > m_maxZoomRatiosLayoutTranslationX)
@@ -229,11 +249,28 @@ internal class ZoomSlider : Grid
                     m_zoomRatiosLayout.TranslationX = desiredTranslationX;
                     m_startingX = e.TotalX;
 
-                    ZoomRatioLevel = actualZoomRatio;
+                    UpdateZoomRatio(CalculateZoomRatio(desiredTranslationX));
 
                     break;
                 }
         }
+    }
+
+    private void UpdateZoomRatio(double zoomRatio)
+    {
+        // Vibrate when near integers
+        var roundedZoomRatio = (int)MathF.Round((float)zoomRatio);
+        if (Math.Abs(roundedZoomRatio - zoomRatio) < 0.025f)
+        {
+            if (roundedZoomRatio != m_currentSnappedZoomRatio)
+            {
+                VibrationService.SelectionChanged();
+            }
+            m_currentSnappedZoomRatio = roundedZoomRatio;
+        }
+        else m_currentSnappedZoomRatio = -1;
+
+        ZoomRatioLevel = zoomRatio;
     }
 
     public double ZoomRatioLevel
@@ -249,13 +286,23 @@ internal class ZoomSlider : Grid
 
     public void SetZoomRatio(float zoomRatio)
     {
-        m_zoomRatiosLayout.TranslationX = CalculateTranslationXFromZoomRatio((int)zoomRatio);
+        zoomRatio = ClampZoomRatio(zoomRatio);
+        m_zoomRatioLevel = zoomRatio;
+        m_zoomRatioLevelLabel.Text = zoomRatio.ToString("F1");
+
+        if (!m_hasMeasuredZoomRatiosLayout)
+        {
+            m_pendingZoomRatio = zoomRatio;
+            return;
+        }
+
+        m_zoomRatiosLayout.TranslationX = CalculateTranslationXFromZoomRatio(zoomRatio);
+        m_pendingZoomRatio = null;
     }
 
     public async Task<bool> OnPinchToZoom(float zoomRatio)
     {
-        m_zoomRatiosLayout.TranslationX = CalculateTranslationXFromZoomRatio(zoomRatio);
-        m_zoomRatioLevelLabel.Text = zoomRatio.ToString("F1");
+        SetZoomRatio(zoomRatio);
 
         m_cancellationTokenSource.Cancel();
         m_cancellationTokenSource = new CancellationTokenSource();

--- a/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/iOS/ImageCapture.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/ImageCapturing/iOS/ImageCapture.cs
@@ -53,11 +53,7 @@ public partial class ImageCapture : CameraSession
     private partial void PlatformOnCameraFailed(CameraException cameraException) =>
         OnCameraFailed<ImageCapture>(cameraException);
 
-    public override AVCaptureDevice? SelectCaptureDevice() =>
-        AVCaptureDevice.GetDefaultDevice(AVCaptureDeviceType.BuiltInWideAngleCamera,
-            AVMediaTypes.Video, AVCaptureDevicePosition.Back) ??
-        AVCaptureDevice.GetDefaultDevice(AVCaptureDeviceType.BuiltInDualCamera,
-            AVMediaTypes.Video, AVCaptureDevicePosition.Back);
+    public override AVCaptureDevice? SelectCaptureDevice() => SelectPreferredBackCaptureDevice();
 
     private void PhotoCaptured(AVCapturePhoto photo)
     {
@@ -223,6 +219,6 @@ internal class PhotoCaptureDelegate(Action<AVCapturePhoto> onPhotoCaptured, Acti
 
         m_onPhotoCaptureFailed = null!;
         m_onPhotoCaptured = null!;
-        m_onBeforeCapture = null;
+        m_onBeforeCapture = null!;
     }
 }

--- a/src/library/DIPS.Mobile.UI/API/Camera/Preview/iOS/PreviewView.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Preview/iOS/PreviewView.cs
@@ -77,15 +77,15 @@ internal sealed class PreviewView : ContentView
         /*UISlider?.BecomeFirstResponder();*/ //Make sure slider does not loose focus for people to slide it after they tap to focus
     }
     
-    public void AddPinchToZoom(AVCaptureDevice captureDevice)
+    public void AddPinchToZoom(AVCaptureDevice captureDevice, float maximumZoomRatio)
     {
         m_pinchToZoomGestureRecognizer =
-            new UIPinchGestureRecognizer((recognizer => PinchToZoom(recognizer, captureDevice)));
+            new UIPinchGestureRecognizer((recognizer => PinchToZoom(recognizer, captureDevice, maximumZoomRatio)));
         AddGestureRecognizer(m_pinchToZoomGestureRecognizer);
     }
     
     //Taken from: https://stackoverflow.com/a/31214458
-    private void PinchToZoom(UIPinchGestureRecognizer pinchRecognizer, AVCaptureDevice captureDevice)
+    private void PinchToZoom(UIPinchGestureRecognizer pinchRecognizer, AVCaptureDevice captureDevice, float maximumZoomRatio)
     {
         if (pinchRecognizer.State == UIGestureRecognizerState.Changed)
         {
@@ -94,13 +94,12 @@ internal sealed class PreviewView : ContentView
                 try
                 {
                     var pinchVelocityDividerFactor = 10f;
-                    var desiredZoomFactor = captureDevice.VideoZoomFactor +
+                    var desiredZoomFactor = (double)captureDevice.VideoZoomFactor +
                                             Math.Atan2(pinchRecognizer.Velocity, pinchVelocityDividerFactor);
                     
-                    var maxZoomFactor = Math.Min(captureDevice.ActiveFormat.VideoMaxZoomFactor, MaxZoomRatio);
+                    var maxZoomFactor = Math.Min((double)captureDevice.ActiveFormat.VideoMaxZoomFactor, maximumZoomRatio);
                     // Check if desiredZoomFactor fits required range from 1.0 to activeFormat.videoMaxZoomFactor
-                    var zoomFactor = (nfloat)Math.Max(1.0,
-                        Math.Min(desiredZoomFactor, maxZoomFactor));
+                    var zoomFactor = (nfloat)Math.Max(1.0, Math.Min(desiredZoomFactor, maxZoomFactor));
                     captureDevice.VideoZoomFactor = zoomFactor;
 
                     OnZoomChanged?.Invoke((float)zoomFactor);

--- a/src/library/DIPS.Mobile.UI/API/Camera/Shared/iOS/CameraSession.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Shared/iOS/CameraSession.cs
@@ -18,7 +18,7 @@ public abstract class CameraSession
 #nullable enable
     
     internal AVCaptureVideoPreviewLayer? PreviewLayer { get; private set; }
-    //The lens to be used for scanning bar codes
+    //The active capture device used by the current camera session
     internal AVCaptureDevice? CaptureDevice { get; private set; }
     
     internal PreviewView? PreviewView { get; private set; }
@@ -34,6 +34,7 @@ public abstract class CameraSession
     private CameraFailed? m_cameraFailedDelegate;
     private NSObject? m_startedSessionObserver;
     private NSObject? m_sessionStoppedObserver;
+    private bool m_shouldStartAtWideConstituent;
     
     private TaskCompletionSource<bool>? m_sessionStartedTask;
     private TaskCompletionSource<bool>? m_sessionStoppedTask;
@@ -129,6 +130,7 @@ public abstract class CameraSession
         //Call beginConfiguration() before changing a session’s inputs or outputs, and call commitConfiguration() after making changes.
         CaptureSession.BeginConfiguration();
         
+        m_shouldStartAtWideConstituent = false;
         CaptureDevice = SelectCaptureDevice();
         
         if (CaptureDevice == null) throw new Exception("Unable to select an capture device.");
@@ -145,7 +147,7 @@ public abstract class CameraSession
         }
         else
         {
-            throw new Exception("Unable to use the back camera wide angle camera to detect bar codes");
+            throw new Exception("Unable to use the selected back camera");
         }
         
         // Set quality based on target resolution
@@ -172,6 +174,7 @@ public abstract class CameraSession
         
         m_avCaptureOutput = avCaptureOutput;
 
+        SetInitialWideConstituentZoomFactor();
         AddCameraZoomView();
         
         if (CaptureSession.CanAddOutput(m_avCaptureOutput))
@@ -246,7 +249,7 @@ public abstract class CameraSession
         var maximumDisplayZoomFactor = GetMaximumDisplayZoomFactor();
         if (m_cameraPreview?.CameraZoomView is not null)
         {
-            m_cameraPreview.CameraZoomView?.SetZoomRatio(ToDisplayZoomRatio((float)CaptureDevice.VideoZoomFactor));
+            m_cameraPreview.CameraZoomView?.SetZoomRatio(GetCurrentDisplayZoomFactor());
         }
         else if(m_cameraPreview is not null)
         {
@@ -254,8 +257,11 @@ public abstract class CameraSession
                 minimumDisplayZoomFactor,
                 maximumDisplayZoomFactor,
                 zoomRatio => OnChangedZoomRatio(ToCaptureDeviceZoomRatio(zoomRatio))) { Opacity = 0 };
+            m_cameraPreview.CameraZoomView.SetZoomRatio(GetCurrentDisplayZoomFactor());
         }
     }
+
+    private float GetCurrentDisplayZoomFactor() => ToDisplayZoomRatio((float)CaptureDevice!.VideoZoomFactor);
 
     private void PreviewViewOnOnTapToFocus(float x, float y)
     {
@@ -273,9 +279,17 @@ public abstract class CameraSession
         m_cameraPreview?.CameraZoomView?.OnPinchToZoom(ToDisplayZoomRatio(zoomRatio));
     }
 
-    protected virtual float ToDisplayZoomRatio(float captureDeviceZoomRatio) => captureDeviceZoomRatio;
+    protected virtual float ToDisplayZoomRatio(float captureDeviceZoomRatio)
+    {
+        var wideConstituentZoomFactor = GetWideConstituentZoomFactor();
+        return wideConstituentZoomFactor is null ? captureDeviceZoomRatio : captureDeviceZoomRatio / (float)wideConstituentZoomFactor.Value;
+    }
 
-    protected virtual float ToCaptureDeviceZoomRatio(float displayZoomRatio) => displayZoomRatio;
+    protected virtual float ToCaptureDeviceZoomRatio(float displayZoomRatio)
+    {
+        var wideConstituentZoomFactor = GetWideConstituentZoomFactor();
+        return wideConstituentZoomFactor is null ? displayZoomRatio : displayZoomRatio * (float)wideConstituentZoomFactor.Value;
+    }
 
     protected virtual float GetMaximumCaptureDeviceZoomFactor() => Math.Min(
         (float)CaptureDevice!.ActiveFormat.VideoMaxZoomFactor,
@@ -342,6 +356,71 @@ public abstract class CameraSession
     public abstract void ConfigureSession();
 
     public abstract AVCaptureDevice? SelectCaptureDevice();
+
+    private protected AVCaptureDevice? SelectPreferredBackCaptureDevice()
+    {
+        return TryGetPreferredBackCaptureDevice(AVCaptureDeviceType.BuiltInTripleCamera, shouldStartAtWideConstituent: true) ??
+               TryGetPreferredBackCaptureDevice(AVCaptureDeviceType.BuiltInDualWideCamera, shouldStartAtWideConstituent: true) ??
+               TryGetPreferredBackCaptureDevice(AVCaptureDeviceType.BuiltInDualCamera, shouldStartAtWideConstituent: false) ??
+               TryGetPreferredBackCaptureDevice(AVCaptureDeviceType.BuiltInUltraWideCamera, shouldStartAtWideConstituent: false) ??
+               TryGetPreferredBackCaptureDevice(AVCaptureDeviceType.BuiltInWideAngleCamera, shouldStartAtWideConstituent: false);
+    }
+
+    private AVCaptureDevice? TryGetPreferredBackCaptureDevice(AVCaptureDeviceType deviceType, bool shouldStartAtWideConstituent)
+    {
+        var captureDevice = AVCaptureDevice.GetDefaultDevice(deviceType, AVMediaTypes.Video, AVCaptureDevicePosition.Back);
+        if (captureDevice is null)
+        {
+            return null;
+        }
+
+        m_shouldStartAtWideConstituent = shouldStartAtWideConstituent;
+        return captureDevice;
+    }
+
+    private void SetInitialWideConstituentZoomFactor()
+    {
+        if (CaptureDevice is null)
+        {
+            return;
+        }
+
+        var wideConstituentZoomFactor = GetWideConstituentZoomFactor();
+        if (wideConstituentZoomFactor is null)
+        {
+            return;
+        }
+
+        if (!CaptureDevice.LockForConfiguration(out var error))
+        {
+            if (error != null)
+            {
+                throw new Exception(error.ToString());
+            }
+
+            return;
+        }
+
+        try
+        {
+            CaptureDevice.VideoZoomFactor = wideConstituentZoomFactor.Value;
+        }
+        finally
+        {
+            CaptureDevice.UnlockForConfiguration();
+        }
+    }
+
+    private nfloat? GetWideConstituentZoomFactor()
+    {
+        if (!m_shouldStartAtWideConstituent || CaptureDevice is null)
+        {
+            return null;
+        }
+
+        var switchOverZoomFactors = CaptureDevice.VirtualDeviceSwitchOverVideoZoomFactors;
+        return switchOverZoomFactors.Length == 0 ? null : (nfloat)switchOverZoomFactors[0].DoubleValue;
+    }
     
     private void SetContinuousAutoFocus()
     {

--- a/src/library/DIPS.Mobile.UI/API/Camera/Shared/iOS/CameraSession.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Shared/iOS/CameraSession.cs
@@ -186,7 +186,7 @@ public abstract class CameraSession
             //Commit the configuration
             CaptureSession.CommitConfiguration();
             
-            PreviewView.AddPinchToZoom(CaptureDevice);
+            PreviewView.AddPinchToZoom(CaptureDevice, GetMaximumCaptureDeviceZoomFactor());
             PreviewView.AddTapToFocus(CaptureDevice);
             PreviewView.OnTapToFocus += PreviewViewOnOnTapToFocus;
 
@@ -242,15 +242,18 @@ public abstract class CameraSession
         if (m_cameraPreview is null || CaptureDevice is null)
             return;
 
+        var minimumDisplayZoomFactor = ToDisplayZoomRatio((float)CaptureDevice.MinAvailableVideoZoomFactor);
+        var maximumDisplayZoomFactor = GetMaximumDisplayZoomFactor();
         if (m_cameraPreview?.CameraZoomView is not null)
         {
-            m_cameraPreview.CameraZoomView?.SetZoomRatio((float)CaptureDevice.VideoZoomFactor);
+            m_cameraPreview.CameraZoomView?.SetZoomRatio(ToDisplayZoomRatio((float)CaptureDevice.VideoZoomFactor));
         }
         else if(m_cameraPreview is not null)
         {
-            m_cameraPreview.CameraZoomView = new CameraZoomView((float)CaptureDevice.MinAvailableVideoZoomFactor,
-                (int)Math.Min(CaptureDevice.MaxAvailableVideoZoomFactor, PreviewView.MaxZoomRatio),
-                OnChangedZoomRatio) { Opacity = 0 };
+            m_cameraPreview.CameraZoomView = new CameraZoomView(
+                minimumDisplayZoomFactor,
+                maximumDisplayZoomFactor,
+                zoomRatio => OnChangedZoomRatio(ToCaptureDeviceZoomRatio(zoomRatio))) { Opacity = 0 };
         }
     }
 
@@ -267,8 +270,18 @@ public abstract class CameraSession
         {
             m_cameraPreview.HasZoomed = true;
         }
-        m_cameraPreview?.CameraZoomView?.OnPinchToZoom(zoomRatio);
+        m_cameraPreview?.CameraZoomView?.OnPinchToZoom(ToDisplayZoomRatio(zoomRatio));
     }
+
+    protected virtual float ToDisplayZoomRatio(float captureDeviceZoomRatio) => captureDeviceZoomRatio;
+
+    protected virtual float ToCaptureDeviceZoomRatio(float displayZoomRatio) => displayZoomRatio;
+
+    protected virtual float GetMaximumCaptureDeviceZoomFactor() => Math.Min(
+        (float)CaptureDevice!.ActiveFormat.VideoMaxZoomFactor,
+        ToCaptureDeviceZoomRatio(PreviewView.MaxZoomRatio));
+
+    protected virtual float GetMaximumDisplayZoomFactor() => ToDisplayZoomRatio(GetMaximumCaptureDeviceZoomFactor());
 
     private void AddObservers()
     {
@@ -307,6 +320,7 @@ public abstract class CameraSession
 
         try
         {
+            zoomRatio = Math.Clamp(zoomRatio, (float)CaptureDevice.MinAvailableVideoZoomFactor, GetMaximumCaptureDeviceZoomFactor());
             CaptureDevice.RampToVideoZoom(zoomRatio, 5.0f);
             if (m_cameraPreview != null)
             {

--- a/wiki/Media/Camera.md
+++ b/wiki/Media/Camera.md
@@ -30,6 +30,8 @@ To start off, add a `CameraPreview` to your page and give it a `x:Name`. This le
 
 DIPS.Mobile.UI provides a camera API for people to scan barcodes. The implementations are optimised and is inspired by [ML Kit Barcode scanning](https://developers.google.com/ml-kit/vision/barcode-scanning) for Android and [AVCamBarcode from Apple](https://developer.apple.com/documentation/avfoundation/capture_setup/avcambarcode_detecting_barcodes_and_faces) for iOS.
 
+> **NOTE:** On iOS, devices with ultra-wide cameras can use the macro-capable lens for close-range barcode focus while starting the preview in normal wide framing. On those devices, the zoom controls can show `0.5x` for the ultra-wide lens.
+
 ## Start scanning
 To get started, create an `BarcodeScanner` object in your code behind, and `Start()` it when it makes sense for people.
 

--- a/wiki/Media/ImageCapture.md
+++ b/wiki/Media/ImageCapture.md
@@ -22,6 +22,8 @@ private readonly ImageCapture m_imageCapture = new();
 
 > We recommend starting the camera in `OnAppearing`.
 
+> **NOTE:** On iOS, devices with ultra-wide cameras can use the ultra-wide lens through the shared zoom controls while starting the preview in normal wide framing. On those devices, the zoom controls can show `0.5x` for the ultra-wide lens.
+
 ## Capturing a single image
 
 Call `StartSingleImageCapture` with the preview, your "image captured" delegate, your "camera failed" delegate, and a `CameraOptions` object:


### PR DESCRIPTION
### Description of Change

Improves iOS barcode scanning at very close range by selecting macro-capable virtual back cameras when available, while starting the preview in normal wide framing instead of ultra-wide. Updates the zoom controls so ultra-wide-capable iOS camera sessions can display `0.5x`, and keeps zoom button, slider, and pinch limits aligned with the available camera range.

### Todos
- [ ] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [x] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
