### PR TITLE
Retain all saved image rotations in GalleryThumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [62.1.4]
+- [Gallery] Fixed issue where only one of multiple image rotations was retained.
+
 ## [62.1.3]
 - [Dictation][Android] The dictation microphone now shows above the keyboard when the focused field is in a modal or a bottom sheet, instead of being hidden behind it.
 

--- a/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/GalleryBottomSheet.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Gallery/BottomSheet/GalleryBottomSheet.cs
@@ -30,7 +30,7 @@ namespace DIPS.Mobile.UI.API.Camera.Gallery.BottomSheet;
 internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObserver, IImageEditStateObserver
 {
     private readonly Action<int> m_onRemoveImage;
-    private readonly Action m_updateImages;
+    private readonly Action<IReadOnlyList<CapturedImage>> m_updateImages;
     private readonly Button m_navigatePreviousImageButton;
     private readonly Button m_navigateNextImageButton;
     private readonly ContentView m_carouselViewWrapperView = new();
@@ -54,7 +54,7 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
     private int? m_positionBeforeRemoval;
     private int? m_positionBeforeEdit;
 
-    public GalleryBottomSheet(List<CapturedImage> images, int startingIndex, Action<int> onRemoveImage, Action updateImages)
+    public GalleryBottomSheet(List<CapturedImage> images, int startingIndex, Action<int> onRemoveImage, Action<IReadOnlyList<CapturedImage>> updateImages)
     {
         Background = Microsoft.Maui.Graphics.Colors.Black;
         
@@ -432,7 +432,7 @@ internal partial class GalleryBottomSheet : ContentPage, IGalleryDefaultStateObs
         Images[m_carouselView!.Position] = m_currentlyRotatedCaptureImageDisplayed;
         m_currentlyCapturedImageDisplayed = m_currentlyRotatedCaptureImageDisplayed;
         GoToDefaultState();   
-        m_updateImages.Invoke();
+        m_updateImages.Invoke(Images);
     }
 
     void IImageEditStateObserver.OnCancelButtonTapped()

--- a/src/library/DIPS.Mobile.UI/API/Camera/Gallery/GalleryThumbnails.cs
+++ b/src/library/DIPS.Mobile.UI/API/Camera/Gallery/GalleryThumbnails.cs
@@ -61,10 +61,9 @@ public partial class GalleryThumbnails : Grid
         Shell.Current.Navigation.PushModalAsync(new NavigationPage(new GalleryBottomSheet(Images, imageIndex, OnRemoveImage, UpdateImages)));
     }
 
-    private void UpdateImages()
+    internal void UpdateImages(IReadOnlyList<CapturedImage> images)
     {
-        var copyOfImages = Images.ToList();
-        Images = copyOfImages;        
+        Images = images.ToList();
     }
     
     private void OnRemoveImage(int imageIndex)

--- a/src/tests/unittests/API/Camera/Gallery/GalleryThumbnailsTests.cs
+++ b/src/tests/unittests/API/Camera/Gallery/GalleryThumbnailsTests.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+using DIPS.Mobile.UI.API.Camera.Gallery;
+using DIPS.Mobile.UI.API.Camera.ImageCapturing;
+
+namespace DIPS.Mobile.UI.UnitTests.API.Camera.Gallery;
+
+public class GalleryThumbnailsTests
+{
+    [Fact]
+    public void UpdateImages_MultipleEditsFromOpenGallery_RetainsEveryEdit()
+    {
+        var firstImage = new CapturedImage();
+        var secondImage = new CapturedImage();
+        var firstEditedImage = new CapturedImage();
+        var secondEditedImage = new CapturedImage();
+        var imagesBeingEdited = new List<CapturedImage> { firstImage, secondImage };
+        var gallery = new GalleryThumbnails { Images = imagesBeingEdited.ToList() };
+
+        imagesBeingEdited[0] = firstEditedImage;
+        gallery.UpdateImages(imagesBeingEdited);
+        imagesBeingEdited[1] = secondEditedImage;
+        gallery.UpdateImages(imagesBeingEdited);
+
+        gallery.Images.Should().Equal(firstEditedImage, secondEditedImage);
+    }
+}

--- a/wiki/Media/ImageCapture.md
+++ b/wiki/Media/ImageCapture.md
@@ -106,6 +106,17 @@ private void OnImageCaptured(CapturedImage capturedImage)
 
 In multi-capture this method is called once per image, in capture order. Pair it with `OnImageRemoved` so your list reflects every add and every removal the user makes.
 
+## Reviewing captured images after capture
+
+Use `GalleryThumbnails` to display a list of captured images after the camera closes:
+
+```xaml
+<dui:GalleryThumbnails Images="{Binding Images}"
+                       CameraButtonTapped="OnCameraButtonTapped" />
+```
+
+Tapping a thumbnail opens a full-screen preview where the user can browse, rotate, inspect, or remove images. Saving a rotation updates `Images` immediately. Multiple images can be rotated during the same preview session, and every saved rotation is retained in the bound list.
+
 ## Handling camera failures
 
 ```csharp


### PR DESCRIPTION
### Description of Change

Fixes `GalleryThumbnails` losing later image rotations when several images are edited during the same full-screen preview session.

- Passes the gallery bottom sheet's current image collection back after each saved rotation instead of copying stale bound state.
- Adds regression coverage for sequential edits in one open gallery.
- Documents post-capture review and rotation behavior.

### Todos
- [ ] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [x] I have supported accessibility
