### PR TITLE
Fix iOS Touch gestures behind overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [61.5.1]
+- [Touch][iOS] Fixed scroll gestures on tappable rows getting stuck after dismissing context menus or picker popovers, and prevented taps behind open overlays from activating touch commands.
+
 ## [61.5.0]
 - [ImageCapture][iOS] Fixed intermittent black images in full-screen gallery previews by refreshing stream-backed sources for current and neighboring carousel items during position updates.
 

--- a/src/app/Playground/MainPage.xaml
+++ b/src/app/Playground/MainPage.xaml
@@ -27,6 +27,10 @@
                                     Tapped="GoToCollectionViewTests" />
             <dui:NavigationListItem Title="ItemPicker Refresh Repro"
                                     Tapped="GoToItemPickerRefreshRepro" />
+            <dui:NavigationListItem Title="Patient List Menu Fling Repro"
+                                    Tapped="GoToPatientListMenuFlingRepro" />
+            <dui:NavigationListItem Title="DatePicker Fling Repro"
+                                    Tapped="GoToDatePickerFlingRepro" />
             <dui:NavigationListItem Title="Barcode Resume Repro (#1415)"
                                     Tapped="GoToBarcodeScanResumeRepro" />
             <dui:NavigationListItem Title="Barcode Resume Repro (Modal)"

--- a/src/app/Playground/MainPage.xaml.cs
+++ b/src/app/Playground/MainPage.xaml.cs
@@ -94,6 +94,16 @@ public partial class MainPage
         Shell.Current.Navigation.PushAsync(new ItemPickerRefreshRepro());
     }
 
+    private void GoToPatientListMenuFlingRepro(object sender, EventArgs e)
+    {
+        Shell.Current.Navigation.PushAsync(new PatientListMenuFlingReproPage());
+    }
+
+    private void GoToDatePickerFlingRepro(object sender, EventArgs e)
+    {
+        Shell.Current.Navigation.PushAsync(new DatePickerFlingReproPage());
+    }
+
     private void GoToCollectionViewTests(object sender, EventArgs e)
     {
         Shell.Current.Navigation.PushAsync(new CollectionViewTests());

--- a/src/app/Playground/VetleSamples/DatePickerFlingReproPage.cs
+++ b/src/app/Playground/VetleSamples/DatePickerFlingReproPage.cs
@@ -1,0 +1,212 @@
+using System.Collections.ObjectModel;
+using DIPS.Mobile.UI.Effects.Touch;
+using DIPS.Mobile.UI.Resources.Colors;
+using DIPS.Mobile.UI.Resources.Sizes;
+using DIPS.Mobile.UI.Resources.Styles;
+using DIPS.Mobile.UI.Resources.Styles.Label;
+using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
+using DuiDateAndTimePicker = DIPS.Mobile.UI.Components.Pickers.DateAndTimePicker.DateAndTimePicker;
+using DuiCollectionView = DIPS.Mobile.UI.Components.Lists.CollectionView;
+using DuiContentPage = DIPS.Mobile.UI.Components.Pages.ContentPage;
+using DuiDatePicker = DIPS.Mobile.UI.Components.Pickers.DatePicker.DatePicker;
+using DuiLabel = DIPS.Mobile.UI.Components.Labels.Label;
+using DuiRefreshView = DIPS.Mobile.UI.Components.Loading.RefreshView;
+using DuiTimePicker = DIPS.Mobile.UI.Components.Pickers.TimePicker.TimePicker;
+
+namespace Playground.VetleSamples;
+
+public class DatePickerFlingReproPage : DuiContentPage
+{
+    private readonly ObservableCollection<DatePickerReproItem> m_items = new(
+        Enumerable.Range(1, 80).Select(index => new DatePickerReproItem(index)));
+
+    private readonly DuiLabel m_statusLabel = new()
+    {
+        Style = Styles.GetLabelStyle(LabelStyle.UI200),
+        Text = "No selection yet"
+    };
+
+    public DatePickerFlingReproPage()
+    {
+        Title = "DatePicker Fling Repro";
+
+        var header = new Grid
+        {
+            Padding = new Thickness(
+                Sizes.GetSize(SizeName.size_5),
+                Sizes.GetSize(SizeName.size_4),
+                Sizes.GetSize(SizeName.size_5),
+                Sizes.GetSize(SizeName.size_2))
+        };
+
+        header.Add(new DuiLabel
+        {
+            Text = "Picker rows (80)",
+            Style = Styles.GetLabelStyle(LabelStyle.SectionHeader),
+            VerticalTextAlignment = TextAlignment.Center
+        });
+
+        var collectionView = new DuiCollectionView
+        {
+            ItemSpacing = Sizes.GetSize(SizeName.size_2),
+            ShouldBounce = true,
+            HasAdditionalSpaceAtTheEnd = true,
+            ItemsSource = m_items,
+            ItemTemplate = new DataTemplate(CreateDatePickerCell),
+            EmptyView = m_statusLabel
+        };
+
+        var refreshView = new DuiRefreshView
+        {
+            Content = collectionView,
+            Command = new Command(() => SetStatus("Refresh completed"))
+        };
+
+        refreshView.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == DuiRefreshView.IsRefreshingProperty.PropertyName && refreshView.IsRefreshing)
+            {
+                refreshView.IsRefreshing = false;
+            }
+        };
+
+        Grid.SetRow(refreshView, 1);
+
+        Content = new Grid
+        {
+            RowDefinitions =
+            [
+                new RowDefinition(GridLength.Auto),
+                new RowDefinition(GridLength.Star)
+            ],
+            Children =
+            {
+                header,
+                refreshView
+            }
+        };
+    }
+
+    private View CreateDatePickerCell()
+    {
+        var root = new Grid
+        {
+            ColumnDefinitions =
+            [
+                new ColumnDefinition(GridLength.Star),
+                new ColumnDefinition(GridLength.Auto)
+            ],
+            ColumnSpacing = Sizes.GetSize(SizeName.size_3),
+            Padding = new Thickness(Sizes.GetSize(SizeName.size_3), Sizes.GetSize(SizeName.size_2)),
+            BackgroundColor = Colors.GetColor(ColorName.color_surface_default)
+        };
+
+        Touch.SetCommand(root, new Command(() => SetStatus("Date row tapped")));
+        SemanticProperties.SetDescription(root, "Date row");
+
+        var textGrid = new Grid
+        {
+            RowDefinitions =
+            [
+                new RowDefinition(GridLength.Auto),
+                new RowDefinition(GridLength.Auto)
+            ]
+        };
+
+        var titleLabel = new DuiLabel
+        {
+            Style = Styles.GetLabelStyle(LabelStyle.UI300),
+            MaxLines = 1,
+            LineBreakMode = LineBreakMode.TailTruncation
+        };
+        titleLabel.SetBinding(Label.TextProperty, nameof(DatePickerReproItem.Title));
+
+        var subtitleLabel = new DuiLabel
+        {
+            Style = Styles.GetLabelStyle(LabelStyle.UI200),
+            TextColor = Colors.GetColor(ColorName.color_text_subtle)
+        };
+        subtitleLabel.SetBinding(Label.TextProperty, nameof(DatePickerReproItem.Subtitle));
+
+        textGrid.Add(titleLabel);
+        textGrid.Add(subtitleLabel, 0, 1);
+
+        var picker = CreatePicker();
+
+        root.Add(textGrid);
+        root.Add(picker, 1);
+
+        return root;
+    }
+
+    private View CreatePicker()
+    {
+        var datePicker = new DuiDatePicker
+        {
+            IgnoreLocalTime = true,
+            HorizontalOptions = LayoutOptions.End,
+            VerticalOptions = LayoutOptions.Center
+        };
+        datePicker.SetBinding(DuiDatePicker.SelectedDateProperty, nameof(DatePickerReproItem.Date));
+        datePicker.SelectedDateCommand = new Command<DateTime?>(date =>
+            SetStatus(date.HasValue ? $"Date selected: {date.Value:yyyy-MM-dd}" : "Date cleared"));
+
+        var timePicker = new DuiTimePicker
+        {
+            HorizontalOptions = LayoutOptions.End,
+            VerticalOptions = LayoutOptions.Center
+        };
+        timePicker.SetBinding(DuiTimePicker.SelectedTimeProperty, nameof(DatePickerReproItem.Time));
+        timePicker.SelectedTimeCommand = new Command<TimeSpan?>(time =>
+            SetStatus(time.HasValue ? $"Time selected: {time.Value:hh\\:mm}" : "Time cleared"));
+
+        var dateAndTimePicker = new DuiDateAndTimePicker
+        {
+            IgnoreLocalTime = true,
+            HorizontalOptions = LayoutOptions.End,
+            VerticalOptions = LayoutOptions.Center
+        };
+        dateAndTimePicker.SetBinding(DuiDateAndTimePicker.SelectedDateTimeProperty, nameof(DatePickerReproItem.DateAndTime));
+        dateAndTimePicker.SelectedDateTimeCommand = new Command<DateTime?>(dateTime =>
+            SetStatus(dateTime.HasValue ? $"Date and time selected: {dateTime.Value:yyyy-MM-dd HH:mm}" : "Date and time cleared"));
+
+        datePicker.SetBinding(IsVisibleProperty, nameof(DatePickerReproItem.IsDatePicker));
+        timePicker.SetBinding(IsVisibleProperty, nameof(DatePickerReproItem.IsTimePicker));
+        dateAndTimePicker.SetBinding(IsVisibleProperty, nameof(DatePickerReproItem.IsDateAndTimePicker));
+
+        return new Grid
+        {
+            Children =
+            {
+                datePicker,
+                timePicker,
+                dateAndTimePicker
+            }
+        };
+    }
+
+    private void SetStatus(string status)
+    {
+        m_statusLabel.Text = status;
+        Console.WriteLine(status);
+    }
+
+    private sealed class DatePickerReproItem(int index)
+    {
+        public string Title { get; } = $"Picker row {index:00}";
+        public string Subtitle { get; } = GetSubtitle(index);
+        public DateTime Date { get; set; } = DateTime.Today.AddDays(index);
+        public TimeSpan Time { get; set; } = new(8 + index % 10, index % 60, 0);
+        public DateTime DateAndTime { get; set; } = DateTime.Today.AddDays(index).AddHours(8 + index % 10).AddMinutes(index % 60);
+        public bool IsDatePicker => index % 3 == 1;
+        public bool IsTimePicker => index % 3 == 2;
+        public bool IsDateAndTimePicker => index % 3 == 0;
+
+        private static string GetSubtitle(int index) => (index % 3) switch
+        {
+            1 => "DatePicker - open, dismiss, then scroll",
+            2 => "TimePicker - open, dismiss, then scroll",
+            _ => "DateAndTimePicker - open, dismiss, then scroll"
+        };
+    }
+}

--- a/src/app/Playground/VetleSamples/PatientListMenuFlingReproPage.cs
+++ b/src/app/Playground/VetleSamples/PatientListMenuFlingReproPage.cs
@@ -1,0 +1,246 @@
+using System.Collections.ObjectModel;
+using DIPS.Mobile.UI.Components.ContextMenus;
+using DIPS.Mobile.UI.Components.Dividers;
+using DIPS.Mobile.UI.Effects.Touch;
+using DIPS.Mobile.UI.Resources.Colors;
+using DIPS.Mobile.UI.Resources.Icons;
+using DIPS.Mobile.UI.Resources.Sizes;
+using DIPS.Mobile.UI.Resources.Styles;
+using DIPS.Mobile.UI.Resources.Styles.Label;
+using Colors = DIPS.Mobile.UI.Resources.Colors.Colors;
+using ContextMenu = DIPS.Mobile.UI.Components.ContextMenus.ContextMenu;
+using ContextMenuItem = DIPS.Mobile.UI.Components.ContextMenus.ContextMenuItem;
+using DuiCollectionView = DIPS.Mobile.UI.Components.Lists.CollectionView;
+using DuiContentPage = DIPS.Mobile.UI.Components.Pages.ContentPage;
+using DuiImage = DIPS.Mobile.UI.Components.Images.Image.Image;
+using DuiLabel = DIPS.Mobile.UI.Components.Labels.Label;
+using DuiRefreshView = DIPS.Mobile.UI.Components.Loading.RefreshView;
+
+namespace Playground.VetleSamples;
+
+public class PatientListMenuFlingReproPage : DuiContentPage
+{
+    private readonly ObservableCollection<PatientReproItem> m_items = new(
+        Enumerable.Range(1, 80).Select(index => new PatientReproItem(index)));
+
+    private readonly DuiLabel m_statusLabel = new()
+    {
+        Style = Styles.GetLabelStyle(LabelStyle.UI200),
+        Text = "No selection yet"
+    };
+
+    public PatientListMenuFlingReproPage()
+    {
+        Title = "Patient List Menu Fling Repro";
+
+        var header = new Grid
+        {
+            Padding = new Thickness(
+                Sizes.GetSize(SizeName.size_5),
+                Sizes.GetSize(SizeName.size_4),
+                Sizes.GetSize(SizeName.size_5),
+                Sizes.GetSize(SizeName.size_2))
+        };
+
+        header.Add(new DuiLabel
+        {
+            Text = "Patients (80)",
+            Style = Styles.GetLabelStyle(LabelStyle.SectionHeader),
+            VerticalTextAlignment = TextAlignment.Center
+        });
+
+        var collectionView = new DuiCollectionView
+        {
+            ItemSpacing = Sizes.GetSize(SizeName.size_2),
+            ShouldBounce = true,
+            HasAdditionalSpaceAtTheEnd = true,
+            ItemsSource = m_items,
+            ItemTemplate = new DataTemplate(CreatePatientCell),
+            EmptyView = m_statusLabel
+        };
+
+        var refreshView = new DuiRefreshView
+        {
+            Content = collectionView,
+            Command = new Command(() => SetStatus("Refresh completed"))
+        };
+
+        refreshView.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == DuiRefreshView.IsRefreshingProperty.PropertyName && refreshView.IsRefreshing)
+            {
+                refreshView.IsRefreshing = false;
+            }
+        };
+
+        Grid.SetRow(refreshView, 1);
+
+        Content = new Grid
+        {
+            RowDefinitions =
+            [
+                new RowDefinition(GridLength.Auto),
+                new RowDefinition(GridLength.Star)
+            ],
+            Children =
+            {
+                header,
+                refreshView
+            }
+        };
+    }
+
+    private View CreatePatientCell()
+    {
+        var root = new Grid
+        {
+            ColumnDefinitions =
+            [
+                new ColumnDefinition(GridLength.Star),
+                new ColumnDefinition(GridLength.Auto),
+                new ColumnDefinition(GridLength.Auto)
+            ],
+            Padding = new Thickness(Sizes.GetSize(SizeName.size_3), 0, 0, 0),
+            BackgroundColor = Colors.GetColor(ColorName.color_surface_default),
+            RowDefinitions = [new RowDefinition(GridLength.Auto)]
+        };
+
+        Touch.SetCommand(root, new Command(() => SetStatus("Patient row tapped")));
+        SemanticProperties.SetDescription(root, "Patient row");
+
+        ContextMenuEffect.SetMode(root, ContextMenuEffect.ContextMenuMode.LongPressed);
+        ContextMenuEffect.SetMenu(root, CreatePatientMenu("Row menu"));
+
+        var textGrid = new Grid
+        {
+            RowDefinitions =
+            [
+                new RowDefinition(GridLength.Auto),
+                new RowDefinition(GridLength.Auto)
+            ]
+        };
+
+        var nameLabel = new DuiLabel
+        {
+            Style = Styles.GetLabelStyle(LabelStyle.UI300),
+            MaxLines = 2,
+            LineBreakMode = LineBreakMode.TailTruncation,
+            Margin = new Thickness(0, Sizes.GetSize(SizeName.size_3), 0, 0)
+        };
+        nameLabel.SetBinding(Label.TextProperty, nameof(PatientReproItem.FullName));
+
+        var personaliaLabel = new DuiLabel
+        {
+            Style = Styles.GetLabelStyle(LabelStyle.UI200),
+            TextColor = Colors.GetColor(ColorName.color_text_subtle),
+            Margin = new Thickness(0, 0, 0, Sizes.GetSize(SizeName.size_3))
+        };
+        personaliaLabel.SetBinding(Label.TextProperty, nameof(PatientReproItem.Personalia));
+
+        textGrid.Add(nameLabel);
+        textGrid.Add(personaliaLabel, 0, 1);
+        root.Add(textGrid);
+
+        root.Add(CreateIconStrip(), 1);
+        root.Add(CreateOptionsButton(), 2);
+
+        return root;
+    }
+
+    private static View CreateIconStrip()
+    {
+        var iconStrip = new Grid
+        {
+            ColumnDefinitions =
+            [
+                new ColumnDefinition(GridLength.Auto),
+                new ColumnDefinition(GridLength.Auto)
+            ],
+            ColumnSpacing = Sizes.GetSize(SizeName.size_1),
+            Margin = new Thickness(0, Sizes.GetSize(SizeName.size_3), Sizes.GetSize(SizeName.size_2), 0),
+            VerticalOptions = LayoutOptions.Start
+        };
+
+        AutomationProperties.SetExcludedWithChildren(iconStrip, true);
+
+        iconStrip.Add(new DuiImage
+        {
+            Source = Icons.GetIcon(IconName.comment_line),
+            WidthRequest = Sizes.GetSize(SizeName.size_4),
+            HeightRequest = Sizes.GetSize(SizeName.size_4)
+        });
+
+        iconStrip.Add(new DuiImage
+        {
+            Source = Icons.GetIcon(IconName.star_fill),
+            WidthRequest = Sizes.GetSize(SizeName.size_4),
+            HeightRequest = Sizes.GetSize(SizeName.size_4)
+        }, 1);
+
+        return iconStrip;
+    }
+
+    private View CreateOptionsButton()
+    {
+        var optionsButton = new Grid
+        {
+            ColumnDefinitions =
+            [
+                new ColumnDefinition(1),
+                new ColumnDefinition(GridLength.Auto)
+            ],
+            ColumnSpacing = Sizes.GetSize(SizeName.size_2),
+            HorizontalOptions = LayoutOptions.End,
+            VerticalOptions = LayoutOptions.Fill
+        };
+
+        ContextMenuEffect.SetMode(optionsButton, ContextMenuEffect.ContextMenuMode.Pressed);
+        ContextMenuEffect.SetMenu(optionsButton, CreatePatientMenu("Options menu"));
+        SemanticProperties.SetDescription(optionsButton, "Patient options");
+        AutomationProperties.SetIsInAccessibleTree(optionsButton, true);
+
+        optionsButton.Add(new Divider
+        {
+            VerticalOptions = LayoutOptions.Fill
+        });
+
+        optionsButton.Add(new DuiImage
+        {
+            Source = Icons.GetIcon(IconName.more_fill),
+            TintColor = Colors.GetColor(ColorName.color_icon_action),
+            Margin = new Thickness(0, 0, Sizes.GetSize(SizeName.size_3), 0),
+            VerticalOptions = LayoutOptions.Center,
+            HorizontalOptions = LayoutOptions.Center,
+            WidthRequest = Sizes.GetSize(SizeName.size_6),
+            HeightRequest = Sizes.GetSize(SizeName.size_6)
+        }, 1);
+
+        return optionsButton;
+    }
+
+    private ContextMenu CreatePatientMenu(string title)
+    {
+        return new ContextMenu
+        {
+            Title = title,
+            ItemsSource =
+            [
+                new ContextMenuItem { Title = "Open", Command = new Command(() => SetStatus($"{title}: Open")) },
+                new ContextMenuItem { Title = "Favorite", Command = new Command(() => SetStatus($"{title}: Favorite")) },
+                new ContextMenuItem { Title = "Remove", IsDestructive = true, Command = new Command(() => SetStatus($"{title}: Remove")) }
+            ]
+        };
+    }
+
+    private void SetStatus(string status)
+    {
+        m_statusLabel.Text = status;
+        Console.WriteLine(status);
+    }
+
+    private sealed class PatientReproItem(int index)
+    {
+        public string FullName { get; } = $"Patient, Test {index:00}";
+        public string Personalia { get; } = $"0101{index:00}12345 - Ward {index % 5 + 1}";
+    }
+}

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.LongPressed.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.LongPressed.cs
@@ -50,7 +50,7 @@ public partial class ContextMenuPlatformEffect
             IUIContextMenuInteractionAnimating? animator)
         {
             if (Element is null)
-                return; 
+                return;
 
             Touch.SetIsEnabled(Element, true);
         }

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.Pressed.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.Pressed.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using CoreGraphics;
 using DIPS.Mobile.UI.Components.ContextMenus.iOS;
+using DIPS.Mobile.UI.Effects.Touch.iOS;
 using Foundation;
 using Microsoft.Maui.Platform;
 using UIKit;
@@ -34,9 +35,11 @@ public partial class ContextMenuPlatformEffect
 
     private UIButton CreateOverlayButton()
     {
-        var uiButton = new UIButton();
-        uiButton.TranslatesAutoresizingMaskIntoConstraints = false;
-        
+        var uiButton = new ContextMenuButton(this)
+        {
+            TranslatesAutoresizingMaskIntoConstraints = false
+        };
+
         Control.AddSubview(uiButton);
         m_uiButtonToRemove = uiButton;
         
@@ -97,11 +100,46 @@ public partial class ContextMenuPlatformEffect
             m_uiButton.Menu = null;
         m_cachedMenu?.Dispose();
         m_cachedMenu = null;
+        m_pressedMenuTouchBlocker?.Dispose();
+        m_pressedMenuTouchBlocker = null;
         m_uiButtonToRemove?.RemoveFromSuperview();
         
         m_contextMenu.SetPlatformRebuildAction(null);
         
         if(Element is not null)
             Element.PropertyChanged -= ElementOnPropertyChanged;
+    }
+
+    private sealed class ContextMenuButton(ContextMenuPlatformEffect effect) : UIButton
+    {
+        private readonly WeakReference<ContextMenuPlatformEffect> m_effectReference = new(effect);
+
+        public override void WillDisplayMenu(UIContextMenuInteraction interaction,
+            UIContextMenuConfiguration configuration, IUIContextMenuInteractionAnimating? animator)
+        {
+            if (m_effectReference.TryGetTarget(out var contextMenuPlatformEffect))
+            {
+                contextMenuPlatformEffect.m_pressedMenuTouchBlocker ??= TouchOverlayTouchBlocker.Block();
+            }
+
+            base.WillDisplayMenu(interaction, configuration, animator);
+        }
+
+        public override void WillEnd(UIContextMenuInteraction interaction, UIContextMenuConfiguration configuration,
+            IUIContextMenuInteractionAnimating? animator)
+        {
+            if (m_effectReference.TryGetTarget(out var contextMenuPlatformEffect))
+            {
+                contextMenuPlatformEffect.DisposePressedMenuTouchBlocker();
+            }
+
+            base.WillEnd(interaction, configuration, animator);
+        }
+    }
+
+    private void DisposePressedMenuTouchBlocker()
+    {
+        m_pressedMenuTouchBlocker?.Dispose();
+        m_pressedMenuTouchBlocker = null;
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.cs
+++ b/src/library/DIPS.Mobile.UI/Components/ContextMenus/iOS/ContextMenuPlatformEffect.cs
@@ -7,6 +7,7 @@ public partial class ContextMenuPlatformEffect
 {
     private UIButton? m_uiButtonToRemove;
     private UIMenu? m_cachedMenu;
+    private IDisposable? m_pressedMenuTouchBlocker;
     
 #nullable disable
     private ContextMenu m_contextMenu;

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectGestureRecognizerDelegate.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectGestureRecognizerDelegate.cs
@@ -6,9 +6,7 @@ internal class TouchEffectGestureRecognizerDelegate : UIGestureRecognizerDelegat
 {
     public override bool ShouldReceiveTouch(UIGestureRecognizer recognizer, UITouch touch)
     {
-        // Do not allow touch recognition if a context menu is currently displayed.
-        // NOTE: This can be subject to change in future iOS versions
-        if (Platform.GetCurrentUIViewController()?.Class.Name?.Contains("UIContextMenuActionsOnlyViewController") ?? false)
+        if (TouchOverlayTouchBlocker.IsBlocked || TouchOverlayTouchBlocker.IsBlockedByActivePopover)
             return false;
 
         var test = Platform.GetCurrentUIViewController()?.Class.Name;
@@ -27,8 +25,11 @@ internal class TouchEffectGestureRecognizerDelegate : UIGestureRecognizerDelegat
         return false;
     }
 
-    private bool CheckRecognizers(UIView view, UIView superViewThatContainsRecognizer)
+    private bool CheckRecognizers(UIView? view, UIView superViewThatContainsRecognizer)
     {
+        if (view is null)
+            return false;
+
         var gestureRecognizers = view.GestureRecognizers;
 
         if (view.Equals(superViewThatContainsRecognizer))
@@ -46,11 +47,11 @@ internal class TouchEffectGestureRecognizerDelegate : UIGestureRecognizerDelegat
         UIGestureRecognizer otherGestureRecognizer)
     {
         if (gestureRecognizer is TouchEffectTapGestureRecognizer touchGesture &&
-            otherGestureRecognizer is UIPanGestureRecognizer &&
-            otherGestureRecognizer.State == UIGestureRecognizerState.Began)
+            otherGestureRecognizer is UIPanGestureRecognizer)
         {
             TouchPlatformEffect.HandleTouch(UIGestureRecognizerState.Cancelled, ref touchGesture.m_currentState,
                 gestureRecognizer.View);
+            return false;
         }
 
         return true;

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchOverlayTouchBlocker.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchOverlayTouchBlocker.cs
@@ -1,0 +1,70 @@
+using UIKit;
+
+namespace DIPS.Mobile.UI.Effects.Touch.iOS;
+
+internal static class TouchOverlayTouchBlocker
+{
+    private static readonly Lock s_lock = new();
+    private static readonly HashSet<int> s_activeTokenIds = [];
+    private static int s_nextTokenId;
+
+    internal static bool IsBlocked
+    {
+        get
+        {
+            lock (s_lock)
+            {
+                return s_activeTokenIds.Count > 0;
+            }
+        }
+    }
+
+    internal static bool IsBlockedByActivePopover => UIApplication.SharedApplication.ConnectedScenes
+        .OfType<UIWindowScene>()
+        .SelectMany(scene => scene.Windows)
+        .Any(window => IsPopoverPresented(window.RootViewController));
+
+    internal static IDisposable Block()
+    {
+        lock (s_lock)
+        {
+            var tokenId = ++s_nextTokenId;
+            s_activeTokenIds.Add(tokenId);
+            return new Token(tokenId);
+        }
+    }
+
+    private sealed class Token(int tokenId) : IDisposable
+    {
+        private bool m_isDisposed;
+
+        public void Dispose()
+        {
+            if (m_isDisposed)
+                return;
+
+            lock (s_lock)
+            {
+                s_activeTokenIds.Remove(tokenId);
+            }
+
+            m_isDisposed = true;
+        }
+    }
+
+    private static bool IsPopoverPresented(UIViewController? viewController)
+    {
+        while (viewController is not null)
+        {
+            if (viewController.ModalPresentationStyle == UIModalPresentationStyle.Popover &&
+                !viewController.IsBeingDismissed)
+            {
+                return true;
+            }
+
+            viewController = viewController.PresentedViewController;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
### Description of Change

Fixes an iOS gesture interaction where tappable rows using `Touch` could get into bad states around context menus and picker popovers.

The issue was isolated to `TouchEffectTapGestureRecognizer` being allowed to recognize simultaneously with `UIPanGestureRecognizer`. In rows that also opened context menus or picker popovers, that broad simultaneity could leave scrolling stuck after overlay dismissal. The fix now cancels the Touch pressed visual state when a pan competes, then returns `false` so the scroll pan wins instead of both recognizers recognizing together.

This also prevents taps behind active overlays from firing `Touch` commands:
- Adds a token-based `TouchOverlayTouchBlocker` used by pressed context menus for their visible lifecycle.
- Centralizes popover detection in `TouchOverlayTouchBlocker`, so future `UIModalPresentationStyle.Popover` presentations are covered without each popover needing explicit Touch-blocker code.
- Updates pressed context menu overlay buttons to use `UIControl` menu lifecycle callbacks.

Additional verification scaffolding was added to Playground:
- `Patient List Menu Fling Repro` for context-menu rows with `Touch`.
- `DatePicker Fling Repro` for DatePicker, TimePicker, and DateAndTimePicker popovers in touched collection rows.

No wiki update was added because this fixes iOS runtime behavior without changing public API usage.

### Todos
- [ ] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [x] I have supported accessibility
