### PR TITLE
Fix iOS image capture gallery preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [60.2.15]
+- [ImageCapture][iOS] Fixed full-screen gallery previews showing black images when opened from thumbnails.
+
 ## [60.2.14]
 - [CollectionView][iOS] Fixed item template root corner radius and stroke being cleared when `AutoCornerRadius` is disabled.
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/GalleryBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/GalleryBottomSheet.cs
@@ -8,6 +8,7 @@ using DIPS.Mobile.UI.API.Camera.Shared;
 using DIPS.Mobile.UI.Components.Alerting.Dialog;
 using DIPS.Mobile.UI.Components.BottomSheets;
 using DIPS.Mobile.UI.Components.BottomSheets.Header;
+using DIPS.Mobile.UI.Converters.ValueConverters;
 using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
 using DIPS.Mobile.UI.Resources.Styles;
 using DIPS.Mobile.UI.Resources.Styles.Button;
@@ -260,7 +261,13 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
 
     private static View CreateImageView()
     {
-        return new CapturedImageCarouselItemView();
+        var image = new Image { VerticalOptions = LayoutOptions.Center };
+        image.SetBinding(
+            Image.SourceProperty,
+            static (CapturedImage capturedImage) => capturedImage.AsByteArray,
+            converter: new ByteArrayToImageSourceConverter());
+
+        return new Grid { Children = { image } };
     }
 
     private void OnImagesChanged()
@@ -377,27 +384,4 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
         m_rotatingImageTcs.SetResult();   
     }
 
-    private sealed class CapturedImageCarouselItemView : Grid
-    {
-        private readonly Image m_image = new()
-        {
-            Aspect = Aspect.AspectFit,
-            HorizontalOptions = LayoutOptions.Fill,
-            VerticalOptions = LayoutOptions.Fill
-        };
-
-        public CapturedImageCarouselItemView()
-        {
-            Add(m_image);
-        }
-
-        protected override void OnBindingContextChanged()
-        {
-            base.OnBindingContextChanged();
-
-            m_image.Source = BindingContext is CapturedImage capturedImage
-                ? ImageSource.FromStream(() => new MemoryStream(capturedImage.AsByteArray))
-                : null;
-        }
-    }
 }

--- a/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/GalleryBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/GalleryBottomSheet.cs
@@ -8,7 +8,6 @@ using DIPS.Mobile.UI.API.Camera.Shared;
 using DIPS.Mobile.UI.Components.Alerting.Dialog;
 using DIPS.Mobile.UI.Components.BottomSheets;
 using DIPS.Mobile.UI.Components.BottomSheets.Header;
-using DIPS.Mobile.UI.Converters.ValueConverters;
 using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
 using DIPS.Mobile.UI.Resources.Styles;
 using DIPS.Mobile.UI.Resources.Styles.Button;
@@ -259,11 +258,9 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
         m_topToolbar.UpdateNumberOfImagesLabel(text);
     }
 
-    private static Image CreateImageView()
+    private static View CreateImageView()
     {
-        var image = new Image { VerticalOptions = LayoutOptions.Center };
-        image.SetBinding(Image.SourceProperty, new Binding(".", converter: new ByteArrayToImageSourceConverter()));
-        return image;
+        return new CapturedImageCarouselItemView();
     }
 
     private void OnImagesChanged()
@@ -273,7 +270,7 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
             Close();
             return;
         }
-        
+
         if(m_positionBeforeRemoval > Images.Count - 1)
             m_positionBeforeRemoval = Images.Count - 1;
 
@@ -310,7 +307,7 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
             Loop = false,
             ItemTemplate = new DataTemplate(CreateImageView),
             Position = carouselViewPosition, 
-            ItemsSource = Images.Select(i => i.AsByteArray)
+            ItemsSource = Images
         };
         m_carouselViewWrapperView.Content = m_carouselView;
         
@@ -378,5 +375,29 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
         }));
             
         m_rotatingImageTcs.SetResult();   
+    }
+
+    private sealed class CapturedImageCarouselItemView : Grid
+    {
+        private readonly Image m_image = new()
+        {
+            Aspect = Aspect.AspectFit,
+            HorizontalOptions = LayoutOptions.Fill,
+            VerticalOptions = LayoutOptions.Fill
+        };
+
+        public CapturedImageCarouselItemView()
+        {
+            Add(m_image);
+        }
+
+        protected override void OnBindingContextChanged()
+        {
+            base.OnBindingContextChanged();
+
+            m_image.Source = BindingContext is CapturedImage capturedImage
+                ? ImageSource.FromStream(() => new MemoryStream(capturedImage.AsByteArray))
+                : null;
+        }
     }
 }


### PR DESCRIPTION
### Description of Change

Fixes iOS full-screen ImageCapture gallery previews rendering black when opened from thumbnails.

The CarouselView now displays `CapturedImage` items through a dedicated item view that creates the image source directly from captured bytes, avoiding the byte-array converter path that failed to render on iOS.

Verified with `dotnet build src/library/DIPS.Mobile.UI/DIPS.Mobile.UI.csproj -f net10.0-ios`.

### Todos
- [ ] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [x] I have supported accessibility