### PR TITLE
Fix iOS CollectionView template root corner radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [60.2.14]
+- [CollectionView][iOS] Fixed item template root corner radius and stroke being cleared when `AutoCornerRadius` is disabled.
+
 ## [60.2.13]
 - [BarcodeScanner] Fixed scanner start/resume racing an in-progress native camera stop, which could leave detection unstable after rapid lifecycle changes.
 - [BarcodeScanner][Android] Fixed scanner crashes and unstable detection when the app is backgrounded while barcode analysis is in progress and then opened again.

--- a/src/app/Playground/VetleSamples/CollectionViewTests/CollectionViewTests.xaml
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/CollectionViewTests.xaml
@@ -12,6 +12,9 @@
         <dui:NavigationListItem Title="Grouped CollectionView"
                                 Tapped="GroupedCollectionView"
                                 HasBottomDivider="True" />
+        <dui:NavigationListItem Title="Corner radius regressions (#1723 + #638)"
+                                Tapped="CornerRadiusRegressionCases"
+                                HasBottomDivider="True" />
         
         <Label Text="Focus Cases" 
                FontAttributes="Bold" 

--- a/src/app/Playground/VetleSamples/CollectionViewTests/CollectionViewTests.xaml.cs
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/CollectionViewTests.xaml.cs
@@ -17,6 +17,11 @@ public partial class CollectionViewTests
         Shell.Current.Navigation.PushAsync(new GroupedCollectionView());
     }
 
+    private void CornerRadiusRegressionCases(object sender, EventArgs e)
+    {
+        Shell.Current.Navigation.PushAsync(new CornerRadiusRegressionCases());
+    }
+
     private void SearchBarOutside(object sender, EventArgs e)
     {
         Shell.Current.Navigation.PushAsync(new RemoveFocusOnScrollPage(wrapInRefreshView: false, searchBarInHeader: false));

--- a/src/app/Playground/VetleSamples/CollectionViewTests/CornerRadiusRegressionCases.xaml
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/CornerRadiusRegressionCases.xaml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:dui="http://dips.com/mobile.ui"
+                 xmlns:collectionViewTests="clr-namespace:Playground.VetleSamples.CollectionViewTests"
+                 x:Class="Playground.VetleSamples.CollectionViewTests.CornerRadiusRegressionCases"
+                 x:DataType="collectionViewTests:CornerRadiusRegressionCasesViewModel"
+                 Title="Corner radius regressions"
+                 BackgroundColor="{dui:Colors color_surface_neutral}">
+
+    <ContentPage.BindingContext>
+        <collectionViewTests:CornerRadiusRegressionCasesViewModel />
+    </ContentPage.BindingContext>
+
+    <dui:ScrollView>
+        <dui:VerticalStackLayout Padding="{dui:Thickness size_3}"
+                                 Spacing="{dui:Sizes size_4}">
+
+            <dui:VerticalStackLayout Spacing="{dui:Sizes size_2}">
+                <dui:Label Text="#1723 - Template root styling"
+                           Style="{dui:Styles Label=UI300}" />
+                <dui:Label Text="Each item root owns its corner radius and stroke. The cards should stay rounded even though CollectionView AutoCornerRadius is false."
+                           Style="{dui:Styles Label=Body200}"
+                           TextColor="{dui:Colors color_text_subtle}" />
+
+                <dui:CollectionView ItemsSource="{Binding RootStyledCards}"
+                                    HeightRequest="300"
+                                    ItemSpacing="{dui:Sizes size_3}"
+                                    BackgroundColor="Transparent"
+                                    dui:Layout.AutoCornerRadius="False">
+                    <dui:CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="collectionViewTests:CornerRadiusCardItem">
+                            <Grid RowDefinitions="Auto, Auto"
+                                  Padding="{dui:Thickness size_3}"
+                                  BackgroundColor="{dui:Colors color_surface_default}"
+                                  dui:Layout.CornerRadius="{dui:CornerRadius size_2}"
+                                  dui:Layout.Stroke="{dui:Colors color_border_default}">
+                                <dui:Label Text="{Binding Title}"
+                                           Style="{dui:Styles Label=UI300}" />
+                                <dui:Label Grid.Row="1"
+                                           Text="{Binding Description}"
+                                           Style="{dui:Styles Label=Body200}"
+                                           TextColor="{dui:Colors color_text_subtle}" />
+                            </Grid>
+                        </DataTemplate>
+                    </dui:CollectionView.ItemTemplate>
+                </dui:CollectionView>
+            </dui:VerticalStackLayout>
+
+            <dui:VerticalStackLayout Spacing="{dui:Sizes size_2}">
+                <dui:Label Text="#638 - Grouped auto corner radius"
+                           Style="{dui:Styles Label=UI300}" />
+                <dui:Label Text="The last plan element in each section should keep bottom corner radius and the last divider should be hidden."
+                           Style="{dui:Styles Label=Body200}"
+                           TextColor="{dui:Colors color_text_subtle}" />
+
+                <Grid ColumnDefinitions="*, *"
+                      RowDefinitions="Auto, Auto"
+                      ColumnSpacing="{dui:Sizes size_2}"
+                      RowSpacing="{dui:Sizes size_2}">
+                    <dui:Button Text="Add last"
+                                Command="{Binding AddLastPlanElementCommand}" />
+                    <dui:Button Grid.Column="1"
+                                Text="Minimize"
+                                Command="{Binding MinimizeFirstPlanElementGroupCommand}" />
+                    <dui:Button Grid.Row="1"
+                                Text="Expand"
+                                Command="{Binding ExpandFirstPlanElementGroupCommand}" />
+                    <dui:Button Grid.Row="1"
+                                Grid.Column="1"
+                                Text="Reset"
+                                Command="{Binding ResetPlanElementGroupsCommand}" />
+                </Grid>
+
+                <dui:CollectionView ItemsSource="{Binding PlanElementGroups}"
+                                    HeightRequest="420"
+                                    IsGrouped="True"
+                                    BackgroundColor="Transparent"
+                                    dui:Layout.AutoCornerRadius="True"
+                                    dui:Layout.AutoHideLastDivider="True">
+                    <dui:CollectionView.GroupHeaderTemplate>
+                        <DataTemplate x:DataType="collectionViewTests:PlanElementGroup">
+                            <dui:Label Text="{Binding Header}"
+                                       Padding="{dui:Thickness Left=size_3, Top=size_4, Bottom=size_1}"
+                                       Style="{dui:Styles Label=SectionHeader}" />
+                        </DataTemplate>
+                    </dui:CollectionView.GroupHeaderTemplate>
+
+                    <dui:CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="collectionViewTests:PlanElementItem">
+                            <Grid ColumnDefinitions="8, *"
+                                  RowDefinitions="Auto, Auto"
+                                  BackgroundColor="{dui:Colors color_surface_default}">
+                                <BoxView Grid.RowSpan="2"
+                                         Color="{Binding StatusColor}" />
+
+                                <Grid Grid.Column="1"
+                                      Padding="{dui:Thickness size_2}"
+                                      RowDefinitions="Auto, Auto">
+                                    <dui:Label Text="{Binding Title}"
+                                               Style="{dui:Styles Label=UI300}" />
+                                    <dui:Label Grid.Row="1"
+                                               Text="{Binding Description}"
+                                               Style="{dui:Styles Label=Body200}"
+                                               TextColor="{dui:Colors color_text_subtle}" />
+                                </Grid>
+
+                                <dui:Divider Grid.Column="1"
+                                             Grid.Row="1"
+                                             HeightRequest="{dui:Sizes stroke_medium}" />
+                            </Grid>
+                        </DataTemplate>
+                    </dui:CollectionView.ItemTemplate>
+                </dui:CollectionView>
+            </dui:VerticalStackLayout>
+        </dui:VerticalStackLayout>
+    </dui:ScrollView>
+</dui:ContentPage>

--- a/src/app/Playground/VetleSamples/CollectionViewTests/CornerRadiusRegressionCases.xaml.cs
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/CornerRadiusRegressionCases.xaml.cs
@@ -1,0 +1,9 @@
+namespace Playground.VetleSamples.CollectionViewTests;
+
+public partial class CornerRadiusRegressionCases
+{
+    public CornerRadiusRegressionCases()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/app/Playground/VetleSamples/CollectionViewTests/CornerRadiusRegressionCasesViewModel.cs
+++ b/src/app/Playground/VetleSamples/CollectionViewTests/CornerRadiusRegressionCasesViewModel.cs
@@ -1,0 +1,101 @@
+using System.Collections.ObjectModel;
+
+namespace Playground.VetleSamples.CollectionViewTests;
+
+public class CornerRadiusRegressionCasesViewModel
+{
+    private int m_planElementCounter;
+
+    public CornerRadiusRegressionCasesViewModel()
+    {
+        AddLastPlanElementCommand = new Command(AddLastPlanElement);
+        MinimizeFirstPlanElementGroupCommand = new Command(MinimizeFirstPlanElementGroup);
+        ExpandFirstPlanElementGroupCommand = new Command(ExpandFirstPlanElementGroup);
+        ResetPlanElementGroupsCommand = new Command(ResetPlanElementGroups);
+
+        ResetPlanElementGroups();
+    }
+
+    public ObservableCollection<CornerRadiusCardItem> RootStyledCards { get; } =
+    [
+        new("Opprett dokument", "Template root has its own corner radius and stroke."),
+        new("Timebok", "CollectionView AutoCornerRadius is false."),
+        new("Kritisk informasjon", "The root styling should survive cell styling."),
+        new("Egne pasienter", "A neutral wrapper should not be required.")
+    ];
+
+    public ObservableCollection<PlanElementGroup> PlanElementGroups { get; } = [];
+
+    public Command AddLastPlanElementCommand { get; }
+    public Command MinimizeFirstPlanElementGroupCommand { get; }
+    public Command ExpandFirstPlanElementGroupCommand { get; }
+    public Command ResetPlanElementGroupsCommand { get; }
+
+    private void AddLastPlanElement()
+    {
+        if (PlanElementGroups.Count == 0)
+            ResetPlanElementGroups();
+
+        PlanElementGroups[0].Add(CreatePlanElement("Nytt nederste planelement", "New last item should take bottom corner radius and hide the divider.", "#8E7CC3"));
+    }
+
+    private void MinimizeFirstPlanElementGroup()
+    {
+        if (PlanElementGroups.Count == 0)
+            return;
+
+        while (PlanElementGroups[0].Count > 1)
+        {
+            PlanElementGroups[0].RemoveAt(PlanElementGroups[0].Count - 1);
+        }
+    }
+
+    private void ExpandFirstPlanElementGroup()
+    {
+        if (PlanElementGroups.Count == 0)
+            ResetPlanElementGroups();
+
+        while (PlanElementGroups[0].Count < 4)
+        {
+            AddLastPlanElement();
+        }
+    }
+
+    private void ResetPlanElementGroups()
+    {
+        m_planElementCounter = 0;
+        PlanElementGroups.Clear();
+
+        PlanElementGroups.Add(new PlanElementGroup("Runtime mutation section",
+        [
+            CreatePlanElement("Forste planelement", "Should have top corners.", "#69B7D6"),
+            CreatePlanElement("Midterste planelement", "Should not have rounded corners.", "#7BBF8A"),
+            CreatePlanElement("Nederste planelement", "Should have bottom corners and no divider.", "#F07F7F")
+        ]));
+
+        PlanElementGroups.Add(new PlanElementGroup("Single item section",
+        [
+            CreatePlanElement("Eneste planelement", "Should have all corners and no divider.", "#F4B740")
+        ]));
+    }
+
+    private PlanElementItem CreatePlanElement(string title, string description, string color)
+    {
+        m_planElementCounter++;
+        return new PlanElementItem($"{title} {m_planElementCounter}", description, Color.FromArgb(color));
+    }
+}
+
+public record CornerRadiusCardItem(string Title, string Description);
+
+public class PlanElementGroup : ObservableCollection<PlanElementItem>
+{
+    public PlanElementGroup(string header, IEnumerable<PlanElementItem> items) : base(items)
+    {
+        Header = header;
+    }
+
+    public string Header { get; }
+}
+
+public record PlanElementItem(string Title, string Description, Color StatusColor);

--- a/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/iOS/CollectionViewHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Lists/CollectionView/iOS/CollectionViewHandler.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Specialized;
+using CoreAnimation;
 using DIPS.Mobile.UI.Components.Dividers;
 using DIPS.Mobile.UI.Effects.Accessibility.Effects;
 using DIPS.Mobile.UI.Effects.Layout;
@@ -79,6 +80,7 @@ public class ReorderableItemsViewController(
 {
     private INotifyCollectionChanged? m_observableSource;
     private readonly List<INotifyCollectionChanged> m_observableGroups = [];
+    private readonly Dictionary<IntPtr, CornerRadiusState> m_originalCornerRadiusStates = [];
 
     #region Lifecycle
 
@@ -95,6 +97,7 @@ public class ReorderableItemsViewController(
         {
             UnsubscribeFromItemsSource();
             mauiCollectionView.PropertyChanged -= OnMauiPropertyChanged;
+            m_originalCornerRadiusStates.Clear();
         }
         base.Dispose(disposing);
     }
@@ -197,7 +200,7 @@ public class ReorderableItemsViewController(
 
         if (!hasCustomFirstCornerRadius && !hasCustomLastCornerRadius && !hasAutoCornerRadius)
         {
-            ResetCornerRadius(contentView);
+            RestoreOriginalCornerRadius(contentView);
             return;
         }
 
@@ -205,22 +208,35 @@ public class ReorderableItemsViewController(
 
         if (!cornerRadius.IsEmpty())
         {
-            contentView.ClipsToBounds = true;
-            contentView.Layer.CornerRadius = (nfloat)cornerRadius.HighestCornerRadius();
-            contentView.Layer.MaskedCorners = CACornerMaskHelper.GetCACornerMask(cornerRadius);
+            ApplyCollectionViewCornerRadius(contentView, cornerRadius);
         }
         else
         {
-            ResetCornerRadius(contentView);
+            RestoreOriginalCornerRadius(contentView);
         }
     }
 
-    private static void ResetCornerRadius(UIView contentView)
+    private void ApplyCollectionViewCornerRadius(UIView contentView, CornerRadius cornerRadius)
     {
-        contentView.ClipsToBounds = false;
-        contentView.Layer.CornerRadius = 0;
-        contentView.Layer.MaskedCorners = 0;
+        var key = contentView.Handle;
+        m_originalCornerRadiusStates.TryAdd(key, new CornerRadiusState(contentView.ClipsToBounds, contentView.Layer.CornerRadius, contentView.Layer.MaskedCorners));
+
+        contentView.ClipsToBounds = true;
+        contentView.Layer.CornerRadius = (nfloat)cornerRadius.HighestCornerRadius();
+        contentView.Layer.MaskedCorners = CACornerMaskHelper.GetCACornerMask(cornerRadius);
     }
+
+    private void RestoreOriginalCornerRadius(UIView contentView)
+    {
+        if (!m_originalCornerRadiusStates.Remove(contentView.Handle, out var originalState))
+            return;
+
+        contentView.ClipsToBounds = originalState.ClipsToBounds;
+        contentView.Layer.CornerRadius = originalState.CornerRadius;
+        contentView.Layer.MaskedCorners = originalState.MaskedCorners;
+    }
+
+    private readonly record struct CornerRadiusState(bool ClipsToBounds, nfloat CornerRadius, CACornerMask MaskedCorners);
 
     private CornerRadius GetCornerRadius(bool isFirst, bool isLast, bool hasCustomFirstCornerRadius, bool hasCustomLastCornerRadius, bool hasAutoCornerRadius)
     {


### PR DESCRIPTION
### Description of Change

Fixes an iOS `CollectionView` styling regression where disabling `dui:Layout.AutoCornerRadius` on the `CollectionView` could still clear corner radius and stroke styling owned by the item template root.

The iOS handler now tracks corner radius state only when the `CollectionView` applies its own first/last-item radius, and restores only that handler-owned state when an item no longer needs automatic radius. This keeps template-root `dui:Layout.CornerRadius` and `dui:Layout.Stroke` intact while preserving the grouped runtime restyling behavior added in #884.

This PR also adds a Playground regression page with two focused cases:

- Template-root styling with `AutoCornerRadius="False"` for the Arena Mobil #1723 scenario.
- Grouped auto corner radius and auto-hide-last-divider runtime mutations to guard the #638 behavior from #884.

Validation:

- Built `src/app/Playground/Playground.csproj -f net10.0-ios -c Debug` successfully.
- Verified the Playground regression cases on iOS.
- Verified the Playground regression cases on Android.

### Todos
- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [x] I have supported accessibility. No accessibility changes.