### PR TITLE
Fix BottomSheet bottom bar automation IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [62.0.1]
+- [BottomSheet] Fixed crash when bottom bar buttons already have consumer-provided `AutomationId` values.
+
 ## [62.0.0]
 - [StepFlow] **BREAKING**: Removed `StepFlowItem.LockWhenCompleted`. Use `StepFlowItem.CanGoBack` to allow selected completed steps to be reopened before the flow is fully completed, while resetting that step and following steps for confirmation again.
 - [BarcodeScanner] Fixed invalid scan-rectangle validation results restarting detection before the overlay returned to idle by waiting for the reset animation and adding a short cooldown before rescanning.

--- a/src/library/DIPS.Mobile.UI/Components/BottomSheets/BottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/Components/BottomSheets/BottomSheet.cs
@@ -109,7 +109,10 @@ namespace DIPS.Mobile.UI.Components.BottomSheets
                 grid.AddColumnDefinition(new ColumnDefinition(GridLength.Star));
                 var index = grid.ColumnDefinitions.Count - 1;
                 grid.Add(button, index);
-                button.AutomationId = $"BottomBarButton{index}".ToDUIAutomationId<BottomSheet>();
+                if (button.AutomationId is null)
+                {
+                    button.AutomationId = $"BottomBarButton{index}".ToDUIAutomationId<BottomSheet>();
+                }
             }
         
             grid.BindingContext = BindingContext;

--- a/src/tests/unittests/Components/BottomSheets/BottomSheetTests.cs
+++ b/src/tests/unittests/Components/BottomSheets/BottomSheetTests.cs
@@ -1,0 +1,25 @@
+using DIPS.Mobile.UI.Components.BottomSheets;
+using Button = Microsoft.Maui.Controls.Button;
+
+namespace DIPS.Mobile.UI.UnitTests.Components.BottomSheets;
+
+public class BottomSheetTests
+{
+    [Fact]
+    public void CreateBottomBar_PreservesConsumerAutomationIdsAndGeneratesMissingIds()
+    {
+        var buttonWithConsumerId = new Button { AutomationId = "Shared_ViewOptions_ResetButton" };
+        var buttonWithoutConsumerId = new Button();
+        var bottomSheet = new BottomSheet { ShowBottombarButtonsOnSubViews = true };
+
+        bottomSheet.BottombarButtons.Add(buttonWithConsumerId);
+        bottomSheet.BottombarButtons.Add(buttonWithoutConsumerId);
+
+        var createBottomBar = () => bottomSheet.CreateBottomBar();
+
+        createBottomBar.Should().NotThrow();
+
+        buttonWithConsumerId.AutomationId.Should().Be("Shared_ViewOptions_ResetButton");
+        buttonWithoutConsumerId.AutomationId.Should().Be("DUI.BottomSheet.BottomBarButton1");
+    }
+}


### PR DESCRIPTION
### Description of Change

Fixes BottomSheet bottom bar button `AutomationId` handling so DUI no longer overwrites IDs supplied by consumers.

Why: MAUI only allows `Element.AutomationId` to be set once. Arena Mobil sets explicit automation IDs on bottom bar buttons, and `BottomSheet.CreateBottomBar()` later reassigned DUI-generated IDs while opening the sheet. That caused `AutomationId may only be set one time`, especially for sheets using `ShowBottombarButtonsOnSubViews="True"`.

The bottom bar now generates `DUI.BottomSheet.BottomBarButton{index}` only when the button has no `AutomationId`, preserving consumer-provided IDs. A regression unit test verifies both preserved IDs and fallback generated IDs.

Verification:
- `dotnet test src/tests/unittests/DIPS.Mobile.UI.UnitTests.csproj --no-restore --filter FullyQualifiedName~BottomSheetTests --logger "console;verbosity=minimal"`

Documentation:
- No wiki update needed; this is a bug fix that preserves intended consumer behavior and does not add or change public API.

### Todos
- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [x] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->