### PR TITLE
Remove BarcodeScanner duplicate scan suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [60.5.1]
+- [BarcodeScanner] Fixed repeated scans of the same barcode being suppressed after the scanner resumes.
+
 ## [60.5.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## [60.5.1]
-- [BarcodeScanner] Fixed repeated scans of the same barcode being suppressed after the scanner resumes.
+## [61.0.0]
+- [BarcodeScanner] **BREAKING**: Removed `BarcodeScannerStartOptions.DuplicateScanCooldown`. Repeated scans of the same barcode are no longer suppressed after the scanner resumes.
 
 ## [60.5.0] 
 - Resources was updated from DIPS.Mobile.DesignTokens

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScanner.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScanner.cs
@@ -7,8 +7,6 @@ namespace DIPS.Mobile.UI.API.Camera.BarcodeScanning;
 
 public partial class BarcodeScanner : ICameraUseCase
 {
-    private const int CooldownTimeout = 500;
-
     // Session lifecycle
     private BarcodeScannerStartOptions m_currentStartOptions = new();
     private BarcodeScanSession? m_scanSession;
@@ -18,11 +16,8 @@ public partial class BarcodeScanner : ICameraUseCase
     private bool m_isDisposed;
     private bool m_isPlatformStarted;
 
-    // Detection pipeline & cooldown
+    // Detection pipeline
     private readonly BarcodeDetectionAggregator m_detectionAggregator = new();
-    private readonly HashSet<string> m_confirmedBarcodeValues = new(StringComparer.Ordinal);
-    private bool m_isCoolingDown;
-    private Timer? m_cooldownTimer;
     private CancellationTokenSource? m_automaticHintCts;
     private bool m_hasCompletedAutomaticHint;
 
@@ -70,9 +65,7 @@ public partial class BarcodeScanner : ICameraUseCase
         m_confirmationHandler?.Dispose();
         m_confirmationHandler = null;
         ResetScanState();
-        DisposeCooldownTimer();
         m_hasCompletedAutomaticHint = false;
-        m_confirmedBarcodeValues.Clear();
 
         m_scanSession?.Dispose();
         m_scanSession = new BarcodeScanSession(m_currentStartOptions, StopPlatformIfNeededAsync);
@@ -182,9 +175,7 @@ public partial class BarcodeScanner : ICameraUseCase
             EndCurrentScanRun();
             m_scanSession?.PauseScanning();
             ResetBarcodeConfirmationState(resetOverlay);
-            DisposeCooldownTimer();
             StopAutomaticHint();
-            m_confirmedBarcodeValues.Clear();
         }
         catch (Exception e)
         {
@@ -205,8 +196,6 @@ public partial class BarcodeScanner : ICameraUseCase
             BeginNewScanRun();
             ResetScanState();
             m_confirmationHandler?.Reset();
-            DisposeCooldownTimer();
-            m_confirmedBarcodeValues.Clear();
             m_scanSession?.ResumeScanning();
             RestartAutomaticHintTimer();
         }
@@ -237,7 +226,6 @@ public partial class BarcodeScanner : ICameraUseCase
         EndCurrentScanRun();
         StopPlatformIfNeeded();
         ResetBarcodeConfirmationState(resetOverlay);
-        DisposeCooldownTimer();
         StopAutomaticHint();
         m_confirmationHandler?.Dispose();
         m_confirmationHandler = null;
@@ -266,15 +254,6 @@ public partial class BarcodeScanner : ICameraUseCase
             return;
 
         StopAutomaticHint();
-
-        if (m_confirmedBarcodeValues.Contains(barcodeKey))
-        {
-            m_confirmationHandler?.OnConfirmedBarcodeRedetected();
-            return;
-        }
-
-        if (m_isCoolingDown)
-            return;
 
         m_detectionAggregator.AddObservation(barcode);
 
@@ -319,11 +298,6 @@ public partial class BarcodeScanner : ICameraUseCase
         }
 
         Log($"The most detected bar code: {mostDetectedBarcodeObservation.Barcode}");
-        foreach (var obs in orderedObservations)
-        {
-            m_confirmedBarcodeValues.Add(BarcodeDetectionAggregator.GetBarcodeKey(obs.Barcode));
-        }
-
         ResetBarcodeConfirmationState(resetOverlay: false);
 
         var barcodeScanResult = new BarcodeScanResult(mostDetectedBarcodeObservation.Barcode,
@@ -375,40 +349,9 @@ public partial class BarcodeScanner : ICameraUseCase
         if (!IsSessionActive)
             return;
 
-        m_confirmedBarcodeValues.Clear();
         ResetScanState();
         m_scanRectangleOverlay?.ResetBarcodeDetection();
         RestartAutomaticHintTimer();
-    }
-
-    private void StartCooldown()
-    {
-        m_isCoolingDown = true;
-        m_cooldownTimer?.Dispose();
-        var scanRunId = CurrentScanRunId;
-        m_cooldownTimer = new Timer(_ => MainThread.BeginInvokeOnMainThread(() => FinishCooldown(scanRunId)),
-            null, (int)Math.Max(m_currentStartOptions.DuplicateScanCooldown.TotalMilliseconds, CooldownTimeout), Timeout.Infinite);
-    }
-
-    private void FinishCooldown(int scanRunId)
-    {
-        if (scanRunId != CurrentScanRunId)
-            return;
-
-        m_isCoolingDown = false;
-        if (m_scanRectangleOverlay is null)
-        {
-            m_confirmedBarcodeValues.Clear();
-        }
-        m_cooldownTimer?.Dispose();
-        m_cooldownTimer = null;
-    }
-
-    private void DisposeCooldownTimer()
-    {
-        m_cooldownTimer?.Dispose();
-        m_cooldownTimer = null;
-        m_isCoolingDown = false;
     }
 
     private void RestartAutomaticHintTimer()
@@ -553,7 +496,6 @@ public partial class BarcodeScanner : ICameraUseCase
         if (!CanResumeSession)
             return;
 
-        StartCooldown();
         m_scanSession?.ResumeScanning();
         RestartAutomaticHintTimer();
     }

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScannerStartOptions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScannerStartOptions.cs
@@ -52,7 +52,9 @@ public class BarcodeScannerStartOptions
     public BarcodeScannerHintOptions Hint { get; set; } = new();
 
     /// <summary>
-    /// Gets or sets the cooldown applied after a scan has been accepted or rejected.
+    /// Gets or sets the legacy duplicate scan cooldown value.
     /// </summary>
+    /// <remarks>The scanner no longer suppresses repeated barcode values, so this setting is ignored.</remarks>
+    [Obsolete("BarcodeScanner no longer suppresses duplicate scans. This setting is ignored.")]
     public TimeSpan DuplicateScanCooldown { get; set; } = TimeSpan.FromMilliseconds(800);
 }

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScannerStartOptions.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/BarcodeScannerStartOptions.cs
@@ -50,11 +50,4 @@ public class BarcodeScannerStartOptions
     /// Gets or sets automatic hint options for scan rectangle barcode scanner sessions.
     /// </summary>
     public BarcodeScannerHintOptions Hint { get; set; } = new();
-
-    /// <summary>
-    /// Gets or sets the legacy duplicate scan cooldown value.
-    /// </summary>
-    /// <remarks>The scanner no longer suppresses repeated barcode values, so this setting is ignored.</remarks>
-    [Obsolete("BarcodeScanner no longer suppresses duplicate scans. This setting is ignored.")]
-    public TimeSpan DuplicateScanCooldown { get; set; } = TimeSpan.FromMilliseconds(800);
 }

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/IBarcodeConfirmationHandler.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/IBarcodeConfirmationHandler.cs
@@ -8,15 +8,9 @@ namespace DIPS.Mobile.UI.API.Camera.BarcodeScanning;
 internal interface IBarcodeConfirmationHandler : IDisposable
 {
     /// <summary>
-    /// Called when a new (unconfirmed, non-cooldown) barcode observation has been recorded.
+    /// Called when a barcode observation has been recorded.
     /// </summary>
     void OnBarcodeDetected(RectF? overlayBounds);
-
-    /// <summary>
-    /// Called when an already-confirmed barcode is detected again.
-    /// Keeps the overlay barcode-lost timer alive in overlay mode; no-op in timer mode.
-    /// </summary>
-    void OnConfirmedBarcodeRedetected();
 
     /// <summary>
     /// Resets transient tracking state (e.g. bracket animation flags) without disposing timers.

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/OverlayBarcodeConfirmationHandler.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/OverlayBarcodeConfirmationHandler.cs
@@ -77,11 +77,6 @@ internal sealed class OverlayBarcodeConfirmationHandler : IBarcodeConfirmationHa
         }
     }
 
-    public void OnConfirmedBarcodeRedetected()
-    {
-        ResetBarcodeLostTimer();
-    }
-
     public void ResetTrackingState()
     {
         m_isTrackingBarcode = false;

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/TimerBarcodeConfirmationHandler.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/TimerBarcodeConfirmationHandler.cs
@@ -36,11 +36,6 @@ internal sealed class TimerBarcodeConfirmationHandler : IBarcodeConfirmationHand
             null, m_detectionTime, Timeout.InfiniteTimeSpan);
     }
 
-    public void OnConfirmedBarcodeRedetected()
-    {
-        // No barcode-lost tracking in timer mode.
-    }
-
     public void ResetTrackingState()
     {
         // No transient tracking state in timer mode.

--- a/wiki/Media/Camera.md
+++ b/wiki/Media/Camera.md
@@ -71,7 +71,7 @@ protected override void OnAppearing()
 > Notice that `CameraPreview` is the code behind reference from the preview guide.
 
 ## Validate barcodes before accepting them
-Use `ValidateBarcodeAsync` when the scanner should ask your app whether a detected barcode belongs in the current workflow before playing the success animation. If validation returns invalid, the scanner plays the failure animation, does not increment the progress counter, and then resumes scanning.
+Use `ValidateBarcodeAsync` when the scanner should ask your app whether a detected barcode belongs in the current workflow before playing the success animation. If validation returns invalid, the scanner plays the failure animation, does not increment the progress counter, and then resumes scanning. Repeated scans of the same barcode are processed like any other scan; reject already-scanned values in `ValidateBarcodeAsync` when your workflow needs that behavior.
 
 ```csharp
 private readonly BarcodeScanner m_scanner = new();

--- a/wiki/Media/Camera.md
+++ b/wiki/Media/Camera.md
@@ -71,7 +71,7 @@ protected override void OnAppearing()
 > Notice that `CameraPreview` is the code behind reference from the preview guide.
 
 ## Validate barcodes before accepting them
-Use `ValidateBarcodeAsync` when the scanner should ask your app whether a detected barcode belongs in the current workflow before playing the success animation. If validation returns invalid, the scanner plays the failure animation, does not increment the progress counter, and resumes scanning after a short cooldown.
+Use `ValidateBarcodeAsync` when the scanner should ask your app whether a detected barcode belongs in the current workflow before playing the success animation. If validation returns invalid, the scanner plays the failure animation, does not increment the progress counter, and then resumes scanning.
 
 ```csharp
 private readonly BarcodeScanner m_scanner = new();


### PR DESCRIPTION
### Description of Change

Removes the repeated-barcode suppression path in `BarcodeScanner` so the same barcode can be confirmed again after scanning resumes. Repeated detections now flow through the normal observation and confirmation pipeline.

This also removes `BarcodeScannerStartOptions.DuplicateScanCooldown`, since the scanner no longer applies a duplicate scan cooldown. The changelog is bumped to `61.0.0` and marks the API removal as breaking.

Updated the Camera wiki page to document that repeated scans of the same barcode are processed like any other scan, and that apps should reject already-scanned values in `ValidateBarcodeAsync` when needed.

Validation: `dotnet build src/library/DIPS.Mobile.UI/DIPS.Mobile.UI.csproj -f net10.0 --nologo -v minimal` succeeds with existing NuGet warning noise.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility (not applicable; scanner behavior only)
