### PR TITLE
Fix iOS Touch popover gesture completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [61.5.2]
+- [Touch][iOS] Fixed popovers and context menus opened from `Touch.Command` breaking scrolling and swipe-back gestures after dismissal.
+
 ## [61.5.1]
 - [Touch][iOS] Fixed scroll gestures on tappable rows getting stuck after dismissing context menus or picker popovers, and prevented taps behind open overlays from activating touch commands.
 

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectGestureRecognizerDelegate.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectGestureRecognizerDelegate.cs
@@ -47,11 +47,11 @@ internal class TouchEffectGestureRecognizerDelegate : UIGestureRecognizerDelegat
         UIGestureRecognizer otherGestureRecognizer)
     {
         if (gestureRecognizer is TouchEffectTapGestureRecognizer touchGesture &&
-            otherGestureRecognizer is UIPanGestureRecognizer)
+            otherGestureRecognizer is UIPanGestureRecognizer &&
+            otherGestureRecognizer.State == UIGestureRecognizerState.Began)
         {
             TouchPlatformEffect.HandleTouch(UIGestureRecognizerState.Cancelled, ref touchGesture.m_currentState,
                 gestureRecognizer.View);
-            return false;
         }
 
         return true;

--- a/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectTapGestureRecognizer.cs
+++ b/src/library/DIPS.Mobile.UI/Effects/Touch/iOS/TouchEffectTapGestureRecognizer.cs
@@ -47,12 +47,18 @@ public class TouchEffectTapGestureRecognizer : UIGestureRecognizer
     public override void TouchesEnded(NSSet touches, UIEvent evt)
     {
         base.TouchesEnded(touches, evt);
-        
-        if(!m_longPressDetected && m_currentState is not UIGestureRecognizerState.Cancelled)
-            m_onTap.Invoke();
+
+        var shouldInvokeTap = !m_longPressDetected && m_currentState is not UIGestureRecognizerState.Cancelled;
         
         TouchPlatformEffect.HandleTouch(UIGestureRecognizerState.Ended, ref m_currentState, m_uiView);
         m_longPressDetected = false;
+
+        State = shouldInvokeTap ? UIGestureRecognizerState.Ended : UIGestureRecognizerState.Failed;
+
+        if (shouldInvokeTap)
+        {
+            MainThread.BeginInvokeOnMainThread(m_onTap);
+        }
     }
 
     public override void TouchesCancelled(NSSet touches, UIEvent evt)
@@ -60,6 +66,7 @@ public class TouchEffectTapGestureRecognizer : UIGestureRecognizer
         base.TouchesCancelled(touches, evt);
 
         TouchPlatformEffect.HandleTouch(UIGestureRecognizerState.Cancelled, ref m_currentState, m_uiView);
+        State = UIGestureRecognizerState.Cancelled;
         m_longPressDetected = false;
     }
     
@@ -76,6 +83,7 @@ public class TouchEffectTapGestureRecognizer : UIGestureRecognizer
         {
             TouchPlatformEffect.HandleTouch(UIGestureRecognizerState.Cancelled, ref m_currentState, m_uiView);
             m_isCancelled = true;
+            State = UIGestureRecognizerState.Failed;
         }
         
         base.TouchesMoved(touches, evt);


### PR DESCRIPTION
### Description of Change

Fixes an iOS gesture state issue where opening a popover or context menu from `Touch.Command` could leave scrolling and swipe-back gestures broken after the overlay was dismissed.

The root cause was that the custom `TouchEffectTapGestureRecognizer` executed the tap command directly from `TouchesEnded` without first completing/failing its own UIKit recognizer state. If that command opened a popover, UIKit could enter the presentation/dismissal flow while the Touch recognizer was still part of the active touch sequence.

This change makes the Touch recognizer explicitly set `Ended`, `Failed`, or `Cancelled`, and defers command execution to the next main-thread turn so UIKit gets a clean gesture boundary before the popover/context menu opens.

It also removes the previous broad Touch + pan simultaneous-recognition workaround because that was a band-aid: it reduced symptoms around scroll gestures but did not fix the fundamental recognizer lifecycle issue. The existing overlay blocker that prevents taps behind open popovers/context menus is kept, since that behavior is still needed and separate from the pan-state bug.

### Todos
- [ ] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
