### PR TITLE
Add StepFlow back navigation and invalid scan cooldown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [62.0.0]
+- [StepFlow] **BREAKING**: Removed `StepFlowItem.LockWhenCompleted`. Use `StepFlowItem.CanGoBack` to allow selected completed steps to be reopened before the flow is fully completed, while resetting that step and following steps for confirmation again.
+- [BarcodeScanner] Fixed invalid scan-rectangle validation results restarting detection before the overlay returned to idle by waiting for the reset animation and adding a short cooldown before rescanning.
+
 ## [61.5.1]
 - [Touch][iOS] Fixed scroll gestures on tappable rows getting stuck after dismissing context menus or picker popovers, and prevented taps behind open overlays from activating touch commands.
 

--- a/src/app/Components/ComponentsSamples/StepFlow/StepFlowSamples.xaml
+++ b/src/app/Components/ComponentsSamples/StepFlow/StepFlowSamples.xaml
@@ -27,6 +27,13 @@
                 <Switch IsToggled="{Binding AutoScrollIntoView}" />
             </dui:HorizontalStackLayout>
 
+            <dui:HorizontalStackLayout Spacing="{dui:Sizes size_3}">
+                <dui:Label Text="CanGoBack"
+                           Style="{dui:Styles Label=UI200}"
+                           VerticalOptions="Center" />
+                <Switch IsToggled="{Binding CanGoBack}" />
+            </dui:HorizontalStackLayout>
+
             <!-- Filler so the StepFlow starts off-screen and the auto-scroll is visible. -->
             <dui:Label Style="{dui:Styles Label=UI100}"
                        Text="↓ Scroll down to start the flow. As steps complete, the next active step will auto-scroll into view." />
@@ -37,7 +44,8 @@
                           AutoScrollIntoView="{Binding AutoScrollIntoView}">
 
                 <!-- Step 1: Confirm patient -->
-                <dui:StepFlowItem Title="Confirm patient">
+                <dui:StepFlowItem Title="Confirm patient"
+                                  CanGoBack="{Binding CanGoBack}">
                     <dui:VerticalStackLayout Spacing="{dui:Sizes size_3}">
                         <dui:Label Style="{dui:Styles Label=UI200}"
                                    Text="{Binding PatientName, StringFormat='Patient: {0}'}" />
@@ -49,7 +57,8 @@
                 </dui:StepFlowItem>
 
                 <!-- Step 2: Scan sample labels -->
-                <dui:StepFlowItem Title="Scan sample labels and verify each barcode against the requisition before confirming the patient sampling">
+                <dui:StepFlowItem Title="Scan sample labels and verify each barcode against the requisition before confirming the patient sampling"
+                                  CanGoBack="{Binding CanGoBack}">
                     <dui:VerticalStackLayout Spacing="{dui:Sizes size_3}">
                         <dui:Label Style="{dui:Styles Label=UI100}"
                                    Text="Tap to add a fake scanned label. After 3 labels you can finish."  />
@@ -77,7 +86,8 @@
                 </dui:StepFlowItem>
 
                 <!-- Step 3: Confirm sampling -->
-                <dui:StepFlowItem Title="Confirm sampling">
+                <dui:StepFlowItem Title="Confirm sampling"
+                                  CanGoBack="{Binding CanGoBack}">
                     <dui:VerticalStackLayout Spacing="{dui:Sizes size_3}">
                         <dui:Label Style="{dui:Styles Label=UI200}"
                                    Text="{Binding PatientName, StringFormat='Patient: {0}'}" />

--- a/src/app/Components/ComponentsSamples/StepFlow/StepFlowSamplesViewModel.cs
+++ b/src/app/Components/ComponentsSamples/StepFlow/StepFlowSamplesViewModel.cs
@@ -12,6 +12,7 @@ public class StepFlowSamplesViewModel : ViewModel
     private bool m_isScanningDone;
     private bool m_isFlowFinished;
     private bool m_autoScrollIntoView = true;
+    private bool m_canGoBack = true;
 
     public StepFlowSamplesViewModel()
     {
@@ -57,6 +58,12 @@ public class StepFlowSamplesViewModel : ViewModel
     {
         get => m_autoScrollIntoView;
         set => RaiseWhenSet(ref m_autoScrollIntoView, value);
+    }
+
+    public bool CanGoBack
+    {
+        get => m_canGoBack;
+        set => RaiseWhenSet(ref m_canGoBack, value);
     }
 
     public AsyncCommand ConfirmPatientCommand { get; }

--- a/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/Overlay/BarcodeScanRectangleOverlay.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/BarcodeScanning/Overlay/BarcodeScanRectangleOverlay.cs
@@ -42,6 +42,8 @@ internal class BarcodeScanRectangleOverlay : Grid
     private const float TrackingTargetLargeChangeThreshold = 48f;
     private const float TrackingTargetSmoothing = .35f;
     private const float TrackingTargetFastSmoothing = .65f;
+    private const uint BracketsReturnLength = 280;
+    private const int FailureRescanCooldownMilliseconds = 500;
 
     private const string AnimationKeyCornerBreathing = "CornerBreathing";
     private const string AnimationKeyBracketsToBarcode = "BracketsToBarcode";
@@ -631,10 +633,16 @@ internal class BarcodeScanRectangleOverlay : Grid
         await m_cornersGraphicsView.TranslateToAsync(-shakeDistance / 2, 0, 65, Easing.CubicInOut);
         await m_cornersGraphicsView.TranslateToAsync(0, 0, 80, Easing.CubicOut);
 
-        ResetBarcodeDetection();
+        await ResetBarcodeDetectionAsync();
+        await Task.Delay(FailureRescanCooldownMilliseconds);
     }
 
     internal void ResetBarcodeDetection()
+    {
+        _ = ResetBarcodeDetectionAsync();
+    }
+
+    private Task ResetBarcodeDetectionAsync()
     {
         m_cornersGraphicsView.AbortAnimation(AnimationKeyBracketsToBarcode);
         m_cornersGraphicsView.AbortAnimation(AnimationKeyBracketsReturn);
@@ -652,11 +660,11 @@ internal class BarcodeScanRectangleOverlay : Grid
 
         if (currentRect is not null)
         {
-            // Animate back to scan rectangle
             var startX = currentRect.Value.X;
             var startY = currentRect.Value.Y;
             var startW = currentRect.Value.Width;
             var startH = currentRect.Value.Height;
+            var taskCompletionSource = new TaskCompletionSource<bool>();
 
             var animation = new Animation(v =>
             {
@@ -671,21 +679,24 @@ internal class BarcodeScanRectangleOverlay : Grid
 
             animation.Commit(m_cornersGraphicsView, AnimationKeyBracketsReturn,
                 rate: 16,
-                length: 280,
+                length: BracketsReturnLength,
                 finished: (_, cancelled) =>
                 {
                     m_cornersDrawable.OverrideRect = null;
                     if (!cancelled)
                         StartBreathingAnimation();
+
+                    taskCompletionSource.TrySetResult(true);
                 });
-        }
-        else
-        {
-            m_cornersDrawable.OverrideRect = null;
-            StartBreathingAnimation();
+
+            return taskCompletionSource.Task;
         }
 
+        m_cornersDrawable.OverrideRect = null;
+        StartBreathingAnimation();
+        return Task.CompletedTask;
     }
+
     private RectF GetScanRectangleForDrawable()
     {
         var w = (float)Width;

--- a/src/library/DIPS.Mobile.UI/Components/StepFlow/StepFlow.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/StepFlow/StepFlow.Properties.cs
@@ -49,7 +49,8 @@ public partial class StepFlow
         nameof(AllowDirectStepActivation),
         typeof(bool),
         typeof(StepFlow),
-        defaultValue: false);
+        defaultValue: false,
+        propertyChanged: (b, _, _) => ((StepFlow)b).RefreshItemTapTargets());
 
     public static readonly BindableProperty AutoScrollIntoViewProperty = BindableProperty.Create(
         nameof(AutoScrollIntoView),

--- a/src/library/DIPS.Mobile.UI/Components/StepFlow/StepFlow.cs
+++ b/src/library/DIPS.Mobile.UI/Components/StepFlow/StepFlow.cs
@@ -174,9 +174,15 @@ public partial class StepFlow : ContentView
         FlowCompleted?.Invoke(this, EventArgs.Empty);
     }
 
-    internal bool CanGoBackFromCompletedSteps => m_attachedController is { } controller
-        ? !controller.IsCompleted
-        : !AreAllItemsCompleted();
+    internal bool CanActivateCompletedStep(StepFlowItem item) =>
+        m_items.Contains(item) &&
+        item.State == StepFlowItemState.Completed &&
+        item.CanGoBack &&
+        !IsFlowCompleted();
+
+    private bool IsFlowCompleted() => m_attachedController is { } controller
+        ? controller.IsCompleted
+        : AreAllItemsCompleted();
 
     private bool AreAllItemsCompleted() => m_items.Count > 0 && m_items.All(item => item.State == StepFlowItemState.Completed);
 
@@ -188,44 +194,69 @@ public partial class StepFlow : ContentView
         var controller = m_attachedController;
         if (controller is null)
         {
-            // Escape hatch (no controller): manually enforce single-active.
-            if (item.State == StepFlowItemState.Completed && !item.CanGoBack) return;
-            if (item.State == StepFlowItemState.Completed && !CanGoBackFromCompletedSteps) return;
-            if (item.State == StepFlowItemState.Completed && item.CanGoBack)
-            {
-                var targetIndex = m_items.IndexOf(item);
-                if (targetIndex < 0) return;
-
-                for (var i = 0; i < m_items.Count; i++)
-                {
-                    var other = m_items[i];
-                    if (ReferenceEquals(other, item))
-                    {
-                        other.State = StepFlowItemState.Active;
-                    }
-                    else if (i > targetIndex || other.State == StepFlowItemState.Active)
-                    {
-                        other.State = StepFlowItemState.Disabled;
-                    }
-                }
-                return;
-            }
-
-            foreach (var other in m_items)
-            {
-                if (!ReferenceEquals(other, item) && other.State == StepFlowItemState.Active)
-                {
-                    other.State = StepFlowItemState.Disabled;
-                }
-            }
-            item.State = StepFlowItemState.Active;
+            ActivateTappedItemWithoutController(item);
             return;
         }
 
-        if (item.Index < 0) return;
-        if (item.State == StepFlowItemState.Completed && item.CanGoBack)
+        ActivateTappedItemWithController(controller, item);
+    }
+
+    private void ActivateTappedItemWithoutController(StepFlowItem item)
+    {
+        // Escape hatch (no controller): manually enforce single-active.
+        if (item.State == StepFlowItemState.Completed)
         {
-            controller.GoBackTo(item.Index);
+            ActivateCompletedItemWithoutController(item);
+            return;
+        }
+
+        DisableOtherActiveItems(item);
+        item.State = StepFlowItemState.Active;
+    }
+
+    private void ActivateCompletedItemWithoutController(StepFlowItem item)
+    {
+        if (!CanActivateCompletedStep(item)) return;
+
+        var targetIndex = m_items.IndexOf(item);
+        if (targetIndex < 0) return;
+
+        for (var i = 0; i < m_items.Count; i++)
+        {
+            var other = m_items[i];
+            if (ReferenceEquals(other, item))
+            {
+                other.State = StepFlowItemState.Active;
+                continue;
+            }
+
+            if (i > targetIndex || other.State == StepFlowItemState.Active)
+            {
+                other.State = StepFlowItemState.Disabled;
+            }
+        }
+    }
+
+    private void DisableOtherActiveItems(StepFlowItem item)
+    {
+        foreach (var other in m_items)
+        {
+            if (!ReferenceEquals(other, item) && other.State == StepFlowItemState.Active)
+            {
+                other.State = StepFlowItemState.Disabled;
+            }
+        }
+    }
+
+    private void ActivateTappedItemWithController(StepFlowController controller, StepFlowItem item)
+    {
+        if (item.Index < 0) return;
+        if (item.State == StepFlowItemState.Completed)
+        {
+            if (CanActivateCompletedStep(item))
+            {
+                controller.GoBackTo(item.Index);
+            }
             return;
         }
 

--- a/src/library/DIPS.Mobile.UI/Components/StepFlow/StepFlow.cs
+++ b/src/library/DIPS.Mobile.UI/Components/StepFlow/StepFlow.cs
@@ -102,6 +102,15 @@ public partial class StepFlow : ContentView
             {
                 m_stack.Children.Insert(Math.Min(i, m_stack.Children.Count), item);
             }
+            item.RefreshTapTarget();
+        }
+    }
+
+    private void RefreshItemTapTargets()
+    {
+        foreach (var item in m_items)
+        {
+            item.RefreshTapTarget();
         }
     }
 
@@ -161,8 +170,15 @@ public partial class StepFlow : ContentView
 
     private void OnControllerFlowCompleted(object? sender, EventArgs e)
     {
+        RefreshItemTapTargets();
         FlowCompleted?.Invoke(this, EventArgs.Empty);
     }
+
+    internal bool CanGoBackFromCompletedSteps => m_attachedController is { } controller
+        ? !controller.IsCompleted
+        : !AreAllItemsCompleted();
+
+    private bool AreAllItemsCompleted() => m_items.Count > 0 && m_items.All(item => item.State == StepFlowItemState.Completed);
 
     private void OnItemCardTapped(object? sender, EventArgs e)
     {
@@ -173,7 +189,28 @@ public partial class StepFlow : ContentView
         if (controller is null)
         {
             // Escape hatch (no controller): manually enforce single-active.
-            if (item.State == StepFlowItemState.Completed && item.LockWhenCompleted) return;
+            if (item.State == StepFlowItemState.Completed && !item.CanGoBack) return;
+            if (item.State == StepFlowItemState.Completed && !CanGoBackFromCompletedSteps) return;
+            if (item.State == StepFlowItemState.Completed && item.CanGoBack)
+            {
+                var targetIndex = m_items.IndexOf(item);
+                if (targetIndex < 0) return;
+
+                for (var i = 0; i < m_items.Count; i++)
+                {
+                    var other = m_items[i];
+                    if (ReferenceEquals(other, item))
+                    {
+                        other.State = StepFlowItemState.Active;
+                    }
+                    else if (i > targetIndex || other.State == StepFlowItemState.Active)
+                    {
+                        other.State = StepFlowItemState.Disabled;
+                    }
+                }
+                return;
+            }
+
             foreach (var other in m_items)
             {
                 if (!ReferenceEquals(other, item) && other.State == StepFlowItemState.Active)
@@ -186,6 +223,12 @@ public partial class StepFlow : ContentView
         }
 
         if (item.Index < 0) return;
+        if (item.State == StepFlowItemState.Completed && item.CanGoBack)
+        {
+            controller.GoBackTo(item.Index);
+            return;
+        }
+
         controller.GoTo(item.Index);
     }
 
@@ -230,7 +273,7 @@ public partial class StepFlow : ContentView
         if (m_scrollerResolved) return m_cachedScroller;
         m_scrollerResolved = true;
 
-        Element? walker = Parent;
+        var walker = Parent;
         while (walker is not null)
         {
             if (walker is MauiScrollView sv)

--- a/src/library/DIPS.Mobile.UI/Components/StepFlow/StepFlowController.cs
+++ b/src/library/DIPS.Mobile.UI/Components/StepFlow/StepFlowController.cs
@@ -103,7 +103,8 @@ public class StepFlowController : ViewModel
 
     /// <summary>
     /// Activates the step at <paramref name="index"/>. No-op if the step is
-    /// <see cref="StepFlowItemState.Disabled"/> or <see cref="StepFlowItemState.Completed"/>.
+    /// <see cref="StepFlowItemState.Completed"/>. Use <see cref="GoBackTo"/> to activate a
+    /// completed step and require it to be confirmed again.
     /// </summary>
     public void GoTo(int index)
     {
@@ -112,6 +113,35 @@ public class StepFlowController : ViewModel
         if (state == StepFlowItemState.Completed) return;
 
         ActivateInternal(index);
+    }
+
+    /// <summary>
+    /// Activates a completed previous step and resets that step and all following steps so they
+    /// must be confirmed again. No-op if the step is not completed or the flow is already
+    /// completed.
+    /// </summary>
+    public void GoBackTo(int index)
+    {
+        if (!IsValidIndex(index)) return;
+        if (IsCompleted) return;
+        if (m_states[index] != StepFlowItemState.Completed) return;
+
+        for (var i = 0; i < m_stepCount; i++)
+        {
+            if (i == index)
+            {
+                if (m_states[i] != StepFlowItemState.Active)
+                    SetStateInternal(i, StepFlowItemState.Active);
+            }
+            else if (i > index || m_states[i] == StepFlowItemState.Active)
+            {
+                if (m_states[i] != StepFlowItemState.Disabled)
+                    SetStateInternal(i, StepFlowItemState.Disabled);
+            }
+        }
+
+        CurrentIndex = index;
+        StepActivated?.Invoke(this, new StepFlowEventArgs(index));
     }
 
     /// <summary>Resets the flow: step 0 becomes <see cref="StepFlowItemState.Active"/>, the rest <see cref="StepFlowItemState.Disabled"/>.</summary>

--- a/src/library/DIPS.Mobile.UI/Components/StepFlow/StepFlowItem.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/StepFlow/StepFlowItem.Properties.cs
@@ -39,11 +39,15 @@ public partial class StepFlowItem
         set => SetValue(IndicatorTemplateProperty, value);
     }
 
-    /// <summary>When <c>true</c> (the default), tapping a completed step does nothing.</summary>
-    public bool LockWhenCompleted
+    /// <summary>
+    /// When <c>true</c>, tapping this completed step activates it again and resets this and the
+    /// following steps so they must be confirmed again. Only applies while the flow is in
+    /// progress. Defaults to <c>false</c>.
+    /// </summary>
+    public bool CanGoBack
     {
-        get => (bool)GetValue(LockWhenCompletedProperty);
-        set => SetValue(LockWhenCompletedProperty, value);
+        get => (bool)GetValue(CanGoBackProperty);
+        set => SetValue(CanGoBackProperty, value);
     }
 
     /// <summary>
@@ -83,11 +87,12 @@ public partial class StepFlowItem
         typeof(StepFlowItem),
         propertyChanged: (b, _, _) => ((StepFlowItem)b).OnIndicatorTemplateChanged());
 
-    public static readonly BindableProperty LockWhenCompletedProperty = BindableProperty.Create(
-        nameof(LockWhenCompleted),
+    public static readonly BindableProperty CanGoBackProperty = BindableProperty.Create(
+        nameof(CanGoBack),
         typeof(bool),
         typeof(StepFlowItem),
-        defaultValue: true);
+        defaultValue: false,
+        propertyChanged: (b, _, _) => ((StepFlowItem)b).RefreshTapTarget());
 
     public static readonly BindableProperty StateProperty = BindableProperty.Create(
         nameof(State),

--- a/src/library/DIPS.Mobile.UI/Components/StepFlow/StepFlowItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/StepFlow/StepFlowItem.cs
@@ -52,6 +52,11 @@ public partial class StepFlowItem : ContentView
     /// <summary>Raised when the user taps the card. The container decides whether the tap should activate the step.</summary>
     internal event EventHandler? CardTapped;
 
+    internal void RefreshTapTarget()
+    {
+        UpdateCardTapTarget(State);
+    }
+
     public StepFlowItem()
     {
         m_animationToken = "stepflow-item-" + Guid.NewGuid().ToString("N");
@@ -233,9 +238,15 @@ public partial class StepFlowItem : ContentView
             return;
         if (State == StepFlowItemState.Active)
             return;
-        if (State == StepFlowItemState.Completed && LockWhenCompleted)
-            return;
-        if (State == StepFlowItemState.Disabled && Parent is StepFlow flow && !flow.AllowDirectStepActivation)
+        if (State == StepFlowItemState.Completed)
+        {
+            var flow = FindParentStepFlow();
+            if (flow?.CanGoBackFromCompletedSteps != true)
+                return;
+            if (!CanGoBack)
+                return;
+        }
+        if (State == StepFlowItemState.Disabled && FindParentStepFlow()?.AllowDirectStepActivation != true)
             return;
 
         CardTapped?.Invoke(this, EventArgs.Empty);
@@ -243,11 +254,54 @@ public partial class StepFlowItem : ContentView
 
     private void UpdateCardTapTarget(StepFlowItemState state)
     {
-        var command = state == StepFlowItemState.Active ? null : m_cardTappedCommand;
+        var command = CanTapCard(state) ? m_cardTappedCommand : null;
         if (ReferenceEquals(Touch.GetCommand(m_root), command))
             return;
 
+        if (command is null && Touch.GetCommand(m_root) is not null)
+        {
+            Dispatcher.Dispatch(() =>
+            {
+                if (!CanTapCard(State) && Touch.GetCommand(m_root) is not null)
+                {
+                    Touch.SetCommand(m_root, null!);
+                }
+            });
+            return;
+        }
+
         Touch.SetCommand(m_root, command!);
+    }
+
+    private bool CanTapCard(StepFlowItemState state) => state switch
+    {
+        StepFlowItemState.Active => false,
+        StepFlowItemState.Completed => CanTapCompletedCard(),
+        StepFlowItemState.Disabled => FindParentStepFlow()?.AllowDirectStepActivation == true,
+        _ => true
+    };
+
+    private bool CanTapCompletedCard()
+    {
+        var flow = FindParentStepFlow();
+        if (flow?.CanGoBackFromCompletedSteps != true)
+            return false;
+
+        return CanGoBack;
+    }
+
+    private StepFlow? FindParentStepFlow()
+    {
+        var walker = Parent;
+        while (walker is not null)
+        {
+            if (walker is StepFlow flow)
+                return flow;
+
+            walker = walker.Parent;
+        }
+
+        return null;
     }
 
     private void OnStateChanged(StepFlowItemState oldState, StepFlowItemState newState)
@@ -291,6 +345,7 @@ public partial class StepFlowItem : ContentView
                 break;
 
             case StepFlowItemState.Active:
+                this.AbortAnimation(m_animationToken + "-opacity");
                 StopCompletionAnimation();
                 AnimateIndicator(show: false, animate);
                 LayoutEffect.SetStroke(m_root, Colors.GetColor(ColorName.color_text_default));
@@ -402,9 +457,9 @@ public partial class StepFlowItem : ContentView
 
         this.AbortAnimation(m_animationToken + "-body");
         parent.Commit(this, m_animationToken + "-body", rate: 16, length: ExpandDurationMs,
-            easing: Easing.Linear, finished: (_, _) =>
+            easing: Easing.Linear, finished: (_, wasCancelled) =>
             {
-                if (State != StepFlowItemState.Active || Handler is null)
+                if (wasCancelled || State != StepFlowItemState.Active || Handler is null)
                     return;
                 // Hand the slot back to auto-sizing so future content changes (async loads,
                 // text wraps) just work without a re-measure dance.
@@ -437,8 +492,11 @@ public partial class StepFlowItem : ContentView
 
         this.AbortAnimation(m_animationToken + "-body");
         parent.Commit(this, m_animationToken + "-body", rate: 16, length: CollapseDurationMs,
-            easing: Easing.Linear, finished: (_, _) =>
+            easing: Easing.Linear, finished: (_, wasCancelled) =>
             {
+                if (wasCancelled || State == StepFlowItemState.Active)
+                    return;
+
                 m_bodyContainer.IsVisible = false;
                 m_bodyContainer.TranslationY = 0;
             });

--- a/src/library/DIPS.Mobile.UI/Components/StepFlow/StepFlowItem.cs
+++ b/src/library/DIPS.Mobile.UI/Components/StepFlow/StepFlowItem.cs
@@ -240,10 +240,7 @@ public partial class StepFlowItem : ContentView
             return;
         if (State == StepFlowItemState.Completed)
         {
-            var flow = FindParentStepFlow();
-            if (flow?.CanGoBackFromCompletedSteps != true)
-                return;
-            if (!CanGoBack)
+            if (FindParentStepFlow()?.CanActivateCompletedStep(this) != true)
                 return;
         }
         if (State == StepFlowItemState.Disabled && FindParentStepFlow()?.AllowDirectStepActivation != true)
@@ -283,11 +280,7 @@ public partial class StepFlowItem : ContentView
 
     private bool CanTapCompletedCard()
     {
-        var flow = FindParentStepFlow();
-        if (flow?.CanGoBackFromCompletedSteps != true)
-            return false;
-
-        return CanGoBack;
+        return FindParentStepFlow()?.CanActivateCompletedStep(this) == true;
     }
 
     private StepFlow? FindParentStepFlow()

--- a/src/tests/unittests/Components/StepFlow/StepFlowControllerTests.cs
+++ b/src/tests/unittests/Components/StepFlow/StepFlowControllerTests.cs
@@ -1,0 +1,103 @@
+using DIPS.Mobile.UI.Components.StepFlow;
+
+namespace DIPS.Mobile.UI.UnitTests.Components.StepFlow;
+
+public class StepFlowControllerTests
+{
+    [Fact]
+    public void GoBackTo_CompletedStep_ActivatesStepAndDisablesFollowingSteps()
+    {
+        var controller = CreateControllerWithCompletedSteps();
+
+        controller.GoBackTo(1);
+
+        controller.CurrentIndex.Should().Be(1);
+        controller.States.Should().Equal(
+            StepFlowItemState.Completed,
+            StepFlowItemState.Active,
+            StepFlowItemState.Disabled,
+            StepFlowItemState.Disabled);
+    }
+
+    [Fact]
+    public void GoBackTo_FirstCompletedStep_ActivatesFirstStepAndDisablesFollowingSteps()
+    {
+        var controller = CreateControllerWithCompletedSteps();
+
+        controller.GoBackTo(0);
+
+        controller.CurrentIndex.Should().Be(0);
+        controller.States.Should().Equal(
+            StepFlowItemState.Active,
+            StepFlowItemState.Disabled,
+            StepFlowItemState.Disabled,
+            StepFlowItemState.Disabled);
+    }
+
+    [Fact]
+    public void GoBackTo_NonCompletedStep_DoesNothing()
+    {
+        var controller = new StepFlowController { AutoAdvance = false };
+        controller.Initialize(3);
+
+        controller.GoBackTo(1);
+
+        controller.GoBackTo(0);
+
+        controller.GoBackTo(-1);
+
+        controller.GoBackTo(3);
+
+        controller.GoBackTo(99);
+
+        controller.CurrentIndex.Should().Be(0);
+        controller.States.Should().Equal(
+            StepFlowItemState.Active,
+            StepFlowItemState.Disabled,
+            StepFlowItemState.Disabled);
+    }
+
+    [Fact]
+    public void GoBackTo_CompletedFlow_DoesNothing()
+    {
+        var controller = CreateControllerWithCompletedSteps();
+        controller.Complete(3);
+
+        controller.GoBackTo(1);
+
+        controller.CurrentIndex.Should().Be(-1);
+        controller.States.Should().Equal(
+            StepFlowItemState.Completed,
+            StepFlowItemState.Completed,
+            StepFlowItemState.Completed,
+            StepFlowItemState.Completed);
+    }
+
+    [Fact]
+    public void GoTo_CompletedStep_DoesNotActivateCompletedStep()
+    {
+        var controller = CreateControllerWithCompletedSteps();
+
+        controller.GoTo(1);
+
+        controller.CurrentIndex.Should().Be(3);
+        controller.States.Should().Equal(
+            StepFlowItemState.Completed,
+            StepFlowItemState.Completed,
+            StepFlowItemState.Completed,
+            StepFlowItemState.Active);
+    }
+
+    private static StepFlowController CreateControllerWithCompletedSteps()
+    {
+        var controller = new StepFlowController { AutoAdvance = false };
+        controller.Initialize(4);
+        controller.Complete(0);
+        controller.GoTo(1);
+        controller.Complete(1);
+        controller.GoTo(2);
+        controller.Complete(2);
+        controller.GoTo(3);
+        return controller;
+    }
+}

--- a/wiki/Components/StepFlow.md
+++ b/wiki/Components/StepFlow.md
@@ -78,7 +78,8 @@ public class SamplingViewModel : ViewModel
 | `AutoAdvanceDelay` | Delay before auto-advance. Defaults to 800 ms. |
 | `CompleteCurrent()` | Marks `CurrentIndex` `Completed` and (optionally) auto-advances. |
 | `Complete(int)` | Marks the step at the given index `Completed`. |
-| `GoTo(int)` | Activates the step at the given index. No-op if disabled or completed. |
+| `GoTo(int)` | Activates the step at the given index. No-op if completed. |
+| `GoBackTo(int)` | Activates a completed previous step and resets that step and all following steps so they must be confirmed again. No-op after the full flow is completed. |
 | `Reset()` | Step 0 → `Active`, all others → `Disabled`. |
 | `SetState(int, state)` | Explicitly set a step's state. Use sparingly. |
 | `StepCompleted` | Raised when a step transitions to `Completed`. |
@@ -103,7 +104,7 @@ public class SamplingViewModel : ViewModel
 | `Subtitle` | Optional smaller line below the title. |
 | `Content` | The body shown when the step is `Active`. XAML default content. |
 | `IndicatorTemplate` | Optional template for the leading indicator. Defaults to a numbered/check circle. |
-| `LockWhenCompleted` | When `true` (default) tapping a completed step does nothing. |
+| `CanGoBack` | When `true`, tapping a completed step activates it again and resets this and following steps so they must be confirmed again. No-op after the full flow is completed. |
 | `State` | Current `StepFlowItemState`. Driven by the container — read-only for advanced scenarios. |
 
 ### `StepFlowItemState`
@@ -141,6 +142,18 @@ Set `AutoScrollIntoView="False"` on the `StepFlow` to opt out — for example wh
 ```
 
 If no ancestor `ScrollView` is found, `AutoScrollIntoView` is a silent no-op. Non-MAUI scrollers (`CollectionView` etc.) are not supported.
+
+## Going back
+
+Set `CanGoBack="True"` on completed steps that people may revisit while the flow is still in progress. When the step is tapped, StepFlow activates that step and resets it plus all following steps to require confirmation again. Once every step is completed, back navigation is disabled.
+
+```xml
+<dui:StepFlow Controller="{Binding Flow}">
+    <dui:StepFlowItem Title="Confirm patient" />
+    <dui:StepFlowItem Title="Scan sample labels" CanGoBack="True" />
+    <dui:StepFlowItem Title="Confirm sampling" CanGoBack="True" />
+</dui:StepFlow>
+```
 
 ## Escape hatch (binding-only)
 


### PR DESCRIPTION
### Description of Change

Adds StepFlow back navigation through `StepFlowItem.CanGoBack` and `StepFlowController.GoBackTo`. Completed steps can be reopened while the flow is still in progress, reopening resets that step and all following steps, and back navigation is disabled once every step is completed.

**BREAKING:** Removes `StepFlowItem.LockWhenCompleted`; `CanGoBack` is now the single API for completed-step navigation.

Fixes invalid barcode validation so the scan rectangle waits for the bracket reset animation to finish, then applies a `500ms` cooldown before detection can resume. This keeps invalid scans from immediately restarting while the same barcode is still visible.

Updates the StepFlow sample, wiki documentation, changelog, and focused controller tests.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [x] I have supported accessibility
