### PR TITLE
Make sure dictation button is not hidden on android when the focused field is inside a modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [62.1.3]
+- [Dictation][Android] The dictation microphone now shows above the keyboard when the focused field is in a modal or a bottom sheet, instead of being hidden behind it.
+
 ## [62.1.2]
 - [BottomSheet][Android] Content now fills the visible sheet height (matching iOS) when Positioning is Medium or Large (non-Fit).
 

--- a/src/app/Components/ComponentsSamples/TextFields/KeyboardDictation/DictationBottomSheet.xaml
+++ b/src/app/Components/ComponentsSamples/TextFields/KeyboardDictation/DictationBottomSheet.xaml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<dui:BottomSheet xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:dui="http://dips.com/mobile.ui"
+                 x:Class="Components.ComponentsSamples.TextFields.KeyboardDictation.DictationBottomSheet"
+                 Title="Dictation in a bottom sheet"
+                 BackgroundColor="{dui:Colors color_background_default}">
+
+    <dui:VerticalStackLayout Spacing="{dui:Sizes size_3}"
+                             Padding="{dui:Thickness size_4}">
+
+        <dui:Label Text="Focus a field. The microphone should appear above the keyboard and on top of this sheet." />
+
+        <dui:Entry Placeholder="Entry"
+                   HasBorder="True" />
+
+        <dui:Editor Placeholder="Editor"
+                    HeightRequest="120"
+                    HasBorder="True" />
+
+        <dui:MultiLineInputField HeaderText="MultiLineInputField" />
+
+    </dui:VerticalStackLayout>
+
+</dui:BottomSheet>

--- a/src/app/Components/ComponentsSamples/TextFields/KeyboardDictation/DictationBottomSheet.xaml.cs
+++ b/src/app/Components/ComponentsSamples/TextFields/KeyboardDictation/DictationBottomSheet.xaml.cs
@@ -1,0 +1,9 @@
+namespace Components.ComponentsSamples.TextFields.KeyboardDictation;
+
+public partial class DictationBottomSheet
+{
+    public DictationBottomSheet()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/app/Components/ComponentsSamples/TextFields/KeyboardDictation/DictationModalSamplePage.xaml
+++ b/src/app/Components/ComponentsSamples/TextFields/KeyboardDictation/DictationModalSamplePage.xaml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<dui:ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:dui="http://dips.com/mobile.ui"
+                 x:Class="Components.ComponentsSamples.TextFields.KeyboardDictation.DictationModalSamplePage"
+                 Padding="{dui:Sizes size_4}"
+                 Title="Dictation in a modal">
+
+    <dui:ContentPage.ToolbarItems>
+        <ToolbarItem Text="Close" Clicked="OnCloseClicked" />
+    </dui:ContentPage.ToolbarItems>
+
+    <dui:ScrollView>
+        <dui:VerticalStackLayout Spacing="{dui:Sizes size_3}">
+
+            <dui:Label Text="Focus a field. The microphone should appear above the keyboard and on top of this modal." />
+
+            <dui:Entry Placeholder="Entry"
+                       HasBorder="True" />
+
+            <dui:Editor Placeholder="Editor"
+                        HeightRequest="120"
+                        HasBorder="True" />
+
+            <dui:MultiLineInputField HeaderText="MultiLineInputField" />
+
+            <!-- Spacer to allow scrolling under the keyboard. -->
+            <BoxView HeightRequest="600" />
+
+        </dui:VerticalStackLayout>
+    </dui:ScrollView>
+
+</dui:ContentPage>

--- a/src/app/Components/ComponentsSamples/TextFields/KeyboardDictation/DictationModalSamplePage.xaml.cs
+++ b/src/app/Components/ComponentsSamples/TextFields/KeyboardDictation/DictationModalSamplePage.xaml.cs
@@ -1,0 +1,14 @@
+namespace Components.ComponentsSamples.TextFields.KeyboardDictation;
+
+public partial class DictationModalSamplePage
+{
+    public DictationModalSamplePage()
+    {
+        InitializeComponent();
+    }
+
+    private async void OnCloseClicked(object? sender, EventArgs e)
+    {
+        await Shell.Current.Navigation.PopModalAsync();
+    }
+}

--- a/src/app/Components/ComponentsSamples/TextFields/KeyboardDictation/KeyboardDictationSamplePage.xaml
+++ b/src/app/Components/ComponentsSamples/TextFields/KeyboardDictation/KeyboardDictationSamplePage.xaml
@@ -12,19 +12,32 @@
 
             <dui:Label Text="Focus any field to raise the keyboard. A microphone appears above the keyboard. Tap it to start and stop dictation, and the recognized text streams into the focused field. This sample uses the built-in dictation simulator." />
 
-            <dui:Entry x:Name="DictationEntry"
-                       Placeholder="Entry"
+            <dui:Label Text="Open the fields in a modal or a bottom sheet to check the microphone still shows above the keyboard there." />
+
+            <dui:Button Text="Open fields in a modal"
+                        Style="{dui:Styles Button=DefaultLarge}"
+                        Clicked="OnOpenInModalClicked" />
+
+            <dui:Button Text="Open fields in a bottom sheet"
+                        Style="{dui:Styles Button=DefaultLarge}"
+                        Clicked="OnOpenInBottomSheetClicked" />
+
+            <dui:Button x:Name="SoftInputModeButton"
+                        Text="Keyboard: resize page (tap for pan)"
+                        Style="{dui:Styles Button=DefaultLarge}"
+                        IsVisible="{OnPlatform Android=True, Default=False}"
+                        Clicked="OnToggleSoftInputModeClicked" />
+
+            <dui:Entry Placeholder="Entry"
                        HasBorder="True" />
 
-            <dui:Editor x:Name="DictationEditor"
-                        Placeholder="Editor"
+            <dui:Editor Placeholder="Editor"
                         HeightRequest="120"
                         HasBorder="True" />
 
-            <dui:MultiLineInputField x:Name="DictationMultiLineInputField"
-                                     HeaderText="MultiLineInputField" />
+            <dui:MultiLineInputField HeaderText="MultiLineInputField" />
 
-            <!-- Space so the multiline caret can go under the keyboard, to check the Android microphone stays pinned. -->
+            <!-- Spacer to allow scrolling under the keyboard. -->
             <BoxView HeightRequest="600" />
 
         </dui:VerticalStackLayout>

--- a/src/app/Components/ComponentsSamples/TextFields/KeyboardDictation/KeyboardDictationSamplePage.xaml.cs
+++ b/src/app/Components/ComponentsSamples/TextFields/KeyboardDictation/KeyboardDictationSamplePage.xaml.cs
@@ -5,12 +5,34 @@ namespace Components.ComponentsSamples.TextFields.KeyboardDictation;
 public partial class KeyboardDictationSamplePage
 {
     private bool m_softInputResizes = true;
+#if ANDROID
+    private Android.Views.SoftInput? m_originalSoftInputMode;
+#endif
 
     public KeyboardDictationSamplePage()
     {
         InitializeComponent();
     }
 
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+#if ANDROID
+        var window = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity?.Window;
+        if (window is not null && m_originalSoftInputMode is null)
+            m_originalSoftInputMode = window.Attributes?.SoftInputMode;
+#endif
+    }
+
+    protected override void OnDisappearing()
+    {
+#if ANDROID
+        var window = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity?.Window;
+        if (window is not null && m_originalSoftInputMode is not null)
+            window.SetSoftInputMode(m_originalSoftInputMode.Value);
+#endif
+        base.OnDisappearing();
+    }
     private async void OnOpenInModalClicked(object? sender, EventArgs e)
     {
         await Shell.Current.Navigation.PushModalAsync(new NavigationPage(new DictationModalSamplePage()));

--- a/src/app/Components/ComponentsSamples/TextFields/KeyboardDictation/KeyboardDictationSamplePage.xaml.cs
+++ b/src/app/Components/ComponentsSamples/TextFields/KeyboardDictation/KeyboardDictationSamplePage.xaml.cs
@@ -1,9 +1,45 @@
+using DIPS.Mobile.UI.Components.BottomSheets;
+
 namespace Components.ComponentsSamples.TextFields.KeyboardDictation;
 
 public partial class KeyboardDictationSamplePage
 {
+    private bool m_softInputResizes = true;
+
     public KeyboardDictationSamplePage()
     {
         InitializeComponent();
+    }
+
+    private async void OnOpenInModalClicked(object? sender, EventArgs e)
+    {
+        await Shell.Current.Navigation.PushModalAsync(new NavigationPage(new DictationModalSamplePage()));
+    }
+
+    private async void OnOpenInBottomSheetClicked(object? sender, EventArgs e)
+    {
+        await BottomSheetService.Open(new DictationBottomSheet());
+    }
+
+    private void OnToggleSoftInputModeClicked(object? sender, EventArgs e)
+    {
+        m_softInputResizes = !m_softInputResizes;
+
+        ApplySoftInputMode(m_softInputResizes);
+
+        SoftInputModeButton.Text = m_softInputResizes
+            ? "Keyboard: resize page (tap for pan)"
+            : "Keyboard: pan page (tap for resize)";
+    }
+
+    private static void ApplySoftInputMode(bool resize)
+    {
+#if ANDROID
+        var window = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity?.Window;
+        if (window is null)
+            return;
+
+        window.SetSoftInputMode(resize ? Android.Views.SoftInput.AdjustResize : Android.Views.SoftInput.AdjustPan);
+#endif
     }
 }

--- a/src/library/DIPS.Mobile.UI/Components/TextFields/Dictation/Android/DictationKeyboardOverlay.Positioning.cs
+++ b/src/library/DIPS.Mobile.UI/Components/TextFields/Dictation/Android/DictationKeyboardOverlay.Positioning.cs
@@ -14,14 +14,12 @@ internal sealed partial class DictationKeyboardOverlay
     private const int BottomMarginDp = 12; // gap between the microphone and the top of the keyboard
     private const int RightMarginDp = 20; // gap between the microphone and the right edge of the screen
     
-    private void StartTrackingKeyboardHeight(ViewGroup contentView)
+    private void CreateKeyboardTracking()
     {
         m_mainThreadHandler = new Handler(Looper.MainLooper!);
         m_beginFadeOutRunnable = new Java.Lang.Runnable(BeginMicrophoneFadeOut);
         m_dismissRunnable = new Java.Lang.Runnable(DismissMicrophonePopup);
-
         m_insetsListener = new KeyboardInsetsListener(this);
-        ViewCompat.SetOnApplyWindowInsetsListener(contentView, m_insetsListener);
     }
 
     private void ReadKeyboardInsets(WindowInsetsCompat insets)
@@ -56,8 +54,8 @@ internal sealed partial class DictationKeyboardOverlay
     {
         var popup = m_popup;
         var buttonView = m_containerView;
-        var decorView = m_decorView;
-        
+        var decorView = m_hostWindowDecorView;
+
         if (popup is null || buttonView is null || decorView is null)
             return;
 
@@ -111,7 +109,6 @@ internal sealed partial class DictationKeyboardOverlay
         }
         catch (WindowManagerBadTokenException)
         {
-            // The activity window went away between the inset callback and the show. Skip; a later callback retries.
             return false;
         }
     }

--- a/src/library/DIPS.Mobile.UI/Components/TextFields/Dictation/Android/DictationKeyboardOverlay.cs
+++ b/src/library/DIPS.Mobile.UI/Components/TextFields/Dictation/Android/DictationKeyboardOverlay.cs
@@ -13,18 +13,16 @@ using ShapeableImageView = Google.Android.Material.ImageView.ShapeableImageView;
 namespace DIPS.Mobile.UI.Components.TextFields.Dictation;
 
 /// <summary>
-/// Shows the dictation microphone in a separate non-focusable window pinned just above the keyboard, so the
-/// activity's adjustPan cannot drag it and the keyboard stays open when it is tapped. One overlay serves every
-/// text field. The coordinator decides which field the microphone dictates into. Lives for the current activity
-/// and tears itself down when that activity is destroyed.
+/// Shows the dictation microphone in its own window just above the keyboard. It follows the window of the focused
+/// field, so it stays on top when the field is in a modal or a bottom sheet.
 /// </summary>
 internal sealed partial class DictationKeyboardOverlay
 {
     public static DictationKeyboardOverlay Current { get; } = new();
 
     private Activity? m_activity;
-    private ViewGroup? m_contentView;
-    private AView? m_decorView;
+    private ViewGroup? m_hostWindowContentView;
+    private AView? m_hostWindowDecorView;
     private PopupWindow? m_popup;
     private ImageButton? m_microphoneImageButton;
     private ShapeableImageView? m_imageView;
@@ -50,47 +48,80 @@ internal sealed partial class DictationKeyboardOverlay
     {
     }
 
-    /// <summary>Prepares the overlay for the given activity. Idempotent per activity. Rebuilds if the activity changes.</summary>
-    public void AttachToActivity(Activity? activity)
+    /// <summary>Shows the microphone in the window of the field that just gained focus.</summary>
+    public void AttachToFocusedField(AView? focusedFieldView)
     {
-        if (activity is null)
+        if (focusedFieldView is null)
             return;
 
-        if (ReferenceEquals(m_activity, activity))
+        var activity = Platform.CurrentActivity;
+        var mauiContext = DUI.GetCurrentMauiContext;
+        if (activity is null || mauiContext is null)
             return;
 
+        var hostWindowDecorView = focusedFieldView.RootView;
+        var hostWindowContentView = hostWindowDecorView?.FindViewById<ViewGroup>(global::Android.Resource.Id.Content);
+        if (hostWindowDecorView is null || hostWindowContentView is null)
+            return;
+
+        if (!ReferenceEquals(m_activity, activity))
+            RebuildForActivity(activity, mauiContext);
+
+        BindToHostWindow(hostWindowContentView, hostWindowDecorView);
+    }
+
+    private void RebuildForActivity(Activity activity, IMauiContext mauiContext)
+    {
         if (m_activity is not null)
             DetachFromActivity();
 
-        var mauiContext = DUI.GetCurrentMauiContext;
-        var contentView = activity.FindViewById<ViewGroup>(global::Android.Resource.Id.Content);
-        var decorView = activity.Window?.DecorView;
-        if (mauiContext is null || contentView is null || decorView is null)
-            return;
-
         var density = activity.Resources?.DisplayMetrics?.Density ?? 1f;
 
-        RegisterCurrentActivity(activity, contentView, decorView, density);
-        
-        CreateMicrophonePopup(activity, mauiContext, density);
-        
-        StartTrackingKeyboardHeight(contentView);
-        
-        StartWatchingForActivityDestroyed(activity);
-        
-        ObserveDictationTarget();
-
-        // Read the current insets now, so the microphone appears immediately if the keyboard is already open.
-        ViewCompat.RequestApplyInsets(contentView);
-    }
-
-    private void RegisterCurrentActivity(Activity activity, ViewGroup contentView, AView decorView, float density)
-    {
         m_activity = activity;
-        m_contentView = contentView;
-        m_decorView = decorView;
         m_bottomMarginPixels = (int)(BottomMarginDp * density);
         m_rightMarginPixels = (int)(RightMarginDp * density);
+
+        CreateMicrophonePopup(activity, mauiContext, density);
+
+        CreateKeyboardTracking();
+
+        StartWatchingForActivityDestroyed(activity);
+
+        ObserveDictationTarget();
+    }
+
+    // A popup stays on the window it opened on, so moving to a new window means releasing the old one and reopening.
+    private void BindToHostWindow(ViewGroup hostWindowContentView, AView hostWindowDecorView)
+    {
+        if (ReferenceEquals(m_hostWindowContentView, hostWindowContentView))
+            return;
+
+        ReleaseHostWindow();
+
+        m_hostWindowContentView = hostWindowContentView;
+        m_hostWindowDecorView = hostWindowDecorView;
+
+        if (m_insetsListener is not null)
+            ViewCompat.SetOnApplyWindowInsetsListener(hostWindowContentView, m_insetsListener);
+
+        // Refresh now in case the keyboard is already open.
+        ViewCompat.RequestApplyInsets(hostWindowContentView);
+    }
+
+    private void ReleaseHostWindow()
+    {
+        CancelPendingFade();
+
+        if (m_hostWindowContentView is not null)
+            ViewCompat.SetOnApplyWindowInsetsListener(m_hostWindowContentView, null);
+
+        if (m_popup is { IsShowing: true })
+            TryDismiss(m_popup);
+
+        m_hostWindowContentView = null;
+        m_hostWindowDecorView = null;
+        m_lastYOffset = int.MinValue;
+        m_isKeyboardVisible = false;
     }
 
     private void ObserveDictationTarget()
@@ -101,15 +132,9 @@ internal sealed partial class DictationKeyboardOverlay
     /// <summary>Removes the overlay, its listeners and popup, and disconnects the hosted button's handler.</summary>
     public void DetachFromActivity()
     {
-        CancelPendingFade();
+        ReleaseHostWindow();
         DictationSessionCoordinator.Current.CurrentConsumerChanged -= OnCurrentConsumerChanged;
         StopWatchingForActivityDestroyed();
-
-        if (m_contentView is not null)
-            ViewCompat.SetOnApplyWindowInsetsListener(m_contentView, null);
-
-        if (m_popup is { IsShowing: true })
-            TryDismiss(m_popup);
 
         m_microphoneImageButton?.Handler?.DisconnectHandler();
 
@@ -120,15 +145,11 @@ internal sealed partial class DictationKeyboardOverlay
         m_stopSquareDrawable = null;
         m_microphoneIconDrawable = null;
         m_insetsListener = null;
-        m_contentView = null;
-        m_decorView = null;
         m_activity = null;
         m_mainThreadHandler = null;
         m_beginFadeOutRunnable = null;
         m_dismissRunnable = null;
-        m_lastYOffset = int.MinValue;
         m_isDictationActive = false;
-        m_isKeyboardVisible = false;
     }
 
     private void StartWatchingForActivityDestroyed(Activity activity)

--- a/src/library/DIPS.Mobile.UI/Components/TextFields/Editor/Android/EditorHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/TextFields/Editor/Android/EditorHandler.cs
@@ -46,7 +46,7 @@ public partial class EditorHandler
 
         if (e.HasFocus)
         {
-            DictationKeyboardOverlay.Current.AttachToActivity(Platform.CurrentActivity);
+            DictationKeyboardOverlay.Current.AttachToFocusedField(PlatformView);
             DictationSessionCoordinator.Current.NotifyFieldFocused(this);
         }
         else

--- a/src/library/DIPS.Mobile.UI/Components/TextFields/Entry/Android/EntryHandler.cs
+++ b/src/library/DIPS.Mobile.UI/Components/TextFields/Entry/Android/EntryHandler.cs
@@ -44,7 +44,7 @@ public partial class EntryHandler
 
         if (e.HasFocus)
         {
-            DictationKeyboardOverlay.Current.AttachToActivity(Platform.CurrentActivity);
+            DictationKeyboardOverlay.Current.AttachToFocusedField(PlatformView);
             DictationSessionCoordinator.Current.NotifyFieldFocused(this);
         }
         else


### PR DESCRIPTION
### Description of Change

The dictation microphone now shows above the keyboard when the focused field is in a modal or a bottom sheet, instead of being hidden behind it. 

### Todos
- [x] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have supported accessibility

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->