### PR TITLE
Fix intermittent iOS gallery black images in CarouselView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 - [Checkmark] Added `AddStrokeToCheckmark` property to display a visible stroke around the checkmark
 - [CheckmarkListItem] Added `AddStrokeToCheckmark` property to display a visible stroke around the checkmark icon
 
+## [60.2.16]
+- [ImageCapture][iOS] Fixed intermittent black images in full-screen gallery previews by refreshing stream-backed sources for current and neighboring carousel items during position updates.
+
 ## [60.2.15]
 - [ImageCapture][iOS] Fixed full-screen gallery previews showing black images when opened from thumbnails.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [61.5.0]
+- [ImageCapture][iOS] Fixed intermittent black images in full-screen gallery previews by refreshing stream-backed sources for current and neighboring carousel items during position updates.
+
 ## [61.4.0]
 - [ImageCapture] When taking several photos in a row, the most recent photo now shows as a thumbnail in the bottom-left corner of the camera and updates with each capture. The thumbnail can be tapped to review and/or remove photos from the capture session.
 - [ImageCapture] Added MaxImageCount with a default of 15 when using MultiImageCapture to avoid crash as images are stored in-memory only.

--- a/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/GalleryBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/GalleryBottomSheet.cs
@@ -8,10 +8,10 @@ using DIPS.Mobile.UI.API.Camera.Shared;
 using DIPS.Mobile.UI.Components.Alerting.Dialog;
 using DIPS.Mobile.UI.Components.BottomSheets;
 using DIPS.Mobile.UI.Components.BottomSheets.Header;
-using DIPS.Mobile.UI.Converters.ValueConverters;
 using DIPS.Mobile.UI.Resources.LocalizedStrings.LocalizedStrings;
 using DIPS.Mobile.UI.Resources.Styles;
 using DIPS.Mobile.UI.Resources.Styles.Button;
+using System.ComponentModel;
 
 #if __IOS__
 using UIKit;
@@ -37,6 +37,7 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
     private readonly Grid m_grid;
     private readonly GalleryBottomSheetTopToolbar m_topToolbar;
     private readonly GalleryBottomSheetBottomToolbar m_bottomToolbar;
+    private List<GalleryImageItem> m_galleryImageItems = [];
     
     private CarouselView? m_carouselView;
     private CancellationTokenSource m_cancellationTokenSource = new();
@@ -202,12 +203,19 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
 
     public Task Close(bool animated = true)
     {
+        DisposeGalleryImageItems();
         return Shell.Current.Navigation.PopModalAsync(true);
     }
 
     protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
         base.OnHandlerChanging(args);
+
+        if(args.NewHandler is null)
+        {
+            DisposeGalleryImageItems();
+            return;
+        }
 
         if (args.NewHandler is not null)
         {
@@ -237,6 +245,12 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
             
             UpdateNavigationButtonsVisibility(currentPosition);
             m_currentlyCapturedImageDisplayed = Images[currentPosition];
+#if __IOS__
+            // CarouselView reuses native cells on iOS, which can leave neighbor items with stale
+            // stream image state. Refreshing adjacent sources ensures they reload correctly.
+            RefreshImageSource(currentPosition - 1);
+            RefreshImageSource(currentPosition + 1);
+#endif
             
             UpdateNumberOfImagesLabel(currentPosition);
         }
@@ -259,15 +273,69 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
         m_topToolbar.UpdateNumberOfImagesLabel(text);
     }
 
+    private void RefreshImageSource(int index)
+    {
+        if(index < 0 || index >= m_galleryImageItems.Count)
+            return;
+
+        m_galleryImageItems[index].RefreshSource();
+    }
+
     private static View CreateImageView()
     {
-        var image = new Image { VerticalOptions = LayoutOptions.Center };
-        image.SetBinding(
-            Image.SourceProperty,
-            static (CapturedImage capturedImage) => capturedImage.AsByteArray,
-            converter: new ByteArrayToImageSourceConverter());
+        return new ImageView();
+    }
 
-        return new Grid { Children = { image } };
+    private sealed class ImageView : Grid
+    {
+        private readonly Image m_image = new()
+        {
+            VerticalOptions = LayoutOptions.Center
+        };
+
+        public ImageView()
+        {
+            m_image.SetBinding(Image.SourceProperty, new Binding(nameof(GalleryImageItem.Source)));
+            Children.Add(m_image);
+        }
+    }
+
+    private sealed class GalleryImageItem : INotifyPropertyChanged
+    {
+        private ImageSource? m_source;
+
+        public GalleryImageItem(CapturedImage capturedImage)
+        {
+            CapturedImage = capturedImage;
+            RefreshSource();
+        }
+
+        private CapturedImage CapturedImage { get; }
+
+        public ImageSource? Source
+        {
+            get => m_source;
+            private set
+            {
+                if (ReferenceEquals(m_source, value))
+                    return;
+
+                m_source = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Source)));
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public void RefreshSource()
+        {
+            Source = ImageSource.FromStream(() => new MemoryStream(CapturedImage.AsByteArray));
+        }
+    }
+
+    private void DisposeGalleryImageItems()
+    {
+        m_galleryImageItems.Clear();
     }
 
     private void OnImagesChanged()
@@ -296,6 +364,8 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
             }
         }
 
+        DisposeGalleryImageItems();
+
         var carouselViewPosition = m_startingIndex;
         
         if(m_positionBeforeRemoval is not null)
@@ -314,7 +384,7 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
             Loop = false,
             ItemTemplate = new DataTemplate(CreateImageView),
             Position = carouselViewPosition, 
-            ItemsSource = Images
+            ItemsSource = m_galleryImageItems = Images.Select(image => new GalleryImageItem(image)).ToList()
         };
         m_carouselViewWrapperView.Content = m_carouselView;
         

--- a/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/GalleryBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/GalleryBottomSheet.cs
@@ -246,8 +246,11 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
             UpdateNavigationButtonsVisibility(currentPosition);
             m_currentlyCapturedImageDisplayed = Images[currentPosition];
 #if __IOS__
-            // CarouselView reuses native cells on iOS, which can leave neighbor items with stale
-            // stream image state. Refreshing adjacent sources ensures they reload correctly.
+            // CarouselView reuses native cells on iOS, which can leave current/neighbor items
+            // with stale stream image state. Refreshing them ensures they reload correctly.
+            // Repro example: Capture 3 images. Open image 1, swipe to 3, close. Open image 2,
+            // swipe to 1 (ok), then to 3 (can become black). Similar inverse repro from 3 -> 1.
+            RefreshImageSource(currentPosition);
             RefreshImageSource(currentPosition - 1);
             RefreshImageSource(currentPosition + 1);
 #endif


### PR DESCRIPTION
### Description of Change
- Fixes intermittent black images in full-screen ImageCapture gallery on iOS.
- Refreshes stream-backed image sources for the current and neighboring carousel items during position updates to avoid stale reused cells.
- Includes changelog entries for version 60.2.16 and latest version 61.5.0 with matching text.

### Todos
- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [x] I have supported accessibility