### PR TITLE
fixed stale datetime picker default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [61.5.2]
+- [DateAndTimePicker][DatePicker][HorizontalInlineDatePicker] Fixed issue where the default value of pickers with no set value was reused and never updated until restart. 
+
 ## [61.5.1]
 - [Touch][iOS] Fixed scroll gestures on tappable rows getting stuck after dismissing context menus or picker popovers, and prevented taps behind open overlays from activating touch commands.
 

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DateAndTimePicker/DateAndTimePicker.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DateAndTimePicker/DateAndTimePicker.Properties.cs
@@ -8,16 +8,20 @@ public partial class DateAndTimePicker
     public static readonly BindableProperty SelectedDateTimeProperty = BindableProperty.Create(
         nameof(SelectedDateTime),
         typeof(DateTime),
-        typeof(DateAndTimePicker), 
-        DateTime.Now,
+        typeof(DateAndTimePicker),
+        default(DateTime),
         defaultBindingMode:BindingMode.TwoWay,
         propertyChanged: (bindable, _, date) =>
         {
             if(date is not DateTime time)
                 return;
-            
+
             ((DateAndTimePicker)bindable).OnSelectedDateTimeChanged(time);
-        });
+        },
+        // A plain DateTime.Now default value is read only once and then shared by every picker,
+        // so all pickers showed the same frozen time until app restart. The creator runs once per
+        // picker, so each picker gets the current time instead.
+        defaultValueCreator: bindable => DateTime.Now);
 
     /// <summary>
     /// The date people selected from the date picker.

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/DatePicker.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/DatePicker.Properties.cs
@@ -60,8 +60,12 @@ namespace DIPS.Mobile.UI.Components.Pickers.DatePicker
             typeof(DateTime),
             typeof(DatePicker),
             defaultBindingMode:BindingMode.TwoWay,
-            defaultValue:DateTime.Now,
-            propertyChanged: (bindable, _, _) => ((DatePicker)bindable).OnSelectedDateChanged());
+            defaultValue:default(DateTime),
+            propertyChanged: (bindable, _, _) => ((DatePicker)bindable).OnSelectedDateChanged(),
+            // A plain DateTime.Now default value is read only once and then shared by every picker,
+            // so all pickers showed the same frozen time until app restart. The creator runs once per
+            // picker, so each picker gets the current time instead.
+            defaultValueCreator: bindable => DateTime.Now);
         
         public static readonly BindableProperty SelectedDateCommandProperty = BindableProperty.Create(
             nameof(SelectedDateCommand),

--- a/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/HorizontalInLine/HorizontalInlineDatePicker.Properties.cs
+++ b/src/library/DIPS.Mobile.UI/Components/Pickers/DatePicker/HorizontalInLine/HorizontalInlineDatePicker.Properties.cs
@@ -5,11 +5,18 @@ public partial class HorizontalInlineDatePicker
     public static readonly BindableProperty SelectedDateProperty = BindableProperty.Create(
         nameof(SelectedDate),
         typeof(DateTime),
-        typeof(HorizontalInlineDatePicker), defaultValue: DateTime.Now, BindingMode.TwoWay, propertyChanged: (b, _, _) =>
+        typeof(HorizontalInlineDatePicker),
+        defaultValue: default(DateTime),
+        defaultBindingMode: BindingMode.TwoWay,
+        propertyChanged: (b, _, _) =>
         {
             if (b is not HorizontalInlineDatePicker horizontalInlineDatePicker) return;
             horizontalInlineDatePicker.OnSelectedDateChanged();
-        }) ;
+        },
+        // A plain DateTime.Now default value is read only once and then shared by every picker,
+        // so all pickers showed the same frozen time until app restart. The creator runs once per
+        // picker, so each picker gets the current time instead.
+        defaultValueCreator: b => DateTime.Now);
 
     /// <summary>
     /// The date that people selected from the horizontal in line date picker.


### PR DESCRIPTION
### Description of Change

Date pickers used `DateTime.Now` as their default value. That default was read only once and then shared by every picker that also have no value of their own, so they all showed the same stale datetime until the app was restarted.

How to reproduce (in a version before the fix)

  1. Open Components > Saving (the picker has no date set).
  2. Note the time it shows.
  3. Go back out and wait a minute or two.
  4. Open it again and see that the time has not updated.



Fixed by using defaultValueCreator to set a default time upon creation of each individual picker.

### Todos
- [ ] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->