### PR TITLE
Stabilize BarcodeScanner lifecycle handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [60.2.13]
+- [BarcodeScanner] Fixed scanner start/resume racing an in-progress native camera stop, which could leave detection unstable after rapid lifecycle changes.
+- [BarcodeScanner][Android] Fixed scanner crashes and unstable detection when the app is backgrounded while barcode analysis is in progress and then opened again.
+
 ## [60.2.12]
 - [Camera][iOS] Added ultra-wide capable back camera selection and zoom mapping for barcode scanning and image capture on supported devices.
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/Android/BarcodeScanner.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/Android/BarcodeScanner.cs
@@ -44,9 +44,11 @@ public partial class BarcodeScanner : CameraFragment, IObserver
 
     internal partial async Task PlatformStop()
     {
+        m_imageAnalysisUseCase?.ClearAnalyzer();
         m_barcodeScanner?.Close();
         m_barcodeScanner = null;
         await base.TryStop();
+        m_imageAnalysisUseCase = null;
         m_imageAnalysisExecutor?.Shutdown();
         m_imageAnalysisExecutor = null;
     }
@@ -63,6 +65,9 @@ public partial class BarcodeScanner : CameraFragment, IObserver
     }
     private void SetupBarCodeScanning()
     {
+        if (m_barcodeScanner is not null)
+            return;
+
         //From docs: https://developers.google.com/ml-kit/vision/barcode-scanning/android#kotlin
         var barcodeScannerBuilder = new BarcodeScannerOptions.Builder();
         //Set formats

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScanner.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScanner.cs
@@ -13,6 +13,7 @@ public partial class BarcodeScanner : ICameraUseCase
     private BarcodeScannerStartOptions m_currentStartOptions = new();
     private BarcodeScanSession? m_scanSession;
     private CancellationTokenSource? m_sessionCts;
+    private Task m_platformStopTask = Task.CompletedTask;
     private int m_scanRunId;
     private bool m_isDisposed;
     private bool m_isPlatformStarted;
@@ -86,7 +87,7 @@ public partial class BarcodeScanner : ICameraUseCase
             ConstructOverlayViews(m_currentStartOptions);
             m_confirmationHandler = CreateConfirmationHandler();
             m_scanSession.AttachProgressCounter(m_cameraPreview);
-            await PlatformStart(m_currentStartOptions, m_currentStartOptions.OnCameraFailed);
+            await PlatformStart(m_currentStartOptions, onCameraFailed);
 
             // The overlay must match the PreviewView's translation so the dim and
             // scan rectangle cover the same area as the camera feed.
@@ -200,7 +201,7 @@ public partial class BarcodeScanner : ICameraUseCase
             m_confirmationHandler?.Reset();
             DisposeCooldownTimer();
             m_confirmedBarcodeValues.Clear();
-            m_scanSession.ResumeScanning();
+            m_scanSession!.ResumeScanning();
         }
         catch (Exception e)
         {
@@ -421,7 +422,7 @@ public partial class BarcodeScanner : ICameraUseCase
             return;
 
         StartCooldown();
-        m_scanSession.ResumeScanning();
+        m_scanSession!.ResumeScanning();
     }
 
     private int BeginNewScanRun() => Interlocked.Increment(ref m_scanRunId);
@@ -449,10 +450,26 @@ public partial class BarcodeScanner : ICameraUseCase
     private async Task StopPlatformIfNeededAsync()
     {
         if (!m_isPlatformStarted)
+        {
+            await m_platformStopTask;
             return;
+        }
 
         m_isPlatformStarted = false;
-        await PlatformStop();
+        m_platformStopTask = StopPlatformCoreAsync();
+        await m_platformStopTask;
+    }
+
+    private async Task StopPlatformCoreAsync()
+    {
+        try
+        {
+            await PlatformStop();
+        }
+        catch (Exception e)
+        {
+            Log(e.Message);
+        }
     }
 
     private void CancelSession()

--- a/src/library/DIPS.Mobile.UI/API/Camera/Shared/Android/CameraFragment.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Shared/Android/CameraFragment.cs
@@ -229,6 +229,12 @@ public abstract class CameraFragment : Fragment
         base.OnStart();
     }
 
+    public override void OnStop()
+    {
+        UnRegisterRotationEvents();
+        base.OnStop();
+    }
+
     private void AddTapToFocus()
     {
         if(PreviewViewHandler is not null)


### PR DESCRIPTION
### Description of Change

Stabilizes BarcodeScanner lifecycle handling across scanner sessions and fixes the Android crash when the app is backgrounded while barcode analysis is in progress and then resumed.

Changes include:
- Wait for any in-progress native camera stop before starting or resuming a scanner session, preventing old teardown from overlapping new startup.
- Keep `CanResumeSession` as the single guard before resuming after pause or success animations.
- Clear the Android CameraX image analyzer before shutting down the analysis executor.
- Avoid recreating the Android ML Kit scanner when the fragment starts again with an existing scanner.
- Unregister Android camera tap, zoom, and display listeners on fragment stop so resume does not duplicate subscriptions.

No public API or accessibility behavior is changed.

Validation performed:
- `dotnet build src/library/DIPS.Mobile.UI/DIPS.Mobile.UI.csproj -f net10.0-android`
- `dotnet build src/library/DIPS.Mobile.UI/DIPS.Mobile.UI.csproj -f net10.0-ios`

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->